### PR TITLE
README: fix broken curl download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Expand-Archive -Path "$env:TEMP\terraform-azurerm-ai-installer.zip" -Destination
 #### macOS/Linux (Bash)
 ```bash
 # Download and extract installer directly to user profile
-curl -L -o /tmp/terraform-azurerm-ai-installer.tar.gz "https://github.com/WodansSon/terraform-azurerm-ai-assisted-development/releases/latest/download/terraform-azurerm-ai-installer.tar.gz"
+curl -L -o /tmp/terraform-azurerm-ai-installer.tar.gz "https://github.com/WodansSon/terraform-azurerm-ai-assisted-development/releases/latest/download/terraform-azurerm-ai-installer-v1.0.0.tar.gz"
 mkdir -p ~/.terraform-azurerm-ai-installer
 tar -xzf /tmp/terraform-azurerm-ai-installer.tar.gz -C ~/.terraform-azurerm-ai-installer --strip-components=1
 


### PR DESCRIPTION
This PR fixes curl download link for Unix which 404 because the actual artifact file name has version suffix on it.

This is a temporary fix, when a new version is released this URL will no longer work. The proper fix for this is to refactor the release pipeline to use non version suffixed file name.