### PR TITLE
[BUG:] Harden code review prompt runtime pathing and rerun output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,8 +82,9 @@ When you give specific commands, I'll act directly:
 ## 🖥️ **TERMINAL COMMAND EXECUTION**
 
 **Windows/WSL Environment Considerations:**
-- For Go commands (`go mod tidy`, `go mod vendor`, `go test`, etc.), **always use WSL terminal** in this repository
-- PowerShell is suitable for: git operations, file operations, simple directory navigation
+- For actual Go toolchain commands (`go mod tidy`, `go mod vendor`, `go test`, etc.), **always use WSL terminal** in this repository
+- Do not treat standalone locally installed CLIs such as `azurerm-linter`, `git`, or the installer scripts as Go commands solely because they operate on Go files or review Go changes
+- PowerShell is suitable for: git operations, file operations, simple directory navigation, and native local CLI execution such as `azurerm-linter`
 - When in doubt about environment compatibility, prefer WSL for build/test operations
 
 ## 📝 **COMMIT MESSAGE STANDARDS**

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -23,7 +23,7 @@ This contract defines the review rules, evidence hierarchy, finding classificati
 Use these sources with the following roles:
 
 - Workspace contributor guidance
-  - CONTRIBUTING.md
+  - Repo-level contributor documentation in common workspace locations such as `CONTRIBUTING.md` and `contributing/README.md`
   - .github/pull_request_template.md
   - README or subsystem documentation when directly relevant to touched files
 - Workspace file-scoped instructions and skills
@@ -88,6 +88,11 @@ If evidence is missing for a claim that would change severity or requested actio
 ### REVIEW-EVID-003: Attribute policies to real sources
 - Rule: Do not claim that a style or implementation rule is mandatory unless it is supported by a current contributor document, instruction file, skill, implementation pattern, or this contract.
 - Reviewer behavior: avoid invented policy language such as "must" or "required" when the source only supports a preference.
+
+### REVIEW-EVID-004: Discover contributor-guidance paths before claiming absence
+- Rule: Do not assume repo-level contributor guidance always lives at `CONTRIBUTING.md`.
+- Rule: Check common workspace locations such as `CONTRIBUTING.md` and `contributing/README.md` before claiming contributor guidance is absent.
+- Rule: When reviewing a `terraform-provider-azurerm` style workspace, treat `contributing/README.md` as repo-level contributor guidance when present.
 
 ## Finding classification
 
@@ -234,12 +239,12 @@ If evidence is missing for a claim that would change severity or requested actio
 
 ### REVIEW-LINT-003A: Treat "no packages to analyze" as Not applicable when caused by zero changed files
 - Rule: If azurerm-linter output shows that it found zero changed files or zero changed packages for the selected scope and then prints `Error: no packages to analyze`, classify the linter section as `Not applicable` rather than `Not run`.
-- Rule: In this case, record the tool output in `Summary`, set `Issue Count` to `0` or `n/a`, and keep `Must Fix` as `None`.
+- Rule: In this case, record the tool output in `Summary`, set `Issue Count` to `0` or `n/a`, and keep the `🎯 Must Fix:` block as `None`.
 - Rule: Do not treat this specific output shape as a tool failure requiring an install hint.
 
 ### REVIEW-LINT-003B: Treat flag and usage parse errors as Not run due to invocation error
 - Rule: If azurerm-linter exits with a flag parsing or usage error such as `flag provided but not defined` and prints its usage help, classify the linter section as `Not run`.
-- Rule: In this case, record the command error in `Summary`, keep `Must Fix` as `None`, and do not emit an install hint unless there is separate evidence that the binary is missing.
+- Rule: In this case, record the command error in `Summary`, keep the `🎯 Must Fix:` block as `None`, and do not emit an install hint unless there is separate evidence that the binary is missing.
 - Rule: When the corrected command form is deterministic from the prompt context, include that correction in `Summary`.
 
 ### REVIEW-LINT-004: azurerm-linter findings are reported as issues
@@ -248,7 +253,7 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If the executed linter scope is broader or narrower than the reviewed diff, disclose that scope mismatch, but still report the linter findings found in the executed scope.
 - Rule: azurerm-linter findings must not remain only inside the linter subsection; they must also be surfaced in the review's main `ISSUES` section.
 - Rule: The linter subsection is the execution report. The main `ISSUES` section is where the actionable findings are enumerated.
-- Rule: Inside the linter subsection, actionable violation lines should be labeled as `Must Fix`.
+- Rule: Inside the linter subsection, actionable violation lines should appear under a standalone `🎯 Must Fix:` label.
 
 ### REVIEW-LINT-005: Report scope and failure reasons explicitly
 - Rule: The linter section must state the scope it covered.
@@ -264,19 +269,19 @@ If evidence is missing for a claim that would change severity or requested actio
   - Run Scope
   - Issue Count
   - Summary
-  - Must Fix
+  - `🎯 Must Fix:`
 - Rule: If a direct linter invocation cannot be interpreted deterministically, prefer `Not run` with a concise reason over creating extra execution scaffolding.
 
 ### REVIEW-LINT-005A: Structure the linter section from actual tool output
 - Rule: Capture the tool's issue footer (`Found X issue(s)`) as the issue count when present.
 - Rule: Treat preamble and cleanup logs (for example auto-detected remote, worktree creation, changed package detection, loading packages, cleanup) as execution notes or summary material, not as findings.
-- Rule: Treat only the violation lines as `Must Fix` entries.
-- Rule: If there are no linter violations, `Must Fix` must be exactly `None`.
-- Rule: If there are one or more linter violations, `Must Fix` must contain one normalized violation per line and must not collapse multiple violations into a single sentence.
-- Rule: Each `Must Fix` line must keep the form `CHECKID path:line: message`.
+- Rule: Treat only the violation lines as `🎯 Must Fix:` entries.
+- Rule: If there are no linter violations, the `🎯 Must Fix:` block must contain exactly `None`.
+- Rule: If there are one or more linter violations, the `🎯 Must Fix:` block must be introduced by a standalone `🎯 Must Fix:` label followed by one normalized violation per bullet and must not collapse multiple violations into a single sentence.
+- Rule: Each `🎯 Must Fix:` bullet must keep the form `CHECKID path:line: message`.
 - Rule: When filtered mode reports changed files but zero changed lines, preserve that fact in `Summary` as tool behavior, not as a trigger for a workaround pass.
 - Rule: Omit low-value execution chatter such as current branch, upstream branch, merge-base, and raw loader mode from normal successful output unless it materially explains the result.
-- Rule: On successful runs, prefer a concise summary and `Must Fix` list over field-by-field diagnostics.
+- Rule: On successful runs, prefer a concise summary and `🎯 Must Fix:` block over field-by-field diagnostics.
 - Rule: Build the normal linter subsection from the direct command output returned by the linter run.
 
 ### REVIEW-LINT-005C: Persist and inspect full linter output deterministically

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -209,6 +209,7 @@ If evidence is missing for a claim that would change severity or requested actio
 
 ### REVIEW-LINT-002A: Local installation is required for linter execution
 - Rule: Review prompts should rely on a locally installed `azurerm-linter` binary.
+- Rule: Treat `azurerm-linter` as a standalone locally installed CLI, not as a Go toolchain command.
 - Rule: Do not fetch or execute `azurerm-linter` via `go run` from a remote module path during review.
 - Rule: The minimum supported `azurerm-linter` version for review is `v0.2.0`.
 - Rule: If the local binary is missing, older than `v0.2.0`, or the tool cannot be executed reliably, report the linter section as `Not run` and include a short install hint pointing to the upstream repository and the local install command.
@@ -216,6 +217,9 @@ If evidence is missing for a claim that would change severity or requested actio
 ### REVIEW-LINT-002B: Execute azurerm-linter from the git repo root
 - Rule: Before running azurerm-linter, resolve the git repository root with `git rev-parse --show-toplevel`.
 - Rule: Execute azurerm-linter from that repo root, not from an arbitrary subdirectory.
+- Rule: Run the linter in the current platform's native shell environment using the plain local CLI invocation.
+- Rule: Do not rewrite the command through another runtime environment or wrapper such as `wsl`, `wsl --cd`, `bash -lc`, `sh -lc`, `cmd /c`, or `powershell -Command`.
+- Rule: On Windows, the expected review-time linter command is plain `azurerm-linter ...` from the resolved repo root, not a WSL-prefixed equivalent.
 - Rule: Record the resolved working directory only when it is needed to explain `Not run`, scope ambiguity, or debugging details.
 - Rule: In the normal review path, run azurerm-linter directly rather than through generated shell scripts or PowerShell wrapper scripts.
 - Rule: Use a longer sync timeout for azurerm-linter than for the quick git inspection commands.
@@ -233,8 +237,8 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If the user explicitly asks for broader package debt or manual no-filter validation, disclose that this is broader than the standard review scope.
 
 ### REVIEW-LINT-002E: Match linter invocation to the review type deterministically
-- Rule: Local review should use a direct filtered `azurerm-linter -output json` invocation without `--pr`.
-- Rule: Committed review should use `azurerm-linter --pr=<number> -output json` when a valid pull request number can be determined deterministically from explicit review context.
+- Rule: Local review should use a direct native filtered `azurerm-linter -output json` invocation without `--pr`.
+- Rule: Committed review should use the direct native invocation `azurerm-linter --pr=<number> -output json` when a valid pull request number can be determined deterministically from explicit review context.
 - Rule: Allowed PR number sources are:
   - the active pull request context, when available
   - the currently open or viewed pull request context, when available
@@ -284,6 +288,7 @@ If evidence is missing for a claim that would change severity or requested actio
   - Repo: [QixiaLu/azurerm-linter](https://github.com/QixiaLu/azurerm-linter)
   - Install: go install github.com/qixialu/azurerm-linter@latest
 - Rule: When the section is `Not run` because the installed binary is older than `v0.2.0` or does not support `-output json`, the summary should explicitly say that review requires `azurerm-linter v0.2.0` or newer.
+- Rule: Do not describe a WSL-prefixed or cross-shell-wrapped linter invocation as compliant review execution on Windows when the local binary is available natively.
 - Rule: The linter section should describe the filtered run that powers the normal review flow.
 - Rule: The `### 🧰 **AZURERM LINTER**` execution report should be limited to these reviewer-facing fields only:
   - Version

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -210,8 +210,8 @@ If evidence is missing for a claim that would change severity or requested actio
 ### REVIEW-LINT-002A: Local installation is required for linter execution
 - Rule: Review prompts should rely on a locally installed `azurerm-linter` binary.
 - Rule: Do not fetch or execute `azurerm-linter` via `go run` from a remote module path during review.
-- Rule: The minimum supported `azurerm-linter` version for review is `v0.1.8`.
-- Rule: If the local binary is missing, older than `v0.1.8`, or the tool cannot be executed reliably, report the linter section as `Not run` and include a short install hint pointing to the upstream repository and the local install command.
+- Rule: The minimum supported `azurerm-linter` version for review is `v0.2.0`.
+- Rule: If the local binary is missing, older than `v0.2.0`, or the tool cannot be executed reliably, report the linter section as `Not run` and include a short install hint pointing to the upstream repository and the local install command.
 
 ### REVIEW-LINT-002B: Execute azurerm-linter from the git repo root
 - Rule: Before running azurerm-linter, resolve the git repository root with `git rev-parse --show-toplevel`.
@@ -265,7 +265,7 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: Ignore human-readable preamble logs when a valid JSON payload is present, except when they are needed to explain a non-JSON failure.
 - Rule: Extract the JSON object from the linter output even if log lines precede it.
 - Rule: If `-output json` is unsupported by the installed binary and the tool reports a flag or usage parse error, classify the section as `Not run` rather than falling back to text scraping.
-- Rule: If a valid JSON payload is present but its `version` field is missing, unparsable, or lower than `v0.1.8`, classify the section as `Not run` and state that JSON review mode requires `azurerm-linter v0.1.8` or newer.
+- Rule: If a valid JSON payload is present but its `version` field is missing, unparsable, or lower than `v0.2.0`, classify the section as `Not run` and state that JSON review mode requires `azurerm-linter v0.2.0` or newer.
 
 ### REVIEW-LINT-004: azurerm-linter findings are reported as issues
 - Rule: When azurerm-linter reports findings for the executed linter scope, report them as issues.
@@ -283,7 +283,7 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: When the local binary is missing or the section is reported as Not run for tool-availability reasons, include an install hint of the form:
   - Repo: [QixiaLu/azurerm-linter](https://github.com/QixiaLu/azurerm-linter)
   - Install: go install github.com/qixialu/azurerm-linter@latest
-- Rule: When the section is `Not run` because the installed binary is older than `v0.1.8` or does not support `-output json`, the summary should explicitly say that review requires `azurerm-linter v0.1.8` or newer.
+- Rule: When the section is `Not run` because the installed binary is older than `v0.2.0` or does not support `-output json`, the summary should explicitly say that review requires `azurerm-linter v0.2.0` or newer.
 - Rule: The linter section should describe the filtered run that powers the normal review flow.
 - Rule: The `### 🧰 **AZURERM LINTER**` execution report should be limited to these reviewer-facing fields only:
   - Version

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -94,6 +94,18 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: Check common workspace locations such as `CONTRIBUTING.md` and `contributing/README.md` before claiming contributor guidance is absent.
 - Rule: When reviewing a `terraform-provider-azurerm` style workspace, treat `contributing/README.md` as repo-level contributor guidance when present.
 
+### REVIEW-EVID-005: Perform post-tool verification silently
+- Rule: When tool output needs confirmation against current file content, diff context, or surrounding code, perform that verification silently.
+- Rule: Do not narrate intermediate verification steps such as reading files, checking lines, confirming linter findings, or comparing tool output against workspace content.
+- Rule: Reviews should present only the final evidence-backed conclusions, not the internal process used to reach them.
+
+### REVIEW-EVID-006: Every invocation is a fresh audit run
+- Rule: Every invocation of a code review prompt is a new audit run.
+- Rule: Do not reuse prior git output, linter output, file classifications, or review conclusions from earlier turns in the conversation.
+- Rule: A previous review in the conversation is not evidence for the current run.
+- Rule: All review findings must be based on commands and file reads executed during the current invocation.
+- Rule: If the required commands for the selected review type were not rerun in the current invocation, do not emit a normal review output.
+
 ## Finding classification
 
 ### REVIEW-CLASS-001: Issues are for actual problems only
@@ -198,7 +210,8 @@ If evidence is missing for a claim that would change severity or requested actio
 ### REVIEW-LINT-002A: Local installation is required for linter execution
 - Rule: Review prompts should rely on a locally installed `azurerm-linter` binary.
 - Rule: Do not fetch or execute `azurerm-linter` via `go run` from a remote module path during review.
-- Rule: If the local binary is missing or the tool cannot be executed reliably, report the linter section as `Not run` and include a short install hint pointing to the upstream repository and the local install command.
+- Rule: The minimum supported `azurerm-linter` version for review is `v0.1.8`.
+- Rule: If the local binary is missing, older than `v0.1.8`, or the tool cannot be executed reliably, report the linter section as `Not run` and include a short install hint pointing to the upstream repository and the local install command.
 
 ### REVIEW-LINT-002B: Execute azurerm-linter from the git repo root
 - Rule: Before running azurerm-linter, resolve the git repository root with `git rev-parse --show-toplevel`.
@@ -210,7 +223,7 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: Do not classify the linter section as `Not run` merely because the initial wait window elapsed while the linter process was still executing.
 
 ### REVIEW-LINT-002C: Default to filtered mode first
-- Rule: The preferred review-time lint pass is normal filtered mode: `azurerm-linter`.
+- Rule: The preferred review-time lint pass is normal filtered JSON mode: `azurerm-linter -output json`.
 - Rule: Do not default to `--no-filter`.
 - Rule: Treat filtered mode as the primary run because it is faster and scoped to the current diff shape detected by the tool.
 
@@ -220,8 +233,8 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If the user explicitly asks for broader package debt or manual no-filter validation, disclose that this is broader than the standard review scope.
 
 ### REVIEW-LINT-002E: Match linter invocation to the review type deterministically
-- Rule: Local review should use a direct filtered `azurerm-linter` invocation without `--pr`.
-- Rule: Committed review should use `azurerm-linter --pr=<number>` when a valid pull request number can be determined deterministically from explicit review context.
+- Rule: Local review should use a direct filtered `azurerm-linter -output json` invocation without `--pr`.
+- Rule: Committed review should use `azurerm-linter --pr=<number> -output json` when a valid pull request number can be determined deterministically from explicit review context.
 - Rule: Allowed PR number sources are:
   - the active pull request context, when available
   - the currently open or viewed pull request context, when available
@@ -239,13 +252,20 @@ If evidence is missing for a claim that would change severity or requested actio
 
 ### REVIEW-LINT-003A: Treat "no packages to analyze" as Not applicable when caused by zero changed files
 - Rule: If azurerm-linter output shows that it found zero changed files or zero changed packages for the selected scope and then prints `Error: no packages to analyze`, classify the linter section as `Not applicable` rather than `Not run`.
-- Rule: In this case, record the tool output in `Summary`, set `Issue Count` to `0` or `n/a`, and keep the `🎯 Must Fix:` block as `None`.
+- Rule: In this case, record the tool output in `Summary`, set `Issue Count` to `0` or `n/a`, and keep the `### 🎯 **MUST FIX**` section as `- None`.
 - Rule: Do not treat this specific output shape as a tool failure requiring an install hint.
 
 ### REVIEW-LINT-003B: Treat flag and usage parse errors as Not run due to invocation error
 - Rule: If azurerm-linter exits with a flag parsing or usage error such as `flag provided but not defined` and prints its usage help, classify the linter section as `Not run`.
-- Rule: In this case, record the command error in `Summary`, keep the `🎯 Must Fix:` block as `None`, and do not emit an install hint unless there is separate evidence that the binary is missing.
+- Rule: In this case, record the command error in `Summary`, keep the `### 🎯 **MUST FIX**` section as `- None`, and do not emit an install hint unless there is separate evidence that the binary is missing.
 - Rule: When the corrected command form is deterministic from the prompt context, include that correction in `Summary`.
+
+### REVIEW-LINT-003C: Prefer JSON payloads when available
+- Rule: When azurerm-linter emits a valid JSON payload, treat that payload as the authoritative source for `Version`, `Status`, `Run Scope`, `Issue Count`, `Summary`, and `### 🎯 **MUST FIX**` content.
+- Rule: Ignore human-readable preamble logs when a valid JSON payload is present, except when they are needed to explain a non-JSON failure.
+- Rule: Extract the JSON object from the linter output even if log lines precede it.
+- Rule: If `-output json` is unsupported by the installed binary and the tool reports a flag or usage parse error, classify the section as `Not run` rather than falling back to text scraping.
+- Rule: If a valid JSON payload is present but its `version` field is missing, unparsable, or lower than `v0.1.8`, classify the section as `Not run` and state that JSON review mode requires `azurerm-linter v0.1.8` or newer.
 
 ### REVIEW-LINT-004: azurerm-linter findings are reported as issues
 - Rule: When azurerm-linter reports findings for the executed linter scope, report them as issues.
@@ -253,7 +273,7 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If the executed linter scope is broader or narrower than the reviewed diff, disclose that scope mismatch, but still report the linter findings found in the executed scope.
 - Rule: azurerm-linter findings must not remain only inside the linter subsection; they must also be surfaced in the review's main `ISSUES` section.
 - Rule: The linter subsection is the execution report. The main `ISSUES` section is where the actionable findings are enumerated.
-- Rule: Inside the linter subsection, actionable violation lines should appear under a standalone `🎯 Must Fix:` label.
+- Rule: Actionable violation lines should appear in a separate `### 🎯 **MUST FIX**` section immediately after the `### 🧰 **AZURERM LINTER**` execution report.
 
 ### REVIEW-LINT-005: Report scope and failure reasons explicitly
 - Rule: The linter section must state the scope it covered.
@@ -263,25 +283,31 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: When the local binary is missing or the section is reported as Not run for tool-availability reasons, include an install hint of the form:
   - Repo: [QixiaLu/azurerm-linter](https://github.com/QixiaLu/azurerm-linter)
   - Install: go install github.com/qixialu/azurerm-linter@latest
+- Rule: When the section is `Not run` because the installed binary is older than `v0.1.8` or does not support `-output json`, the summary should explicitly say that review requires `azurerm-linter v0.1.8` or newer.
 - Rule: The linter section should describe the filtered run that powers the normal review flow.
-- Rule: The normal linter subsection should be limited to these reviewer-facing fields only:
+- Rule: The `### 🧰 **AZURERM LINTER**` execution report should be limited to these reviewer-facing fields only:
+  - Version
   - Status
   - Run Scope
   - Issue Count
   - Summary
-  - `🎯 Must Fix:`
+- Rule: The normal review output should then include a separate `### 🎯 **MUST FIX**` section with the actionable lines.
 - Rule: If a direct linter invocation cannot be interpreted deterministically, prefer `Not run` with a concise reason over creating extra execution scaffolding.
 
 ### REVIEW-LINT-005A: Structure the linter section from actual tool output
-- Rule: Capture the tool's issue footer (`Found X issue(s)`) as the issue count when present.
+- Rule: When a valid JSON payload is present, capture `version` as the linter version and `summary.issue_count` as the issue count.
+- Rule: When a valid JSON payload is absent, the tool's issue footer (`Found X issue(s)`) may be used as the issue count when present.
 - Rule: Treat preamble and cleanup logs (for example auto-detected remote, worktree creation, changed package detection, loading packages, cleanup) as execution notes or summary material, not as findings.
-- Rule: Treat only the violation lines as `🎯 Must Fix:` entries.
-- Rule: If there are no linter violations, the `🎯 Must Fix:` block must contain exactly `None`.
-- Rule: If there are one or more linter violations, the `🎯 Must Fix:` block must be introduced by a standalone `🎯 Must Fix:` label followed by one normalized violation per bullet and must not collapse multiple violations into a single sentence.
-- Rule: Each `🎯 Must Fix:` bullet must keep the form `CHECKID path:line: message`.
+- Rule: Treat only the violation lines as `### 🎯 **MUST FIX**` entries.
+- Rule: If there are no linter violations, the `### 🎯 **MUST FIX**` section must contain exactly one bullet: `- None`.
+- Rule: If there are one or more linter violations, the `### 🎯 **MUST FIX**` section must be introduced by that exact heading and then list one normalized violation per bullet, and must not collapse multiple violations into a single sentence.
+- Rule: Each `### 🎯 **MUST FIX**` bullet must keep the form `CHECKID path:line: message`.
+- Rule: When a valid JSON payload is present, derive findings from `findings[]` rather than scraping text lines.
+- Rule: When a JSON finding message repeats the check ID as a leading prefix (for example `AZBP010: ...`), remove that duplicate prefix when constructing the final `CHECKID path:line: message` bullet.
+- Rule: When a valid JSON payload is present, derive reviewer-facing summary facts from JSON fields such as `version`, `summary.changed_files`, `summary.changed_lines`, `summary.issue_count`, `scope.mode`, and `scope.patterns` rather than from log lines.
 - Rule: When filtered mode reports changed files but zero changed lines, preserve that fact in `Summary` as tool behavior, not as a trigger for a workaround pass.
 - Rule: Omit low-value execution chatter such as current branch, upstream branch, merge-base, and raw loader mode from normal successful output unless it materially explains the result.
-- Rule: On successful runs, prefer a concise summary and `🎯 Must Fix:` block over field-by-field diagnostics.
+- Rule: On successful runs, prefer a concise execution report plus a separate `### 🎯 **MUST FIX**` section over field-by-field diagnostics.
 - Rule: Build the normal linter subsection from the direct command output returned by the linter run.
 
 ### REVIEW-LINT-005C: Persist and inspect full linter output deterministically

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -106,6 +106,15 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: All review findings must be based on commands and file reads executed during the current invocation.
 - Rule: If the required commands for the selected review type were not rerun in the current invocation, do not emit a normal review output.
 
+### REVIEW-EVID-007: Describe only current-run facts
+- Rule: Do not compare the current review invocation to earlier invocations in user-visible output.
+- Rule: Do not use comparative carry-over wording such as `still`, `again`, `reloaded`, `same as before`, `remains`, or `continues` when describing current-run evidence unless directly quoting user input or tool output.
+- Rule: State current-run facts directly from the evidence gathered in the current invocation.
+
+### REVIEW-EVID-008: Do not reuse prior review body text
+- Rule: Do not reuse, quote, paraphrase, or summarize a prior review body as the current review output, even when the reviewed change-set and findings are unchanged.
+- Rule: Reconstruct the review body from current-run evidence and the current prompt/template requirements for every invocation.
+
 ## Finding classification
 
 ### REVIEW-CLASS-001: Issues are for actual problems only
@@ -306,9 +315,13 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: Treat only the violation lines as `### 🎯 **MUST FIX**` entries.
 - Rule: If there are no linter violations, the `### 🎯 **MUST FIX**` section must contain exactly one bullet: `- None`.
 - Rule: If there are one or more linter violations, the `### 🎯 **MUST FIX**` section must be introduced by that exact heading and then list one normalized violation per bullet, and must not collapse multiple violations into a single sentence.
-- Rule: Each `### 🎯 **MUST FIX**` bullet must keep the form `CHECKID path:line: message`.
+- Rule: When a deterministic repo-relative file path and line number are available, each `### 🎯 **MUST FIX**` bullet should prefer the form `CHECKID [file:line](repo/relative/path#Lline): message`.
+- Rule: In the linked form, the `file:line` token should be a single Markdown link so the visible shape matches other clickable file references in the review.
+- Rule: When the basename is unambiguous within the current `### 🎯 **MUST FIX**` section, use `basename:line` as the link label.
+- Rule: When the basename would be ambiguous within the current `### 🎯 **MUST FIX**` section, use `repo/relative/path:line` as both the link label and the link target label.
+- Rule: If deterministic repo-relative path normalization is not possible, keep the fallback form `CHECKID path:line: message` rather than guessing.
 - Rule: When a valid JSON payload is present, derive findings from `findings[]` rather than scraping text lines.
-- Rule: When a JSON finding message repeats the check ID as a leading prefix (for example `AZBP010: ...`), remove that duplicate prefix when constructing the final `CHECKID path:line: message` bullet.
+- Rule: When a JSON finding message repeats the check ID as a leading prefix (for example `AZBP010: ...`), remove that duplicate prefix when constructing the final `### 🎯 **MUST FIX**` bullet.
 - Rule: When a valid JSON payload is present, derive reviewer-facing summary facts from JSON fields such as `version`, `summary.changed_files`, `summary.changed_lines`, `summary.issue_count`, `scope.mode`, and `scope.patterns` rather than from log lines.
 - Rule: When filtered mode reports changed files but zero changed lines, preserve that fact in `Summary` as tool behavior, not as a trigger for a workaround pass.
 - Rule: Omit low-value execution chatter such as current branch, upstream branch, merge-base, and raw loader mode from normal successful output unless it materially explains the result.
@@ -344,5 +357,16 @@ If evidence is missing for a claim that would change severity or requested actio
 
 ### REVIEW-OUT-003: Missing evidence must be disclosed plainly
 - Rule: When a conclusion cannot be proven, say so directly in the review rather than compensating with invented certainty.
+
+### REVIEW-OUT-004: Normal review output must not include execution narration
+- Rule: The normal review output must not include preambles, execution commentary, progress narration, or step-by-step status updates.
+- Rule: Do not emit text such as `re-running the local audit`, `the scope is still`, `the review remains`, `I am finishing`, `I have reloaded`, or similar execution-process narration in user-visible review output.
+- Rule: The normal review output should contain only the prompt-defined review headings and their content.
+
+### REVIEW-OUT-005: Successful fresh runs must emit the full current template
+- Rule: If the mandatory procedure succeeds for the selected review type, emit the full current prompt-defined review template.
+- Rule: Do not short-circuit to a previous review, a delta-only summary, or wording such as `same findings as before` or `no change from the last review`.
+- Rule: This applies even when the reviewed code, linter findings, or conclusions are unchanged from an earlier invocation.
+- Rule: Current prompt/template/layout requirements are part of the output contract and must be honored on every successful fresh run.
 
 <!-- REVIEW-CONTRACT-EOF -->

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -24,6 +24,8 @@ If the user asks to run the prompt again, rerun the full mandatory procedure fro
 A previous review in the conversation is not evidence for the current run.
 All review findings must be based on commands and file reads executed during the current invocation of this prompt.
 If the required commands were not rerun in this invocation, do not emit a normal review output.
+Do not reuse, paraphrase, or summarize a previous review body, even if the reviewed diff and findings are unchanged.
+If this invocation completes the mandatory procedure successfully, emit the full current review template defined by this prompt.
 If the fresh-run requirements are not satisfied, hard-stop and output exactly this one line and nothing else:
   - `Cannot run code-review-committed-changes: fresh-run requirements not satisfied. Re-run the mandatory procedure from step 0 in this invocation.`
 
@@ -40,6 +42,13 @@ Do not emit a preamble that asks permission or waits for approval before running
 - Do not output progress narration, plans, or TODO lists.
 - Do not narrate intermediate verification steps such as checking file content after linter findings; perform those checks silently and present only final conclusions.
 - The first character of the normal review output must be `#`.
+
+## No preamble / no progress narration
+- Do not output any sentences before the review headings.
+- The only allowed normal output is the review template defined in this prompt.
+- Do not output progress narration such as `re-running the committed audit`, `the scope is still`, `the review remains`, `I am finishing`, `I have reloaded`, `next I will`, `now I will`, or similar.
+- Do not compare the current run to earlier runs in the conversation; state only the facts established in the current invocation.
+- Do not short-circuit to wording such as `same findings as before`, `no change from the last review`, or other abbreviated carry-over summaries.
 
 ## Mandatory procedure
 
@@ -117,7 +126,8 @@ Rules:
   - Put remote/worktree/package-detection/loading/cleanup logs into `Summary`, not the `### 🎯 **MUST FIX**` section
   - Put only actual violation lines into the `### 🎯 **MUST FIX**` section
   - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
-  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
+  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID [file:line](path#Lline): message` entry per bullet when repo-relative path normalization is deterministic; otherwise keep the raw `CHECKID path:line: message` form
+  - In the linked form, keep `file:line` together inside the same Markdown link so it matches the clickable file-reference style used elsewhere in the review
   - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
   - If a valid JSON payload is present but `version` is lower than `v0.2.0`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.2.0` or newer
   - Normalize temporary worktree paths to repo-relative paths when deterministic; otherwise keep the raw path
@@ -204,7 +214,7 @@ Use this template:
 
 ### 🎯 **MUST FIX**
 - `None`
-- [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
+- [when violations exist, replace `None` with one normalized `CHECKID [file:line](path#Lline): message` entry per bullet when repo-relative path normalization is deterministic; otherwise use `CHECKID path:line: message`]
 
 ### 🟢 **STRENGTHS**
 - [Concrete positive findings only]

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -15,6 +15,16 @@ If the committed change-set includes `.github/prompts/code-review-committed-chan
 ## Minimal user input policy
 Assume the user may invoke this prompt with minimal instructions. Run the full procedure below even if the request is short.
 
+## Fresh-run requirement
+Every invocation of this prompt is a new audit run.
+Do not reuse prior git output, linter output, file classifications, or review conclusions from earlier turns.
+If the user asks to run the prompt again, rerun the full mandatory procedure from step 0 using the current workspace state.
+
+## No cached review state
+A previous review in the conversation is not evidence for the current run.
+All review findings must be based on commands and file reads executed during the current invocation of this prompt.
+If the required commands were not rerun in this invocation, do not emit a normal review output.
+
 ## Command authorization
 The required git and `azurerm-linter` commands in this prompt are already authorized by the prompt itself.
 Execute the required review commands immediately when their step applies.
@@ -26,6 +36,7 @@ Do not emit a preamble that asks permission or waits for approval before running
 - Do not guess when evidence is missing.
 - Do not present multiple alternative fixes unless the user explicitly asks for options.
 - Do not output progress narration, plans, or TODO lists.
+- Do not narrate intermediate verification steps such as checking file content after linter findings; perform those checks silently and present only final conclusions.
 - The first character of the normal review output must be `#`.
 
 ## Mandatory procedure
@@ -39,6 +50,7 @@ Do not emit a preamble that asks permission or waits for approval before running
 ### 1) Gather the committed change-set
 Use `run_in_terminal` with `mode: "sync"`, a concrete `goal`, and a short `timeout` for each command.
 Execute these required commands directly when this step begins; do not pause for confirmation.
+The commands in steps 1 and 4 must be executed again for each invocation of this prompt, even if they were executed earlier in the conversation.
 
 Run these commands in order and do not repeat them:
 
@@ -83,29 +95,35 @@ Rules:
     - the active pull request context, when available
     - the currently open or viewed pull request context, when available
     - an explicit PR number supplied by the user or prompt invocation text
-  - If a valid PR number is available, run `azurerm-linter --pr=<number>`
+  - If a valid PR number is available, run `azurerm-linter --pr=<number> -output json`
   - Do not guess or invent a PR number from the branch name, diff text, commit messages, or other ambiguous signals
 - If no in-scope provider Go files exist, mark the linter section as `Not applicable`.
 - If no valid pull request number can be determined for the committed branch changes, mark the linter section as `Not run` and instruct the user to create a draft PR and run the review again.
 - If the local binary is missing or the tool cannot be run or scoped correctly, mark the section as `Not run` and state the reason.
 - If the tool reports `Found 0 changed files` or otherwise has no changed packages to analyze and prints `Error: no packages to analyze`, treat that result as `Not applicable`, not `Not run`.
 - If the tool reports a flag or usage parse error such as `flag provided but not defined` and prints usage help, treat that result as `Not run` due to invocation error, not as an install problem.
-- When the local binary is missing or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
+- Require `azurerm-linter v0.1.8` or newer for review-time JSON mode.
+- When the local binary is missing, older than `v0.1.8`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
 - Report azurerm-linter findings from the executed filtered linter scope as `Issues`.
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
-  - Use the tool footer such as `Found X issue(s)` as the issue count when present
-  - Put remote/worktree/package-detection/loading/cleanup logs into `Summary`, not the `🎯 Must Fix:` block
-  - Put only actual violation lines into the `🎯 Must Fix:` block
-  - If there are no violations, set the `🎯 Must Fix:` block to `None`
-  - If there are multiple violations, introduce a standalone `🎯 Must Fix:` label and render one normalized `CHECKID path:line: message` entry per bullet below it
+  - When a valid JSON payload is present, use `version` as the linter version, use `summary.issue_count` as the issue count, and ignore human-readable preamble logs for structured fields
+  - When a valid JSON payload is absent, the tool footer such as `Found X issue(s)` may be used as the issue count when present
+  - Put remote/worktree/package-detection/loading/cleanup logs into `Summary`, not the `### 🎯 **MUST FIX**` section
+  - Put only actual violation lines into the `### 🎯 **MUST FIX**` section
+  - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
+  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
+  - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
+  - If a valid JSON payload is present but `version` is lower than `v0.1.8`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.1.8` or newer
   - Normalize temporary worktree paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
-  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `🎯 Must Fix:` block as `None`, and do not show an install hint unless the binary is actually missing
+  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and do not show an install hint unless the binary is actually missing
+  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.1.8` or newer, and do not fall back to text scraping
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
-  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
-  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
+  - Limit the `### 🧰 **AZURERM LINTER**` execution report to `Version`, `Status`, `Run Scope`, `Issue Count`, and `Summary`
+  - Follow it with a separate `### 🎯 **MUST FIX**` section
+  - Use the completed linter output, not partial early output, when determining `Version`, `Status`, `Issue Count`, `Summary`, and the `### 🎯 **MUST FIX**` section
   - If the local binary is not found, do not attempt remote execution; report `Not run` and direct the user to install the tool locally
   - If no valid PR number can be determined, use `Status: Not run`, `Run Scope: PR scope`, `Issue Count: n/a`, and a summary that tells the user to create a draft PR and run the review again
   - If the PR number was not supplied explicitly in the committed review invocation, include an example such as `/code-review-committed-changes PR 12345` in that summary
@@ -173,11 +191,14 @@ Use this template:
 - **Notes**: [scope-specific guidance that affected severity or classification]
 
 ### 🧰 **AZURERM LINTER**
+- **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]
 - **Status**: [Issues found/No issues/Not applicable/Not run]
 - **Run Scope**: [PR scope via `--pr=<number>` or `n/a`]
-- **Issue Count**: [number from tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
+- **Issue Count**: [JSON `summary.issue_count`, tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
 - **Summary**: [result summary or failure reason]
-**🎯 Must Fix:** `None`
+
+### 🎯 **MUST FIX**
+- `None`
 - [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
 
 ### 🟢 **STRENGTHS**

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -104,8 +104,8 @@ Rules:
 - If the local binary is missing or the tool cannot be run or scoped correctly, mark the section as `Not run` and state the reason.
 - If the tool reports `Found 0 changed files` or otherwise has no changed packages to analyze and prints `Error: no packages to analyze`, treat that result as `Not applicable`, not `Not run`.
 - If the tool reports a flag or usage parse error such as `flag provided but not defined` and prints usage help, treat that result as `Not run` due to invocation error, not as an install problem.
-- Require `azurerm-linter v0.1.8` or newer for review-time JSON mode.
-- When the local binary is missing, older than `v0.1.8`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
+- Require `azurerm-linter v0.2.0` or newer for review-time JSON mode.
+- When the local binary is missing, older than `v0.2.0`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
 - Report azurerm-linter findings from the executed filtered linter scope as `Issues`.
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
@@ -116,11 +116,11 @@ Rules:
   - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
   - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
   - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
-  - If a valid JSON payload is present but `version` is lower than `v0.1.8`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.1.8` or newer
+  - If a valid JSON payload is present but `version` is lower than `v0.2.0`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.2.0` or newer
   - Normalize temporary worktree paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
   - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and do not show an install hint unless the binary is actually missing
-  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.1.8` or newer, and do not fall back to text scraping
+  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.2.0` or newer, and do not fall back to text scraping
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
   - Limit the `### 🧰 **AZURERM LINTER**` execution report to `Version`, `Status`, `Run Scope`, `Issue Count`, and `Summary`

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -24,6 +24,8 @@ If the user asks to run the prompt again, rerun the full mandatory procedure fro
 A previous review in the conversation is not evidence for the current run.
 All review findings must be based on commands and file reads executed during the current invocation of this prompt.
 If the required commands were not rerun in this invocation, do not emit a normal review output.
+If the fresh-run requirements are not satisfied, hard-stop and output exactly this one line and nothing else:
+  - `Cannot run code-review-committed-changes: fresh-run requirements not satisfied. Re-run the mandatory procedure from step 0 in this invocation.`
 
 ## Command authorization
 The required git and `azurerm-linter` commands in this prompt are already authorized by the prompt itself.

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -60,7 +60,9 @@ Rules:
 - Do not silently skip files that belong to the committed review scope.
 
 ### 3) Load applicable workspace standards
-- Read the current workspace `CONTRIBUTING.md`.
+- Discover repo-level contributor guidance in the current workspace before reading it.
+- Check `CONTRIBUTING.md` and `contributing/README.md`, then read the applicable file(s) that exist.
+- When reviewing a `terraform-provider-azurerm` style workspace, treat `contributing/README.md` as the repo-level contributor guide when present.
 - Read `.github/pull_request_template.md` when present.
 - Read any file-scoped instructions or skills that directly govern the changed files.
 - If the review scope includes `website/docs/**/*.html.markdown`, also read `.github/instructions/docs-compliance-contract.instructions.md` and `.github/instructions/documentation-guidelines.instructions.md`, and apply `DOCS-*` rules only to those docs files.
@@ -93,17 +95,17 @@ Rules:
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
   - Use the tool footer such as `Found X issue(s)` as the issue count when present
-  - Put remote/worktree/package-detection/loading/cleanup logs into `Summary`, not `Must Fix`
-  - Put only actual violation lines into `Must Fix`
-  - If there are no violations, set `Must Fix` to `None`
-  - If there are multiple violations, list them as newline-separated entries, one normalized `CHECKID path:line: message` per line
+  - Put remote/worktree/package-detection/loading/cleanup logs into `Summary`, not the `🎯 Must Fix:` block
+  - Put only actual violation lines into the `🎯 Must Fix:` block
+  - If there are no violations, set the `🎯 Must Fix:` block to `None`
+  - If there are multiple violations, introduce a standalone `🎯 Must Fix:` label and render one normalized `CHECKID path:line: message` entry per bullet below it
   - Normalize temporary worktree paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
-  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep `Must Fix: None`, and do not show an install hint unless the binary is actually missing
+  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `🎯 Must Fix:` block as `None`, and do not show an install hint unless the binary is actually missing
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
-  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and `Must Fix`
-  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and `Must Fix`
+  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
+  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
   - If the local binary is not found, do not attempt remote execution; report `Not run` and direct the user to install the tool locally
   - If no valid PR number can be determined, use `Status: Not run`, `Run Scope: PR scope`, `Issue Count: n/a`, and a summary that tells the user to create a draft PR and run the review again
   - If the PR number was not supplied explicitly in the committed review invocation, include an example such as `/code-review-committed-changes PR 12345` in that summary
@@ -175,7 +177,8 @@ Use this template:
 - **Run Scope**: [PR scope via `--pr=<number>` or `n/a`]
 - **Issue Count**: [number from tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
 - **Summary**: [result summary or failure reason]
-- **Must Fix**: [use `None` when there are no violations; otherwise list one normalized `CHECKID path:line: message` entry per line]
+**🎯 Must Fix:** `None`
+- [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
 
 ### 🟢 **STRENGTHS**
 - [Concrete positive findings only]

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -92,6 +92,9 @@ Rules:
 - Committed review prefers exact committed-scope linting:
   - Automatically resolve the git repo root by running `git rev-parse --show-toplevel`; do not ask the user for the repo root
   - Run the linter from that repo root
+  - Treat `azurerm-linter` as a standalone locally installed CLI, not as a Go toolchain command
+  - Run the plain local CLI invocation in the current platform shell; do not rewrite it through `wsl`, `wsl --cd`, `bash -lc`, `sh -lc`, `cmd /c`, or `powershell -Command`
+  - On Windows, use plain `azurerm-linter --pr=<number> -output json` from the resolved repo root rather than a WSL-prefixed equivalent
   - Determine a valid pull request number deterministically from explicit review context only
   - Allowed PR number sources are:
     - the active pull request context, when available

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -96,6 +96,9 @@ Rules:
 - Local review prefers exact local-scope linting from the repo root:
   - Automatically resolve the git repo root by running `git rev-parse --show-toplevel`; do not ask the user for the repo root
   - Run the linter from that repo root
+  - Treat `azurerm-linter` as a standalone locally installed CLI, not as a Go toolchain command
+  - Run the plain local CLI invocation in the current platform shell; do not rewrite it through `wsl`, `wsl --cd`, `bash -lc`, `sh -lc`, `cmd /c`, or `powershell -Command`
+  - On Windows, use plain `azurerm-linter -output json` from the resolved repo root rather than a WSL-prefixed equivalent
   - Run filtered mode first using a direct `azurerm-linter -output json` invocation without `--pr`
   - Treat filtered mode as the baseline review behavior for this feature
   - Do not add a `--no-filter` workaround pass during ordinary review runs

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -15,6 +15,16 @@ If the local change-set includes `.github/prompts/code-review-local-changes.prom
 ## Minimal user input policy
 Assume the user may invoke this prompt with minimal instructions. Run the full procedure below even if the request is short.
 
+## Fresh-run requirement
+Every invocation of this prompt is a new audit run.
+Do not reuse prior git output, linter output, file classifications, or review conclusions from earlier turns.
+If the user asks to run the prompt again, rerun the full mandatory procedure from step 0 using the current workspace state.
+
+## No cached review state
+A previous review in the conversation is not evidence for the current run.
+All review findings must be based on commands and file reads executed during the current invocation of this prompt.
+If the required commands were not rerun in this invocation, do not emit a normal review output.
+
 ## Command authorization
 The required git and `azurerm-linter` commands in this prompt are already authorized by the prompt itself.
 Execute the required review commands immediately when their step applies.
@@ -26,6 +36,7 @@ Do not emit a preamble that asks permission or waits for approval before running
 - Do not guess when evidence is missing.
 - Do not present multiple alternative fixes unless the user explicitly asks for options.
 - Do not output progress narration, plans, or TODO lists.
+- Do not narrate intermediate verification steps such as checking file content after linter findings; perform those checks silently and present only final conclusions.
 - The first character of the normal review output must be `#`.
 
 ## Mandatory procedure
@@ -39,6 +50,7 @@ Do not emit a preamble that asks permission or waits for approval before running
 ### 1) Gather the local change-set
 Use `run_in_terminal` with `mode: "sync"`, a concrete `goal`, and a short `timeout` for each command.
 Execute these required commands directly when this step begins; do not pause for confirmation.
+The commands in steps 1 and 4 must be executed again for each invocation of this prompt, even if they were executed earlier in the conversation.
 
 Run these commands in order and do not repeat them:
 
@@ -82,29 +94,35 @@ Rules:
 - Local review prefers exact local-scope linting from the repo root:
   - Automatically resolve the git repo root by running `git rev-parse --show-toplevel`; do not ask the user for the repo root
   - Run the linter from that repo root
-  - Run filtered mode first using a direct `azurerm-linter` invocation without `--pr`
+  - Run filtered mode first using a direct `azurerm-linter -output json` invocation without `--pr`
   - Treat filtered mode as the baseline review behavior for this feature
   - Do not add a `--no-filter` workaround pass during ordinary review runs
 - If no in-scope provider Go files exist, mark the linter section as `Not applicable`.
 - If the local binary is missing or the tool cannot be run, mark the section as `Not run` and state the reason.
 - If the tool reports no changed files or no changed packages to analyze and prints `Error: no packages to analyze`, treat that result as `Not applicable`, not `Not run`.
 - If the tool reports a flag or usage parse error such as `flag provided but not defined` and prints usage help, treat that result as `Not run` due to invocation error, not as an install problem.
-- When the local binary is missing or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
+- Require `azurerm-linter v0.1.8` or newer for review-time JSON mode.
+- When the local binary is missing, older than `v0.1.8`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
 - Report azurerm-linter findings from the executed filtered linter scope as `Issues`.
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
-  - Use the tool footer such as `Found X issue(s)` as the issue count when present
-  - Put branch/package-detection/loading/cleanup logs into `Summary`, not the `🎯 Must Fix:` block
-  - Put only actual violation lines into the `🎯 Must Fix:` block
-  - If there are no violations, set the `🎯 Must Fix:` block to `None`
-  - If there are multiple violations, introduce a standalone `🎯 Must Fix:` label and render one normalized `CHECKID path:line: message` entry per bullet below it
+  - When a valid JSON payload is present, use `version` as the linter version, use `summary.issue_count` as the issue count, and ignore human-readable preamble logs for structured fields
+  - When a valid JSON payload is absent, the tool footer such as `Found X issue(s)` may be used as the issue count when present
+  - Put branch/package-detection/loading/cleanup logs into `Summary`, not the `### 🎯 **MUST FIX**` section
+  - Put only actual violation lines into the `### 🎯 **MUST FIX**` section
+  - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
+  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
+  - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
+  - If a valid JSON payload is present but `version` is lower than `v0.1.8`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.1.8` or newer
   - Normalize temporary or absolute paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
-  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `🎯 Must Fix:` block as `None`, and do not show an install hint unless the binary is actually missing
+  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and do not show an install hint unless the binary is actually missing
+  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.1.8` or newer, and do not fall back to text scraping
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
-  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
-  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
+  - Limit the `### 🧰 **AZURERM LINTER**` execution report to `Version`, `Status`, `Run Scope`, `Issue Count`, and `Summary`
+  - Follow it with a separate `### 🎯 **MUST FIX**` section
+  - Use the completed linter output, not partial early output, when determining `Version`, `Status`, `Issue Count`, `Summary`, and the `### 🎯 **MUST FIX**` section
   - If the local binary is not found, do not attempt remote execution; report `Not run` and direct the user to install the tool locally
   - Do not ask the user to approve `git rev-parse --show-toplevel` or `azurerm-linter` execution during the normal review flow
   - Do not create temporary scripts or persisted temp log files to run or parse the linter in the normal review flow
@@ -174,11 +192,14 @@ Use this template:
 - **Notes**: [scope-specific guidance that affected severity or classification]
 
 ### 🧰 **AZURERM LINTER**
+- **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]
 - **Status**: [Issues found/No issues/Not applicable/Not run]
 - **Run Scope**: [filtered local-diff scope or `n/a`]
-- **Issue Count**: [number from tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
+- **Issue Count**: [JSON `summary.issue_count`, tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
 - **Summary**: [result summary or failure reason]
-**🎯 Must Fix:** `None`
+
+### 🎯 **MUST FIX**
+- `None`
 - [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
 
 ### 🟢 **STRENGTHS**

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -64,7 +64,9 @@ Rules:
 - Do not omit any file that belongs to the selected review scope.
 
 ### 3) Load applicable workspace standards
-- Read the current workspace `CONTRIBUTING.md`.
+- Discover repo-level contributor guidance in the current workspace before reading it.
+- Check `CONTRIBUTING.md` and `contributing/README.md`, then read the applicable file(s) that exist.
+- When reviewing a `terraform-provider-azurerm` style workspace, treat `contributing/README.md` as the repo-level contributor guide when present.
 - Read `.github/pull_request_template.md` when present.
 - Read any file-scoped instructions or skills that directly govern the changed files.
 - If the review scope includes `website/docs/**/*.html.markdown`, also read `.github/instructions/docs-compliance-contract.instructions.md` and `.github/instructions/documentation-guidelines.instructions.md`, and apply `DOCS-*` rules only to those docs files.
@@ -92,17 +94,17 @@ Rules:
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
   - Use the tool footer such as `Found X issue(s)` as the issue count when present
-  - Put branch/package-detection/loading/cleanup logs into `Summary`, not `Must Fix`
-  - Put only actual violation lines into `Must Fix`
-  - If there are no violations, set `Must Fix` to `None`
-  - If there are multiple violations, list them as newline-separated entries, one normalized `CHECKID path:line: message` per line
+  - Put branch/package-detection/loading/cleanup logs into `Summary`, not the `🎯 Must Fix:` block
+  - Put only actual violation lines into the `🎯 Must Fix:` block
+  - If there are no violations, set the `🎯 Must Fix:` block to `None`
+  - If there are multiple violations, introduce a standalone `🎯 Must Fix:` label and render one normalized `CHECKID path:line: message` entry per bullet below it
   - Normalize temporary or absolute paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
-  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep `Must Fix: None`, and do not show an install hint unless the binary is actually missing
+  - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `🎯 Must Fix:` block as `None`, and do not show an install hint unless the binary is actually missing
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
-  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and `Must Fix`
-  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and `Must Fix`
+  - Limit the normal linter subsection to `Status`, `Run Scope`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
+  - Use the completed linter output, not partial early output, when determining `Status`, `Issue Count`, `Summary`, and the `🎯 Must Fix:` block
   - If the local binary is not found, do not attempt remote execution; report `Not run` and direct the user to install the tool locally
   - Do not ask the user to approve `git rev-parse --show-toplevel` or `azurerm-linter` execution during the normal review flow
   - Do not create temporary scripts or persisted temp log files to run or parse the linter in the normal review flow
@@ -176,7 +178,8 @@ Use this template:
 - **Run Scope**: [filtered local-diff scope or `n/a`]
 - **Issue Count**: [number from tool footer such as `Found X issue(s)`, `0`, or `n/a`, when helpful]
 - **Summary**: [result summary or failure reason]
-- **Must Fix**: [use `None` when there are no violations; otherwise list one normalized `CHECKID path:line: message` entry per line]
+**🎯 Must Fix:** `None`
+- [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
 
 ### 🟢 **STRENGTHS**
 - [Concrete positive findings only]

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -24,6 +24,8 @@ If the user asks to run the prompt again, rerun the full mandatory procedure fro
 A previous review in the conversation is not evidence for the current run.
 All review findings must be based on commands and file reads executed during the current invocation of this prompt.
 If the required commands were not rerun in this invocation, do not emit a normal review output.
+If the fresh-run requirements are not satisfied, hard-stop and output exactly this one line and nothing else:
+  - `Cannot run code-review-local-changes: fresh-run requirements not satisfied. Re-run the mandatory procedure from step 0 in this invocation.`
 
 ## Command authorization
 The required git and `azurerm-linter` commands in this prompt are already authorized by the prompt itself.

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -24,6 +24,8 @@ If the user asks to run the prompt again, rerun the full mandatory procedure fro
 A previous review in the conversation is not evidence for the current run.
 All review findings must be based on commands and file reads executed during the current invocation of this prompt.
 If the required commands were not rerun in this invocation, do not emit a normal review output.
+Do not reuse, paraphrase, or summarize a previous review body, even if the reviewed diff and findings are unchanged.
+If this invocation completes the mandatory procedure successfully, emit the full current review template defined by this prompt.
 If the fresh-run requirements are not satisfied, hard-stop and output exactly this one line and nothing else:
   - `Cannot run code-review-local-changes: fresh-run requirements not satisfied. Re-run the mandatory procedure from step 0 in this invocation.`
 
@@ -40,6 +42,13 @@ Do not emit a preamble that asks permission or waits for approval before running
 - Do not output progress narration, plans, or TODO lists.
 - Do not narrate intermediate verification steps such as checking file content after linter findings; perform those checks silently and present only final conclusions.
 - The first character of the normal review output must be `#`.
+
+## No preamble / no progress narration
+- Do not output any sentences before the review headings.
+- The only allowed normal output is the review template defined in this prompt.
+- Do not output progress narration such as `re-running the local audit`, `the scope is still`, `the review remains`, `I am finishing`, `I have reloaded`, `next I will`, `now I will`, or similar.
+- Do not compare the current run to earlier runs in the conversation; state only the facts established in the current invocation.
+- Do not short-circuit to wording such as `same findings as before`, `no change from the last review`, or other abbreviated carry-over summaries.
 
 ## Mandatory procedure
 
@@ -116,7 +125,8 @@ Rules:
   - Put branch/package-detection/loading/cleanup logs into `Summary`, not the `### 🎯 **MUST FIX**` section
   - Put only actual violation lines into the `### 🎯 **MUST FIX**` section
   - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
-  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
+  - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID [file:line](path#Lline): message` entry per bullet when repo-relative path normalization is deterministic; otherwise keep the raw `CHECKID path:line: message` form
+  - In the linked form, keep `file:line` together inside the same Markdown link so it matches the clickable file-reference style used elsewhere in the review
   - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
   - If a valid JSON payload is present but `version` is lower than `v0.2.0`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.2.0` or newer
   - Normalize temporary or absolute paths to repo-relative paths when deterministic; otherwise keep the raw path
@@ -205,7 +215,7 @@ Use this template:
 
 ### 🎯 **MUST FIX**
 - `None`
-- [when violations exist, replace `None` with one normalized `CHECKID path:line: message` entry per bullet]
+- [when violations exist, replace `None` with one normalized `CHECKID [file:line](path#Lline): message` entry per bullet when repo-relative path normalization is deterministic; otherwise use `CHECKID path:line: message`]
 
 ### 🟢 **STRENGTHS**
 - [Concrete positive findings only]

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -103,8 +103,8 @@ Rules:
 - If the local binary is missing or the tool cannot be run, mark the section as `Not run` and state the reason.
 - If the tool reports no changed files or no changed packages to analyze and prints `Error: no packages to analyze`, treat that result as `Not applicable`, not `Not run`.
 - If the tool reports a flag or usage parse error such as `flag provided but not defined` and prints usage help, treat that result as `Not run` due to invocation error, not as an install problem.
-- Require `azurerm-linter v0.1.8` or newer for review-time JSON mode.
-- When the local binary is missing, older than `v0.1.8`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
+- Require `azurerm-linter v0.2.0` or newer for review-time JSON mode.
+- When the local binary is missing, older than `v0.2.0`, or execution fails for tool-availability reasons, include an install hint pointing to `https://github.com/QixiaLu/azurerm-linter` and `go install github.com/qixialu/azurerm-linter@latest`.
 - Report azurerm-linter findings from the executed filtered linter scope as `Issues`.
 - Do not leave azurerm-linter findings only inside the `AZURERM LINTER` subsection; also surface them in the main `### 🔴 **ISSUES**` section.
 - Structure the linter section from the actual tool output:
@@ -115,11 +115,11 @@ Rules:
   - If there are no violations, set the `### 🎯 **MUST FIX**` section to a single bullet: `- None`
   - If there are multiple violations, render a separate `### 🎯 **MUST FIX**` section after the linter execution report and list one normalized `CHECKID path:line: message` entry per bullet
   - When a valid JSON payload is present, derive findings from `findings[]`, derive the reviewer-facing summary from JSON `summary` and `scope` fields, and trim any duplicated leading check ID from `message`
-  - If a valid JSON payload is present but `version` is lower than `v0.1.8`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.1.8` or newer
+  - If a valid JSON payload is present but `version` is lower than `v0.2.0`, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and state that JSON review mode requires `azurerm-linter v0.2.0` or newer
   - Normalize temporary or absolute paths to repo-relative paths when deterministic; otherwise keep the raw path
   - If the output shape is `Found 0 changed files` plus `Error: no packages to analyze`, use `Status: Not applicable`, not `Not run`
   - If the output shape is a flag or usage parse error, use `Status: Not run`, keep the `### 🎯 **MUST FIX**` section as `- None`, and do not show an install hint unless the binary is actually missing
-  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.1.8` or newer, and do not fall back to text scraping
+  - If `-output json` is unsupported and the tool reports a flag or usage parse error, report that as `Not run`, state that review requires `azurerm-linter v0.2.0` or newer, and do not fall back to text scraping
   - Do not invent broader-scope fallback reporting fields in the normal review flow
   - Keep successful linter output concise and reviewer-facing; do not dump branch, upstream, merge-base, command, log-file, or similar debug details unless they materially explain the result
   - Limit the `### 🧰 **AZURERM LINTER**` execution report to `Version`, `Status`, `Run Scope`, `Issue Count`, and `Summary`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the generic local and committed review prompts plus the shared review contract to prefer `azurerm-linter` JSON output, report the linter version in the review output, and require `azurerm-linter v0.2.0` or newer for JSON-mode review.
+- Updated the generic local and committed review prompts plus the shared review contract to prefer [`azurerm-linter`](https://github.com/QixiaLu/azurerm-linter) JSON output, report the linter version in the review output, and require [`azurerm-linter v0.2.0`](https://github.com/QixiaLu/azurerm-linter/releases/tag/v0.2.0) or newer for JSON-mode review.
+- Clarified the workspace terminal guidance so [`azurerm-linter`](https://github.com/QixiaLu/azurerm-linter) is treated as a standalone local CLI instead of a Go toolchain command, and hardened the review prompts/contract to require native local linter execution from the repo root instead of WSL-prefixed or cross-shell-wrapped invocations.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the generic local and committed review prompts plus the shared review contract to prefer `azurerm-linter` JSON output, report the linter version in the review output, and require `azurerm-linter v0.1.8` or newer for JSON-mode review.
+- Updated the generic local and committed review prompts plus the shared review contract to prefer `azurerm-linter` JSON output, report the linter version in the review output, and require `azurerm-linter v0.2.0` or newer for JSON-mode review.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the generic local and committed review prompts plus the shared review contract to prefer `azurerm-linter` JSON output, report the linter version in the review output, and require `azurerm-linter v0.1.8` or newer for JSON-mode review.
+
 ### Fixed
+
+- Fixed installed review behavior in `terraform-provider-azurerm` workspaces by discovering repo-level contributor guidance from common target-repo paths, forcing fresh review reruns instead of reusing prior review state, suppressing narrated post-linter verification steps, and rendering azurerm-linter findings in a dedicated `### 🎯 **MUST FIX**` section instead of malformed inline list output.
 
 ## [3.0.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed installed review behavior in `terraform-provider-azurerm` workspaces by discovering repo-level contributor guidance from common target-repo paths, forcing fresh review reruns instead of reusing prior review state, suppressing narrated post-linter verification steps, and rendering azurerm-linter findings in a dedicated `### 🎯 **MUST FIX**` section instead of malformed inline list output.
+- Fixed installed review behavior in `terraform-provider-azurerm` workspaces by discovering repo-level contributor guidance from common target-repo paths, forcing fresh review reruns instead of reusing prior review state, hard-stopping with deterministic fresh-run failure messages, suppressing narrated post-linter verification steps, and rendering azurerm-linter findings in a dedicated `### 🎯 **MUST FIX**` section instead of malformed inline list output.
 
 ## [3.0.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the generic local and committed review prompts plus the shared review contract to prefer [`azurerm-linter`](https://github.com/QixiaLu/azurerm-linter) JSON output, report the linter version in the review output, and require [`azurerm-linter v0.2.0`](https://github.com/QixiaLu/azurerm-linter/releases/tag/v0.2.0) or newer for JSON-mode review.
 - Clarified the workspace terminal guidance so [`azurerm-linter`](https://github.com/QixiaLu/azurerm-linter) is treated as a standalone local CLI instead of a Go toolchain command, and hardened the review prompts/contract to require native local linter execution from the repo root instead of WSL-prefixed or cross-shell-wrapped invocations.
+- Updated the review prompt output guidance so normalized `### 🎯 **MUST FIX**` linter findings prefer compact Markdown file links like `CHECKID [file:line](repo/relative/path#Lline): message` when deterministic repo-relative paths are available, matching the clickable file-reference style used elsewhere in the review.
+- Tightened the fresh-run review rules so repeated code-review invocations must describe only current-run evidence, with no carry-over wording or execution-progress narration before the final review headings.
+- Tightened the fresh-run review rules so successful reruns must emit the full current review template even when the reviewed diff and findings are unchanged, instead of short-circuiting to prior review text or delta-only summaries.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ If Copilot does not already have PR context for your branch, pass the PR number 
 ```
 
 > [!NOTE]
-> The generic review prompts require `azurerm-linter v0.2.0` or newer for JSON-mode review and assume a recent local `azurerm-linter` binary. If you are testing these prompt-side linter behaviors before the corresponding upstream `azurerm-linter` changes are merged and installed locally, the linter subsection may not yet behave exactly as documented. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50). After those upstream changes land, reinstall or update your local `azurerm-linter` binary and rerun the review.
+> The generic review prompts require a local `v0.2.0` or newer `azurerm-linter` binary from the [QixiaLu/azurerm-linter](https://github.com/QixiaLu/azurerm-linter) repo for JSON-mode review. The linter is expected to run as the plain local CLI from the repo root on every platform, including Windows; it should not be rewritten through WSL or another shell wrapper.
 
 If you want to reduce approval prompts for the harmless repo-root lookup used by the review prompts, you can allow just that command in your VS Code user settings:
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ If Copilot does not already have PR context for your branch, pass the PR number 
 ```
 
 > [!NOTE]
-> The generic review prompts assume a recent local `azurerm-linter` binary. If you are testing these prompt-side linter behaviors before the corresponding upstream `azurerm-linter` changes are merged and installed locally, the linter subsection may not yet behave exactly as documented. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50). After those upstream changes land, reinstall or update your local `azurerm-linter` binary and rerun the review.
+> The generic review prompts require `azurerm-linter v0.2.0` or newer for JSON-mode review and assume a recent local `azurerm-linter` binary. If you are testing these prompt-side linter behaviors before the corresponding upstream `azurerm-linter` changes are merged and installed locally, the linter subsection may not yet behave exactly as documented. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50). After those upstream changes land, reinstall or update your local `azurerm-linter` binary and rerun the review.
 
 If you want to reduce approval prompts for the harmless repo-root lookup used by the review prompts, you can allow just that command in your VS Code user settings:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -472,7 +472,7 @@ go install github.com/qixialu/azurerm-linter@latest
 **Notes**:
 - `/code-review-local-changes` does not require PR context and continues to use local-diff linting.
 - The committed review prompt does not guess PR numbers from branch names or git history.
-- The prompt-side linter flow assumes a recent local `azurerm-linter` build. If the corresponding upstream `azurerm-linter` changes are not merged and installed locally yet, the linter subsection can still behave like the older tool version until you update your local binary. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50).
+- The prompt-side linter flow requires `azurerm-linter v0.2.0` or newer for JSON-mode review and assumes a recent local `azurerm-linter` build. If the corresponding upstream `azurerm-linter` changes are not merged and installed locally yet, the linter subsection can still behave like the older tool version until you update your local binary. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -472,7 +472,7 @@ go install github.com/qixialu/azurerm-linter@latest
 **Notes**:
 - `/code-review-local-changes` does not require PR context and continues to use local-diff linting.
 - The committed review prompt does not guess PR numbers from branch names or git history.
-- The prompt-side linter flow requires `azurerm-linter v0.2.0` or newer for JSON-mode review and assumes a recent local `azurerm-linter` build. If the corresponding upstream `azurerm-linter` changes are not merged and installed locally yet, the linter subsection can still behave like the older tool version until you update your local binary. The current upstream dependency is [QixiaLu/azurerm-linter#50](https://github.com/QixiaLu/azurerm-linter/pull/50).
+- The prompt-side linter flow requires a local `v0.2.0` or newer `azurerm-linter` binary from the [QixiaLu/azurerm-linter](https://github.com/QixiaLu/azurerm-linter) repo for JSON-mode review. The expected review-time command is the plain local CLI from the repo root on every platform, including Windows, and it should not be rewritten through WSL or another shell wrapper.
 
 ---
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Summary

Harden the generic code review prompts so they rerun deterministically, execute `azurerm-linter` natively from the repo root, and render reviewer-facing linter findings in a cleaner, more clickable format.

## Description

This change tightens the shared code review contract and the generic local/committed review prompts to fix runtime and UX problems that showed up during repeated review runs.

The main goals are:

- require native local `azurerm-linter` execution instead of WSL-prefixed or cross-shell-wrapped invocations
- require true fresh-run behavior on repeated review requests, instead of reusing prior review state or short-circuiting to earlier output
- improve `### 🎯 **MUST FIX**` rendering so linter findings use compact clickable `file:line` links that match the rest of the review output
- clarify the end-user documentation around the required `azurerm-linter` version and upstream source

The branch updates the shared review contract, both generic review prompts, and the user-facing docs/changelog text that explain the expected behavior.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [x] Installer
- [ ] Bash
- [ ] PowerShell
- [x] AI prompts (`.github/prompts/`)
- [x] AI instructions (`.github/instructions/`)
- [ ] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

<!-- None -->

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

Validated through repeated prompt-review iterations and repo updates to confirm:

- native Windows `azurerm-linter -output json` execution is required and documented as the compliant path
- repeated `/code-review-local-changes` and `/code-review-committed-changes` runs must be treated as fresh audits
- repeated successful reruns must emit the full current review template instead of reusing a prior review body
- `### 🎯 **MUST FIX**` findings now use compact clickable `file:line` links and match the rest of the review output style
- README, troubleshooting guidance, and changelog wording were aligned with the prompt/runtime behavior

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

AI assistance was used to refine the prompt/instruction wording, update documentation text, and iterate on review-output UX/details while keeping the behavior aligned with the repository’s shared review contract.

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [ ] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github_actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.