### PR TITLE
[ENHANCEMENT:] Expand regression harness and align AI toolkit validation

### DIFF
--- a/.github/instructions/implementation-guide.instructions.md
+++ b/.github/instructions/implementation-guide.instructions.md
@@ -777,6 +777,12 @@ d.SetId(id.ID())
 - Use provider-generated legacy parse and validate helpers only when neither `go-azure-sdk` nor `commonids` currently support the ID shape.
 - Keep import validation, state parsing, and resource identity generation aligned to the same underlying ID type.
 
+### Codebase Orientation and Build Context
+
+- When explaining provider directory layout, service-package boundaries, or typed-versus-untyped implementation choices, align the explanation to the upstream high-level overview rather than inventing local package terminology.
+- When explaining terms such as `Service Package`, `Typed Resource`, `Typed Plugin SDK`, `Resource ID Parser`, or `Terraform Managed Resource ID`, use the upstream glossary definitions consistently.
+- When a contributor asks how to build the provider locally, treat the upstream building guide as the canonical entry point for the current build flow rather than inventing repo-specific build commands.
+
 ### Extending Existing Resources and Data Sources
 
 - When adding a new resource field, update schema or model ordering first, then wire the property through create, update, and read logic, keeping pointer handling nil-safe in state.
@@ -793,11 +799,14 @@ d.SetId(id.ID())
 
 Official upstream references:
 
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/building-the-provider.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-new-feature.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-list-resource.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-new-fields-to-resource.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-new-fields-to-data-source.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-new-service-package.md`
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/high-level-overview.md`
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/reference-glossary.md`
 - `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/guide-resource-ids.md`
 
 ---

--- a/.github/instructions/schema-patterns.instructions.md
+++ b/.github/instructions/schema-patterns.instructions.md
@@ -1091,6 +1091,7 @@ func validateAdvancedConfiguration(ctx context.Context, diff *pluginsdk.Resource
 
 - Typed resources that support resource identity should implement `sdk.ResourceWithIdentity`, set identity data immediately after `metadata.SetID(id)` in create, and set it again during read before encoding state.
 - Untyped resources should pair `pluginsdk.GenerateIdentitySchema(...)` with `pluginsdk.ImporterValidatingIdentity(...)` and `pluginsdk.SetResourceIdentityData(...)` in create and read.
+- Resource identity tests are generator-driven. Add the `go:generate` resource-identity test comment near the imports and map every ID segment through either `-properties` or `-compare-values`; if the resource ID omits `subscription_id`, use `-no-subscription-id`.
 - Resource identity generation currently does not support composite resource IDs or custom IDs outside `commonids` and `go-azure-sdk`, and numeric ID segment names can produce incorrect snake_case field names.
 - Write-only attributes are appropriate only for sensitive scalar resource attributes that are not `ForceNew`, not `Computed`, and not nested in unsupported collection shapes.
 - Pair each write-only field with a non-write-only trigger field such as `<name>_wo_version`, wire `ConflictsWith` and `RequiredWith` both ways, use `pluginsdk.GetWriteOnly(...)` in create and update, and persist the trigger field in state during read to avoid permanent diffs.

--- a/.github/instructions/testing-guidelines.instructions.md
+++ b/.github/instructions/testing-guidelines.instructions.md
@@ -27,6 +27,7 @@ If this guide conflicts with the testing contract, follow the testing contract a
 - Tests may incur Azure costs depending on resources created
 - Ensure proper cleanup after test execution
 - Unit tests are safe and don't require Azure credentials
+- The upstream acceptance-test entry point is `make acctests SERVICE='<service>' TESTARGS='-run=<nameOfTheTest>' TESTTIMEOUT='60m'` with the required `ARM_*` and `ARM_TEST_LOCATION*` environment variables present in the shell.
 
 **Example Command Format:**
 ```bash
@@ -595,8 +596,9 @@ make testacc TEST=./internal/services/cdn TESTARGS='-run=TestAccCdnFrontDoorProf
 - Scale-down operations blocked due to health monitoring requirements
 - Soft-delete conflicts preventing immediate recreation
 
-**📚 Official Acceptance Testing Reference:**
-For comprehensive acceptance testing guidelines, see: [Acceptance Testing Reference](../../../contributing/topics/reference-acceptance-testing.md)
+**📚 Official Acceptance Testing References:**
+- [Acceptance Testing Reference](../../../contributing/topics/reference-acceptance-testing.md)
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/running-the-tests.md`
 
 ## 📚 Specialized Testing Guidance (On-Demand)
 

--- a/.github/instructions/troubleshooting-decision-trees.instructions.md
+++ b/.github/instructions/troubleshooting-decision-trees.instructions.md
@@ -155,6 +155,13 @@ terraform plan -target=azurerm_resource.example
 az rest --method GET --url "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/{rg}/providers/Microsoft.Service/resources/{name}?api-version=2023-01-01"
 ```
 
+**4. Escalate When Logs Are Not Enough**
+```text
+- Prefer logging parsed resource ID structs rather than raw ID strings when tracing provider behavior.
+- If TF_LOG output is insufficient, inspect traffic through an HTTPS debugging proxy.
+- If request-level inspection still is not enough, attach a debugger such as delve rather than adding long-lived ad-hoc debug code.
+```
+
 ### Network and Connectivity Issues
 
 **Debugging Pattern:**
@@ -262,6 +269,11 @@ data := acceptance.BuildTestData(t, "azurerm_resource", "test")
 // Verify resource group cleanup
 // Review parallel test execution
 ```
+
+**Official upstream debugging references:**
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/building-the-provider.md`
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/debugging-the-provider.md`
+- `https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing/topics/running-the-tests.md`
 
 ### CustomizeDiff Debugging
 

--- a/.github/skills/ai-toolkit-maintenance/SKILL.md
+++ b/.github/skills/ai-toolkit-maintenance/SKILL.md
@@ -92,6 +92,14 @@ If preflight is incomplete, do not proceed with toolkit-maintenance work.
   - Added because pure logic can prove exact references and exact drift states, but cannot prove semantic equivalence or meaning-preserving upstream rewrites
   - The repo-only maintainer workflow needs an explicit handoff from deterministic detection to AI-assisted semantic review rather than heuristic auto-mapping
 
+### MAINT-UPSTREAM-004: Keep contributor merge-conflict guidance aligned with upstream FAQ expectations
+
+- Rule: Do not broadly tell contributors to rebase or merge from `main` just because a pull request is stale or conflicted; prefer that only after a maintainer has reviewed the PR and explicitly requested it.
+- **Provenance**: Published upstream standard.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/frequently-asked-questions.md` says contributors should generally rebase or merge from `main` only once a maintainer has taken a look through the PR and explicitly requested it
+  - That guidance is relevant when local maintainer workflow or AI suggestions discuss how contributors should resolve merge conflicts on open PRs
+
 - Classify the change first:
   - Decide whether the file belongs in shipped runtime payload or repo-only maintenance tooling.
   - Leave repo-only files out of `installer/file-manifest.config`.
@@ -117,6 +125,9 @@ If preflight is incomplete, do not proceed with toolkit-maintenance work.
   - When a tracked upstream doc changes, review the dynamically discovered local references and remove any conflicting local rules while preserving verified tribal knowledge that still does not conflict.
 
 - Run the repo maintenance checks:
+  - Prefer `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1` for the one-shot maintainer validation flow.
+  - Use `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -AllowCatalogIssues` when CI should still fail on changed tracked sources or rule issues but the remaining uncovered upstream topic catalog gaps are being reviewed separately.
+  - Treat the one-shot validator as including an explicit branch-local changelog decision: update `CHANGELOG.md`, or rerun with `-ChangelogNotRequired -ChangelogReason "..."` when no release-note entry is warranted.
   - Run `pwsh -NoProfile -File ./tools/check-upstream-contributor-drift.ps1` when local AI guidance is meant to stay aligned with upstream HashiCorp contributor docs.
   - Run `pwsh -NoProfile -File ./tools/validate-contracts.ps1` after contract or consumer changes.
   - Run `npx -y markdownlint-cli2 ".github/**/*.md" "docs/**/*.md" --config .github/.markdownlint.json` after Markdown-based AI-toolkit changes.

--- a/.github/workflows/contracts-validation.yml
+++ b/.github/workflows/contracts-validation.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run AI toolkit validator
         shell: pwsh
         run: |

--- a/.github/workflows/contracts-validation.yml
+++ b/.github/workflows/contracts-validation.yml
@@ -1,4 +1,4 @@
-name: Validate Contracts
+name: Validate AI Toolkit
 
 on:
   push:
@@ -7,6 +7,10 @@ on:
       - '.github/instructions/**'
       - '.github/prompts/**'
       - '.github/skills/**'
+      - 'docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md'
+      - 'tools/config/upstream-contributor.json'
+      - 'tools/check-upstream-contributor-drift.ps1'
+      - 'tools/validate-ai-toolkit.ps1'
       - 'tools/validate-contracts.ps1'
       - '.github/workflows/contracts-validation.yml'
   pull_request:
@@ -15,19 +19,23 @@ on:
       - '.github/instructions/**'
       - '.github/prompts/**'
       - '.github/skills/**'
+      - 'docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md'
+      - 'tools/config/upstream-contributor.json'
+      - 'tools/check-upstream-contributor-drift.ps1'
+      - 'tools/validate-ai-toolkit.ps1'
       - 'tools/validate-contracts.ps1'
       - '.github/workflows/contracts-validation.yml'
   workflow_dispatch:
 
 jobs:
   validate-contracts:
-    name: Validate Contract Model
+    name: Validate AI Toolkit
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Run contract validator
+      - name: Run AI toolkit validator
         shell: pwsh
         run: |
-          ./tools/validate-contracts.ps1
+          ./tools/validate-ai-toolkit.ps1 -SkipRegressionHarness -AllowCatalogIssues

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -23,20 +23,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-
       - name: Run markdownlint
-        run: |
-          markdownlint '**/*.md' \
-            --ignore node_modules \
-            --ignore CHANGELOG.md \
-            --config .github/markdownlint.json || true
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          config: '.github/.markdownlint.json'
+          globs: |
+            **/*.md
+            !**/node_modules/**
+            !CHANGELOG.md
         continue-on-error: true
 
   check-links:

--- a/.github/workflows/regression-harness-validation.yml
+++ b/.github/workflows/regression-harness-validation.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run AI toolkit validator for regression scope
         shell: pwsh

--- a/.github/workflows/regression-harness-validation.yml
+++ b/.github/workflows/regression-harness-validation.yml
@@ -1,0 +1,54 @@
+name: Validate Regression Harness
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/regression/**'
+      - 'tools/validate-ai-toolkit.ps1'
+      - 'docs/AI_REGRESSION_HARNESS.md'
+      - '.github/workflows/regression-harness-validation.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'tools/regression/**'
+      - 'tools/validate-ai-toolkit.ps1'
+      - 'docs/AI_REGRESSION_HARNESS.md'
+      - '.github/workflows/regression-harness-validation.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-regression-harness:
+    name: Validate Regression Harness
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run AI toolkit validator for regression scope
+        shell: pwsh
+        run: |
+          ./tools/validate-ai-toolkit.ps1 -SkipUpstreamDrift
+
+      - name: Publish workflow summary
+        shell: pwsh
+        run: |
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Regression Harness"
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ""
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value '```text'
+          Get-Content -LiteralPath ./tools/regression/results/latest/regression-history-summary.txt | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value '```'
+
+      - name: Upload regression harness reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-harness-reports
+          path: |
+            tools/regression/results/latest/validation.json
+            tools/regression/results/latest/regression-suite.txt
+            tools/regression/results/latest/regression-suite.json
+            tools/regression/results/latest/regression-history-snapshot.json
+            tools/regression/results/latest/regression-history-summary.txt
+            tools/regression/results/latest/regression-history-summary.json
+            tools/regression/results/latest/regression-harness-summary.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ installer/aii.checksum
 
 # Regression harness generated run artifacts
 tools/regression/runs/
+tools/regression/results/latest/
+tools/regression/results/history/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Thumbs.db
 
 # Installer artifacts
 installer/aii.checksum
+
+# Regression harness generated run artifacts
+tools/regression/runs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a single-case regression run orchestrator that resolves case aliases, creates per-run directories, generates a run manifest, and scaffolds result and review artifacts under `tools/regression/runs/`.
 - Added a regression run hydrator that copies adjudicated example artifacts into a scaffolded run, plus a cleanup script for generated `tools/regression/runs/` directories.
 - Added `-Case` alias support to the example runner and expanded the regression-harness docs so the scoring weights and pass-threshold knobs are explained explicitly.
+- Added contributor-facing HCL regression test authoring under `tools/regression/test/`, including the canonical `AccTest`/`test_case`/`rules` DSL, `new-regression-test.ps1`, `build-regression-test.ps1`, and `publish-regression-test.ps1`.
+- Added regression-harness schema validation, suite scoring, history snapshotting, history summarization, and committed-review/docs-writer/acceptance-testing adjudicated example coverage.
+- Added a one-shot repo-only maintainer validator at `tools/validate-ai-toolkit.ps1` so contract validation, markdown lint, regression-harness validation, and upstream contributor drift can run through a single entry point.
+- Added tracked upstream contributor baselines for building, debugging, FAQ, high-level overview, glossary, and running-the-tests guidance so the drift checker can validate those local reference points explicitly.
 
 ### Changed
 
+- Tightened the one-shot AI toolkit validator so changelog handling is now an explicit maintainer decision instead of a path-based heuristic: update `CHANGELOG.md`, or pass an explicit `-ChangelogNotRequired -ChangelogReason "..."` waiver when no release-note entry is warranted.
+- Tightened the regression harness around deterministic run envelopes by snapshotting per-run case and weights inputs, recording repository snapshot and capture metadata, validating run manifests against schema, and validating result artifacts before scoring.
+- Renamed the regression test implementation surface to the public `new-regression-test.ps1`, `build-regression-test.ps1`, and `publish-regression-test.ps1` entry points, removing the old `acctest`-named implementation files and documenting the stricter unreleased HCL standard directly.
+- Updated the AI toolkit alignment checklist, maintainer skill, and CI workflows to use the shared one-shot maintainer validator, including CI-specific catalog-issue tolerance via `-AllowCatalogIssues`.
+- Expanded local AI guidance to incorporate the reviewed upstream contributor topics for provider build entry points, codebase overview and terminology, provider debugging escalation, acceptance-test invocation, and contributor merge-conflict guidance.
+
 ### Fixed
+
+- Fixed the upstream contributor drift coverage gap so all tracked and explicitly referenced upstream contributor topics now resolve cleanly with `Changed Sources: 0`, `Catalog Issues: 0`, and `Rule Issues: 0`.
 
 
 ## [3.1.0] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a repo-only regression-harness foundation under `tools/regression/` plus supporting docs, JSON schemas, scoring weights, and a starter five-case corpus plan so prompt, instruction, and skill behavior can move toward objective, repeatable evaluation instead of ad hoc subjective checks.
+- Added initial regression-harness utility scripts to scaffold result templates and score case results against weighted benchmark criteria, along with a synthetic adjudicated smoke case and sample result fixture.
+- Added the first sanitized adjudicated real-world regression case for resource-implementation guidance, including a neutral fixture summary and a scored example result.
+- Added the first adjudicated review-side regression case for local Go review behavior, including a sanitized fixture, a sample human-readable review output, and a scored example result.
+- Added an adjudicated docs-review regression case plus a thin example runner script so benchmark cases can be previewed and scored together from a single command.
+- Added a single-case regression run orchestrator that resolves case aliases, creates per-run directories, generates a run manifest, and scaffolds result and review artifacts under `tools/regression/runs/`.
+- Added a regression run hydrator that copies adjudicated example artifacts into a scaffolded run, plus a cleanup script for generated `tools/regression/runs/` directories.
+- Added `-Case` alias support to the example runner and expanded the regression-harness docs so the scoring weights and pass-threshold knobs are explained explicitly.
+
 ### Changed
 
 ### Fixed
+
 
 ## [3.1.0] - 2026-04-26
 

--- a/docs/AI_REGRESSION_HARNESS.md
+++ b/docs/AI_REGRESSION_HARNESS.md
@@ -1,0 +1,343 @@
+# AI Regression Harness
+
+This document defines the objective benchmark model for evaluating this repository's AI prompts, instructions, and skills.
+
+## Goal
+
+The current validation model is strong for structural correctness, but still weak for behavioral regressions.
+
+Today we can validate things like:
+
+- Contract structure
+- Markdown formatting
+- Manifest coverage
+- Release packaging
+
+What remains subjective is whether prompt, instruction, and skill behavior gets better or worse over time. This harness foundation exists to make those evaluations repeatable and evidence-based.
+
+## Core Principle
+
+The benchmark must score behavior, not prose.
+
+The harness should not fail a run because the wording changed. It should fail a run because the run:
+- Missed a must-catch issue
+- Raised a false positive that should not be raised
+- Used the wrong tool flow
+- Loaded the wrong rule family
+- Violated the expected output contract
+
+## What Makes The Benchmark Objective
+
+The benchmark becomes objective when all of the following are fixed:
+
+- The repository snapshot under evaluation
+- The changed files or patch fixture
+- The task being invoked
+- The expected rules that should apply
+- The adjudicated must-catch and must-not-flag outcomes
+- The scoring rubric
+
+**_Human judgment is still required when authoring and approving a case_**, but once a case is adjudicated the day-to-day scoring should be automatic.
+
+## Repository Layout
+
+The initial foundation lives under `tools/regression/`:
+- `tools/regression/README.md`
+- `tools/regression/config/score-weights.json`
+- `tools/regression/schema/review-case.schema.json`
+- `tools/regression/schema/review-result.schema.json`
+- `tools/regression/cases/`
+- `tools/regression/new-regression-result-template.ps1`
+- `tools/regression/score-regression-case.ps1`
+- `tools/regression/run-regression-example.ps1`
+- `tools/regression/run-regression-case.ps1`
+- `tools/regression/hydrate-regression-run.ps1`
+- `tools/regression/clean-regression-runs.ps1`
+
+This is repo-only maintenance tooling. It is not installer payload.
+
+## Case Model
+
+Each case should define:
+
+- A stable case ID
+- The task or prompt being invoked
+- The intended scope and changed files
+- The expected rule families that should activate
+- A must-catch set
+- A must-not-flag set
+- The expected tool behavior
+- The required output structure checks
+
+Cases should be sanitized fixtures, not live PR links.
+
+## Scoring Model
+
+The initial score model is weighted toward correctness over formatting.
+
+- Must-catch recall
+- False-positive control
+- Severity correctness
+- Scope and tool correctness
+- Output compliance
+- Determinism
+
+The exact weights live in `tools/regression/config/score-weights.json`.
+
+## Score Weights File
+
+The `tools/regression/config/score-weights.json` file controls two things:
+
+- How much each scoring dimension contributes to the final overall score
+- The minimum thresholds required for a run to count as passing
+
+### Think of the file as two separate layers:
+
+- `weights`
+	- This section controls score composition.
+	- It answers: `How much should each dimension matter in the weighted overall score?`
+- `passGuidance`
+	- This section controls pass or fail policy.
+	- It answers: `After the score is calculated, what minimum conditions are required for the run to count as passing?`
+
+Those two sections do different jobs and should be read in order:
+
+- The harness calculates the per-dimension scores
+- The harness applies the `weights` section to compute the weighted overall score
+- The harness applies the `passGuidance` section to decide whether that scored run is allowed to pass
+
+That means a run can have a high overall score and still fail if it violates a stricter policy floor in `passGuidance`. All numeric values in this file are designed to be easy to reason about as percentages.
+
+### General guidance for the whole file:
+
+- Each value under `weights` should normally be a number from `0` to `100`
+- Each numeric value under `passGuidance` should normally be a number from `0` to `100`
+- `allowFalsePositives` is a boolean, so its valid values are `true` or `false`
+
+## The `weights` Section
+
+The `weights` section controls how the overall score is calculated.
+
+### General guidance for `weights`:
+
+- The values under `weights` should normally add up to `100`
+- Keeping the total at `100` lets reviewers read each weight as a percentage share of the final score
+- Totals above `100` or below `100` are not invalid mathematically, but they make the scoring policy harder to reason about
+
+### What higher and lower values mean in the `weights` section:
+
+- A higher weight means that scoring dimension has more influence on the final overall score
+- A lower weight means that scoring dimension has less influence on the final overall score
+- A weight of `0` effectively removes that dimension from the weighted score
+
+### Current scoring dimensions:
+
+- `mustCatchRecall`
+	- **Description:** Measures whether the run actually surfaced the adjudicated must-catch findings.
+	- **Reason:** This is intentionally the largest weight because missing a real issue is worse than wording differences.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** Must-catch recall matters more in the overall score.
+	- **Lower value:** The harness becomes more tolerant of missing important issues, which is usually a bad tradeoff.
+- `falsePositiveControl`
+	- **Description:** Measures whether the run avoided raising issues that the case explicitly says must not be flagged.
+	- **Reason:** This stays heavily weighted because noisy reviews reduce trust in the harness quickly.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** False positives hurt the score more strongly.
+	- **Lower value:** The harness becomes more permissive of noisy or overreaching output.
+- `severityCorrectness`
+	- **Description:** Measures whether the important findings were classified at the expected severity.
+	- **Reason:** Finding the right issue is important, but classifying it correctly is also part of trustworthy review behavior.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** Severity mismatches matter more.
+	- **Lower value:** The harness cares less about whether the right issue was classified at the right level.
+- `scopeAndToolCorrectness`
+	- **Description:** Measures whether the right rule families and tool behavior were applied for the case.
+	- **Reason:** A run that uses the wrong tools or applies the wrong rules can look plausible while still being fundamentally unreliable.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** Using the right scope and tools matters more in the final score.
+	- **Lower value:** The harness becomes more forgiving of incorrect tool or scope behavior.
+- `outputCompliance`
+	- **Description:** Measures whether required sections or markers are present in the output artifact.
+	- **Reason:** Some workflows depend on stable output structure, even when prose wording is allowed to vary.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** Output-shape compliance matters more.
+	- **Lower value:** The harness focuses less on formatting and required sections.
+- `determinism`
+	- **Description:** Measures whether repeated runs are materially equivalent.
+	- **Reason:** A regression benchmark loses value quickly if the same case produces meaningfully different outcomes from run to run.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** Run-to-run stability matters more.
+	- **Lower value:** The harness becomes more tolerant of variability.
+
+## The `passGuidance` Section
+
+The `passGuidance` section does not change how the score is calculated. It changes how the harness interprets the score after calculation, this is effectivly the policy gate.
+
+### What higher and lower values mean in `passGuidance`:
+
+- A higher pass threshold makes the benchmark stricter
+- A lower pass threshold makes the benchmark more permissive
+- A stricter `passGuidance` block can cause a run to fail even when the weighted overall score still looks relatively strong
+
+### Current pass-guidance knobs:
+
+- `minimumOverallScore`
+	- **Description:** The weighted overall score required for a run to pass.
+	- **Reason:** This is the broad policy threshold for deciding whether the full score profile is acceptable.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** stricter overall pass criteria.
+	- **Lower value:** easier overall pass criteria.
+- `minimumMustCatchRecall`
+	- **Description:** A floor for must-catch recall so a run cannot pass on formatting or low-severity behavior while still missing the important issue.
+	- **Reason:** This protects the harness from approving runs that look polished but fail at the main job of catching important issues.
+	- **Expected range:** `0` to `100`.
+	- **Higher value:** stricter requirement that important issues must be found.
+	- **Lower value:** more tolerance for missing must-catch findings.
+- `allowFalsePositives`
+	- **Description:** Whether a run with any false positives is allowed to pass.
+	- **Reason:** This is a policy choice about whether noise is acceptable while the harness and corpus are still maturing.
+	- **Valid values:** `true` or `false`.
+	  - **`true`:** More permissive, useful during early experimentation if the corpus is still immature.
+	  - **`false`:** Stricter, better when false positives are considered a serious trust problem.
+
+## How `weights` And `passGuidance` Affect Each Other
+
+The simplest way to think about the interaction is:
+
+- `weights` decide the shape of the score
+- `passGuidance` decides whether that score is good enough
+
+### Examples:
+
+- If `mustCatchRecall` has a very high weight, then missing important findings will drag the weighted overall score down sharply.
+- Even if the weighted overall score stays high, a high `minimumMustCatchRecall` can still force the run to fail.
+- If `allowFalsePositives` is `false`, then even a strong weighted score may still fail when the run invents issues that should not have been flagged.
+
+### Why these knobs matter:
+
+- A higher `minimumOverallScore` makes the harness stricter overall
+- A higher `minimumMustCatchRecall` makes it harder for a run to pass while missing core issues
+- `allowFalsePositives: false` keeps the benchmark conservative while the corpus is still small and trust-sensitive
+
+In other words, `weights` shape the score distribution, while `passGuidance` sets the policy boundary for accepting or rejecting the run.
+
+These values are policy choices, not immutable truths. They should be adjusted only when the team has enough case coverage to justify changing the strictness.
+
+## Initial Corpus Strategy
+
+The starter corpus is intentionally small and covers the main current review and guidance surfaces:
+
+- Local code review
+- Committed code review
+- Docs review
+- Implementation guidance
+- Acceptance-testing guidance
+
+These starter cases are planning manifests first. They define the shape and expectations of the future corpus even before a full runner exists.
+
+The first non-synthetic adjudicated case should be treated as the reference pattern for future case authoring:
+
+- Sanitize the historical source
+- Remove PR identity from the final artifact
+- Preserve the real failure mode and expected review behavior
+- Attach a scored example result when practical
+
+## Case Lifecycle
+
+Recommended states:
+
+- `planned`: Case idea exists, but fixture or gold-set data is incomplete
+- `ready`: Fixture exists and expected outcomes are drafted
+- `adjudicated`: Expectations are reviewed and can be used for scoring
+- `retired`: No longer representative, but retained for history
+
+## Runner Expectations
+
+The future runner should:
+
+- prepare a clean fixture workspace
+- invoke the exact prompt or skill under test
+- capture the output and tool behavior
+- score the run against the adjudicated case expectations
+- emit a machine-readable result object that matches `review-result.schema.json`
+
+The current starter scripts do not execute prompts or skills yet. They solve the next smaller problem first:
+
+- Scaffold a result document from a case definition
+- Score a completed result document against a case and the weighted rubric
+- Present the case fixture, sample review output, and score summary together for easier inspection
+- Create a repeatable single-case run directory with a manifest and placeholder artifacts so a real run can be captured consistently
+- Hydrate a scaffolded run from adjudicated example artifacts so the full run layout can be inspected end to end
+- Clean generated run directories as routine housekeeping
+
+That means the repository now supports repeatable scoring once a human or later automation has produced a result file.
+
+## Non-Goals
+
+This foundation does not attempt to:
+
+- Force exact output snapshots
+- Replace human review of new benchmark cases
+- Act as a release blocker until the corpus is broad enough to be trusted
+
+## Recommended Rollout
+
+Start with the starter corpus as a reporting-only benchmark.
+
+After enough real cases are adjudicated, use the score trends to detect regressions before changes are merged. Only later should this become a CI gate.
+
+## Starter Workflow
+
+The initial benchmark workflow is:
+
+- Choose a case from `tools/regression/cases/`.
+- Scaffold a single run with `tools/regression/run-regression-case.ps1`.
+- Optionally hydrate the scaffold from adjudicated example artifacts with `tools/regression/hydrate-regression-run.ps1`.
+- Fill in or replace the generated review artifact from a real prompt or skill run.
+- Update the generated result file for the adjudicated outcome.
+- Score it with `tools/regression/score-regression-case.ps1`.
+- Review the weighted score and pass or fail guidance.
+
+## Single-Case Orchestrator
+
+The first-pass orchestrator intentionally keeps execution simple:
+
+- It accepts one case at a time
+- It resolves a case alias to a case manifest under `tools/regression/cases/`
+- It creates a timestamped run directory under `tools/regression/runs/`
+- It generates a run manifest plus placeholder review and result artifacts
+
+This keeps the single-case lifecycle stable before any batch or suite features are introduced.
+
+## Run Hydration
+
+The hydrator exists to make the run layout easier to understand.
+
+It does not execute prompts or skills. Instead, it copies the sample review and sample result artifacts for an adjudicated case into an already scaffolded run directory so that the full end-to-end artifact shape can be inspected quickly.
+
+## Run Cleanup
+
+Generated run directories are intentionally ignored in git.
+
+Use the cleanup script to remove:
+
+- A single run by ID
+- The latest run
+- All generated runs
+
+## Adjudicated Case Pattern
+
+The repository now includes two distinct examples:
+
+- A synthetic smoke case used to validate harness mechanics
+- A sanitized adjudicated real-world case used to show how a historical miss or review correction should be preserved without keeping live PR identity
+
+The repository now also includes a docs-review adjudicated case so the benchmark shows three distinct output styles:
+
+- Implementation guidance
+- Local code review
+- Docs review
+
+The repository also now includes a review-side adjudicated example with a sample Markdown review body so maintainers can see the intended human-readable output shape alongside the machine-readable scoring artifact.
+
+Use the real-world case as the authoring pattern when converting future historical incidents into benchmark fixtures.

--- a/docs/AI_REGRESSION_HARNESS.md
+++ b/docs/AI_REGRESSION_HARNESS.md
@@ -233,6 +233,14 @@ The starter corpus is intentionally small and covers the main current review and
 - Implementation guidance
 - Acceptance-testing guidance
 
+The direct skill surface currently in scope for this harness is narrower:
+
+- `docs-writer`
+- `resource-implementation`
+- `acceptance-testing`
+
+The repo-only `ai-toolkit-maintenance` skill is intentionally excluded from the regression benchmark surface because it exists to keep repository guidance aligned before commit rather than to benchmark the end-user AI workflow itself.
+
 These starter cases are planning manifests first. They define the shape and expectations of the future corpus even before a full runner exists.
 
 The first non-synthetic adjudicated case should be treated as the reference pattern for future case authoring:
@@ -255,18 +263,20 @@ Recommended states:
 
 The future runner should:
 
-- prepare a clean fixture workspace
-- invoke the exact prompt or skill under test
-- capture the output and tool behavior
-- score the run against the adjudicated case expectations
-- emit a machine-readable result object that matches `review-result.schema.json`
+- Prepare a clean fixture workspace
+- Invoke the exact prompt or skill under test
+- Capture the output and tool behavior
+- Score the run against the adjudicated case expectations
+- Emit a machine-readable result object that matches `review-result.schema.json`
 
 The current starter scripts do not execute prompts or skills yet. They solve the next smaller problem first:
 
 - Scaffold a result document from a case definition
+- Validate case and result artifacts against the benchmark schemas before scoring
 - Score a completed result document against a case and the weighted rubric
+- Score the adjudicated example corpus as a suite and report direct target-skill coverage gaps
 - Present the case fixture, sample review output, and score summary together for easier inspection
-- Create a repeatable single-case run directory with a manifest and placeholder artifacts so a real run can be captured consistently
+- Create a repeatable single-case run directory with snapshotted inputs, repository metadata, and placeholder artifacts so a real run can be captured consistently
 - Hydrate a scaffolded run from adjudicated example artifacts so the full run layout can be inspected end to end
 - Clean generated run directories as routine housekeeping
 
@@ -292,11 +302,55 @@ The initial benchmark workflow is:
 
 - Choose a case from `tools/regression/cases/`.
 - Scaffold a single run with `tools/regression/run-regression-case.ps1`.
+- Treat the generated `run-manifest.json`, `input/case.json`, and `input/score-weights.json` as the stable execution envelope for that run.
 - Optionally hydrate the scaffold from adjudicated example artifacts with `tools/regression/hydrate-regression-run.ps1`.
 - Fill in or replace the generated review artifact from a real prompt or skill run.
+- Fill in `capture/execution-metadata.json` with the exact executor and invocation details used to produce the run.
 - Update the generated result file for the adjudicated outcome.
 - Score it with `tools/regression/score-regression-case.ps1`.
 - Review the weighted score and pass or fail guidance.
+
+The current suite-level benchmark workflow is:
+
+- Run `tools/regression/validate-regression-artifacts.ps1` so schema or fixture-shape drift fails fast.
+- Run `tools/regression/run-regression-suite.ps1` to score every adjudicated example result in the corpus.
+- Use the target-skill coverage summary to see which direct skills are covered, planned-only, or still missing a direct case.
+- Add or adjudicate direct skill cases before treating that skill as benchmarked.
+
+The harness now exposes a normalized machine-readable output parameter for local and CI reporting:
+
+- `tools/regression/validate-regression-artifacts.ps1 -Output json`
+- `tools/regression/score-regression-case.ps1 -Output json`
+- `tools/regression/run-regression-suite.ps1 -Output json`
+
+The repository also now supports a report-only CI path for the harness corpus:
+
+- `.github/workflows/regression-harness-validation.yml` now shells through `tools/validate-ai-toolkit.ps1 -SkipUpstreamDrift`, which keeps the regression CI path aligned with the same maintainer validator used locally while still publishing regression outputs.
+- The workflow publishes text and JSON suite output plus a suite-history snapshot artifact so maintainers can inspect the current corpus health without turning the benchmark into a merge gate.
+
+The harness also now supports a lightweight history layer on top of stable suite output:
+
+- `tools/regression/write-regression-history-snapshot.ps1` persists timestamped suite snapshots under `tools/regression/results/history/`.
+- `tools/regression/summarize-regression-history.ps1` compares the latest snapshot against prior saved snapshots and reports trend deltas.
+- This history layer stays fixture-driven and repo-local; it does not depend on live prompt execution against arbitrary repository state.
+
+The contributor-facing authoring model is now moving toward a Terraform-style test abstraction layer:
+
+- `tools/regression/new-regression-test.ps1` scaffolds a contributor-facing HCL test template under `tools/regression/test/`.
+- Contributors author one HCL test spec instead of assembling the internal artifact graph by hand.
+- `tools/regression/build-regression-test.ps1 -SpecPath ...` materializes the internal harness artifacts from that HCL test spec.
+- `tools/regression/publish-regression-test.ps1` is the maintainer promotion step that turns a reviewed draft into the adjudicated examples corpus.
+
+For routine human use, the preferred entry point is now `tools/regression/run-regression-harness.ps1`.
+
+That top-level runner executes the stable harness flow in order:
+
+- Artifact validation
+- Suite scoring
+- History snapshot capture
+- History summary generation
+
+This keeps the day-to-day harness UX to one command while preserving the lower-level scripts for debugging, CI composition, and targeted troubleshooting.
 
 ## Single-Case Orchestrator
 
@@ -305,9 +359,15 @@ The first-pass orchestrator intentionally keeps execution simple:
 - It accepts one case at a time
 - It resolves a case alias to a case manifest under `tools/regression/cases/`
 - It creates a timestamped run directory under `tools/regression/runs/`
+- It snapshots the case and weights inputs used for the run
+- It records repository snapshot metadata and a capture file for the eventual invocation details
 - It generates a run manifest plus placeholder review and result artifacts
 
 This keeps the single-case lifecycle stable before any batch or suite features are introduced.
+
+The suite runner stays intentionally narrow in v1.
+
+It does not invoke Copilot or simulate live skill execution. It evaluates the adjudicated example corpus that already exists in the repository and reports coverage gaps so the next case-authoring work is obvious.
 
 ## Run Hydration
 
@@ -339,5 +399,7 @@ The repository now also includes a docs-review adjudicated case so the benchmark
 - Docs review
 
 The repository also now includes a review-side adjudicated example with a sample Markdown review body so maintainers can see the intended human-readable output shape alongside the machine-readable scoring artifact.
+
+The repository now also includes a committed-review adjudicated example so the corpus covers linter-scope reporting for explicit PR review context in addition to local-review and docs-review output styles.
 
 Use the real-world case as the authoring pattern when converting future historical incidents into benchmark fixtures.

--- a/docs/AI_REGRESSION_HARNESS.md
+++ b/docs/AI_REGRESSION_HARNESS.md
@@ -171,7 +171,7 @@ The `weights` section controls how the overall score is calculated.
 
 ## The `passGuidance` Section
 
-The `passGuidance` section does not change how the score is calculated. It changes how the harness interprets the score after calculation, this is effectivly the policy gate.
+The `passGuidance` section does not change how the score is calculated. It changes how the harness interprets the score after calculation, this is effectively the policy gate.
 
 ### What higher and lower values mean in `passGuidance`:
 

--- a/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
+++ b/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
@@ -4,10 +4,10 @@ This checklist is for maintainers of this repository.
 
 Use it when you want to answer questions like:
 
-- is the AI toolkit up to date?
-- did we wire a new contract family completely?
-- does bootstrap/install include the right runtime payload?
-- did we update the docs that explain the current rule model?
+- Is the AI toolkit up to date?
+- Did we wire a new contract family completely?
+- Does bootstrap/install include the right runtime payload?
+- Did we update the docs that explain the current rule model?
 
 This is a maintenance checklist for this repository only. It is not part of the runtime toolkit that gets installed into target repositories.
 
@@ -59,13 +59,13 @@ The current contract-driven domains are:
 
 For each changed or new `*-contract.instructions.md` file, confirm it still has:
 
-- frontmatter
+- Frontmatter
 - `## Consumers`
 - `## Canonical sources of truth (precedence)`
 - `Conflict resolution:`
 - `## Rule IDs`
 - `## Evidence hierarchy`
-- a contract EOF marker comment as the last non-empty line
+- A contract EOF marker comment as the last non-empty line
 
 If the contract uses provenance, only use supported labels:
 
@@ -77,30 +77,30 @@ If the contract uses provenance, only use supported labels:
 
 For every declared consumer in a contract:
 
-- the file exists
-- the file references the contract path
-- any consumer marked `Requires EOF Load: yes` explicitly mentions loading the contract to EOF
+- The file exists
+- The file references the contract path
+- Any consumer marked `Requires EOF Load: yes` explicitly mentions loading the contract to EOF
 
 Typical consumers include:
 
-- prompts in `.github/prompts/`
-- skills in `.github/skills/`
-- routing instructions in `.github/instructions/ai-skill-routing-*.instructions.md`
+- Prompts in `.github/prompts/`
+- Skills in `.github/skills/`
+- Routing instructions in `.github/instructions/ai-skill-routing-*.instructions.md`
 
 ### 3. Companion guidance points back to the contract
 
 If a contract declares companion guidance, each companion file should:
 
-- explicitly state that it is companion guidance
-- point back to the contract path
-- defer compliance authority to the contract instead of acting as a second authority source
+- Explicitly state that it is companion guidance
+- Point back to the contract path
+- Defer compliance authority to the contract instead of acting as a second authority source
 
 ### 4. Rule-reference documentation is still accurate
 
 Update `docs/CODE_REVIEW_RULES.md` when either of these happens:
 
-- a new contract family is added
-- a new rule area is introduced that is useful for end users to understand
+- A new contract family is added
+- A new rule area is introduced that is useful for end users to understand
 
 You do not need to update it for every new individual rule inside an already-documented area.
 
@@ -108,8 +108,8 @@ You do not need to update it for every new individual rule inside an already-doc
 
 When a new file is added, decide whether it is:
 
-- runtime toolkit payload
-- repo-maintenance-only tooling
+- Runtime toolkit payload
+- Repo-maintenance-only tooling
 
 Runtime toolkit payload belongs in `installer/file-manifest.config` if it must be copied into target repositories.
 
@@ -124,20 +124,61 @@ Typical runtime payload files:
 Typical maintenance-only files that should stay out of the installed payload:
 
 - `tools/config/upstream-contributor.json`
+- `tools/validate-ai-toolkit.ps1`
 - `tools/validate-contracts.ps1`
 - `tools/check-upstream-contributor-drift.ps1`
 - `.github/workflows/contracts-validation.yml`
 - `.github/skills/ai-toolkit-maintenance/SKILL.md`
-- repo-only maintenance checklists like this file
+- Repo-only maintenance checklists like this file
 
 ### 6. Changelog and release docs are aligned
 
 When the runtime toolkit changes in a user-visible way:
 
-- update `CHANGELOG.md`
-- if the change affects release or maintenance expectations, update `.github/workflows/RELEASING.md` when needed
+- Update `CHANGELOG.md`
+- If the change affects release or maintenance expectations, update `.github/workflows/RELEASING.md` when needed
 
 ### 7. Validation passes
+
+Preferred one-shot maintainer validation:
+
+```powershell
+pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1
+```
+
+That command runs the current repo-level maintainer validation flow in one pass:
+
+- Explicit changelog-decision validation for current branch changes
+- Contract validation
+- Markdown lint for `.github/`, `docs/`, and `CHANGELOG.md`
+- Regression harness validation and suite scoring
+- Upstream contributor drift detection
+
+If the current branch intentionally does not need a changelog entry, make that explicit instead of relying on path-based inference:
+
+```powershell
+pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -ChangelogNotRequired -ChangelogReason "Repo-only maintenance change with no release-note impact"
+```
+
+When you need the machine-readable summary:
+
+```powershell
+pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -OutputFormat Json
+```
+
+If you intentionally want the summary without failing on unresolved upstream drift:
+
+```powershell
+pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -AllowDrift
+```
+
+If you want CI-style behavior that still fails on changed tracked sources or rule issues but tolerates the currently known uncovered topic catalog gaps:
+
+```powershell
+pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -AllowCatalogIssues
+```
+
+The lower-level commands remain available for debugging and targeted re-runs.
 
 Run:
 
@@ -175,7 +216,7 @@ If the current file contents and workspace validators are clean but the VS Code 
 
 Practical recovery step:
 
-- reload the VS Code window so the YAML language service rebuilds diagnostics from the current on-disk files
+- Reload the VS Code window so the YAML language service rebuilds diagnostics from the current on-disk files
 
 ### 8. Bootstrap payload matches expectations
 
@@ -183,38 +224,38 @@ When the runtime payload changes, confirm bootstrap/install copies the expected 
 
 At a minimum, verify that:
 
-- new runtime contracts are copied
-- new or updated routing instructions are copied
-- updated skills are copied
-- maintenance-only scripts are not copied into target repositories
+- New runtime contracts are copied
+- New or updated routing instructions are copied
+- Updated skills are copied
+- Maintenance-only scripts are not copied into target repositories
 
 ### 9. Avoid known formatting and validation traps
 
 When maintaining AI-toolkit support docs and checklists in this repository:
 
-- prefer flat bullet lists over numbered lists when the exact sequence is not important
-- avoid adding ordered lists just for presentation symmetry
-- if a document is intended to be machine-read, copied into prompts, or reused in validation-sensitive contexts, favor simpler Markdown structures
+- Prefer flat bullet lists over numbered lists when the exact sequence is not important
+- Avoid adding ordered lists just for presentation symmetry
+- If a document is intended to be machine-read, copied into prompts, or reused in validation-sensitive contexts, favor simpler Markdown structures
 
 Standard authoring pattern for AI-toolkit files:
 
-- use titled subsections to express the major stages or categories
-- use flat or nested bullets under each title to express the concrete guidance
-- let heading order and bullet indentation convey sequence instead of explicit numbering
-- treat this as the default pattern for `.github/skills/`, `.github/prompts/`, and `.github/instructions/`
+- Use titled subsections to express the major stages or categories
+- Use flat or nested bullets under each title to express the concrete guidance
+- Let heading order and bullet indentation convey sequence instead of explicit numbering
+- Treat this as the default pattern for `.github/skills/`, `.github/prompts/`, and `.github/instructions/`
 
 This is a practical safeguard. The CI/CD pipeline validates Markdown with `DavidAnson/markdownlint-cli2-action@v18`, and we have previously hit `MD029` failures in AI-toolkit files.
 
 Known failure pattern:
 
-- multiple top-level ordered lists under the same section that each restart at `1.`
-- mixed ordered-list numbering styles that make markdownlint treat the numbering as inconsistent
+- Multiple top-level ordered lists under the same section that each restart at `1.`
+- Mixed ordered-list numbering styles that make markdownlint treat the numbering as inconsistent
 
 Practical rule:
 
-- if the content is just a set of guidance bullets, use unordered lists
-- if you truly need an ordered list, keep one consistent ordered-list sequence instead of creating multiple sibling ordered lists that each restart at `1.`
-- prefer titled subsections plus bullets for procedural guidance, letting heading order and bullet indentation convey sequence without explicit numbering
+- If the content is just a set of guidance bullets, use unordered lists
+- If you truly need an ordered list, keep one consistent ordered-list sequence instead of creating multiple sibling ordered lists that each restart at `1.`
+- Prefer titled subsections plus bullets for procedural guidance, letting heading order and bullet indentation convey sequence without explicit numbering
 
 Pay extra attention to files under:
 
@@ -234,8 +275,7 @@ npx -y markdownlint-cli2 ".github/**/*.md" "docs/**/*.md" --config .github/.mark
 
 When asked whether the AI toolkit is up to date, check these in order:
 
-- `pwsh -NoProfile -File ./tools/validate-contracts.ps1` passes.
-- `pwsh -NoProfile -File ./tools/check-upstream-contributor-drift.ps1` reports no unresolved upstream-doc drift for the tracked sources you rely on.
+- `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1` passes.
 - `installer/file-manifest.config` includes all required runtime payload files.
 - `docs/CODE_REVIEW_RULES.md` still matches the current contract families and rule areas.
 - `CHANGELOG.md` reflects the current release state.

--- a/docs/CODE_REVIEW_RULES.md
+++ b/docs/CODE_REVIEW_RULES.md
@@ -84,11 +84,11 @@ These IDs come from `.github/instructions/code-review-compliance-contract.instru
 
 This means the review checked user-visible text quality. It commonly applies to:
 
-- comments
+- Comments
 - README changes
-- prompt text
-- installer help text
-- end-user error messages
+- Prompt text
+- Installer help text
+- End-user error messages
 
 ### `REVIEW-SCOPE-004`
 
@@ -113,10 +113,10 @@ It is the rule that tells the auditor to load the scoped Go instructions and ski
 
 These rules explain how `azurerm-linter` should be handled. If you see a `REVIEW-LINT-*` citation, it usually means the review is explaining one of these:
 
-- whether the linter was applicable
-- how it was invoked
-- why the linter section is `Issues found`, `No issues`, `Not applicable`, or `Not run`
-- how linter findings were turned into review Issues
+- Whether the linter was applicable
+- How it was invoked
+- Why the linter section is `Issues found`, `No issues`, `Not applicable`, or `Not run`
+- How linter findings were turned into review Issues
 
 ## `DOCS-*` Rule Areas
 
@@ -180,10 +180,10 @@ If the review feels unclear, look up the exact rule in the contract file and rea
 
 This reference is most useful when:
 
-- a review says a specific rule was directly relevant
-- you want to understand why a prompt checked something that was not obvious from the diff alone
-- you want to challenge a finding and verify whether the cited contract rule really applies
-- you are updating the prompts or contracts and want the output to stay understandable to end users
+- A review says a specific rule was directly relevant
+- You want to understand why a prompt checked something that was not obvious from the diff alone
+- You want to challenge a finding and verify whether the cited contract rule really applies
+- You are updating the prompts or contracts and want the output to stay understandable to end users
 
 ## Short Version
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -223,7 +223,7 @@ If attestation verification fails:
 
 **Cause**:
 - GitHub CLI is not authenticated correctly to `github.com`, or
-- a stale `GH_TOKEN` / `GITHUB_TOKEN` environment variable is overriding your normal `gh` login
+- A stale `GH_TOKEN` / `GITHUB_TOKEN` environment variable is overriding your normal `gh` login
 
 **Fixes**:
 - Check your current GitHub CLI authentication state:
@@ -352,7 +352,7 @@ You have existing Copilot instructions. The installer creates backups automatica
 
 **To Review Backups**:
 - Windows: `%USERPROFILE%\.vscode\copilot\backups\`
-- macOS/Linux: `~/.vscode/copilot/backups/`
+- On macOS/Linux: `~/.vscode/copilot/backups/`
 
 ---
 

--- a/tools/config/upstream-contributor.json
+++ b/tools/config/upstream-contributor.json
@@ -19,6 +19,67 @@
       ]
     },
     {
+      "id": "building-the-provider",
+      "domain": "build-and-development",
+      "title": "Building the Provider",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/building-the-provider.md",
+      "baselineSha256": "57f7750ff5d93b3285a81895809e8bfae96968498c2b8c80c0d05009f9ec65dd",
+      "reviewNotes": [
+        "Current upstream entry point for canonical provider build guidance.",
+        "Review when upstream build prerequisites or the canonical build handoff move to a different document."
+      ]
+    },
+    {
+      "id": "debugging-the-provider",
+      "domain": "debugging",
+      "title": "Debugging the Provider",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/debugging-the-provider.md",
+      "baselineSha256": "defe5a8e1033e686e0adc1a927f7cc1a6931fc27a3407a1237385d87b4cf3533",
+      "reviewNotes": [
+        "Primary upstream source for logging, proxy, and debugger-based provider debugging guidance."
+      ]
+    },
+    {
+      "id": "frequently-asked-questions",
+      "domain": "contributor-faq",
+      "title": "Frequently Asked Questions",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/frequently-asked-questions.md",
+      "baselineSha256": "872030e9203527835ca3f05e762265eaf11fde45d70750d5f32197e9fb7cad5c",
+      "reviewNotes": [
+        "Review contributor-facing workflow expectations such as merge-conflict handling, release cadence, label meanings, and issue-routing norms."
+      ]
+    },
+    {
+      "id": "high-level-overview",
+      "domain": "codebase-overview",
+      "title": "High Level Overview",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/high-level-overview.md",
+      "baselineSha256": "6aae0eb200c3822eaaa99216f75a1a0859def7dbe7778fcdbb7924a2a1534b97",
+      "reviewNotes": [
+        "Primary upstream source for provider package layout, service package anatomy, and typed-versus-untyped implementation taxonomy."
+      ]
+    },
+    {
+      "id": "reference-glossary",
+      "domain": "terminology",
+      "title": "Glossary",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/reference-glossary.md",
+      "baselineSha256": "6aaef642055293e02a801f3dbb39c2847021b1bcf037cf9847475b2897b18077",
+      "reviewNotes": [
+        "Primary upstream source for provider terminology such as service packages, resource ID parser or validator types, and typed-versus-untyped concepts."
+      ]
+    },
+    {
+      "id": "running-the-tests",
+      "domain": "testing",
+      "title": "Running the Tests",
+      "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/running-the-tests.md",
+      "baselineSha256": "a99ecdb28904eb41dbfa4cfd847e64be3910d46bb2c5279f163b641c6a17cd6e",
+      "reviewNotes": [
+        "Primary upstream source for acceptance-test entry points, required ARM_* environment variables, and targeted test filtering."
+      ]
+    },
+    {
       "id": "guide-opening-a-pr",
       "domain": "pr-process",
       "title": "Opening a PR",
@@ -203,7 +264,7 @@
       "domain": "schema-design",
       "title": "Guide: Resource Identity",
       "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/guide-resource-identity.md",
-      "baselineSha256": "97f1df5310cc6612dc6b9c3e7fce23ccfa6961fadda313f6f05487b258e9dc2d",
+      "baselineSha256": "b322422a6f68661766c4ad867429fec20d686fdc5992fbfd7aaf67477e68f787",
       "reviewNotes": [
         "Primary upstream source for resource identity schema, SetResourceIdentityData usage, generated tests, and current generator limitations."
       ]

--- a/tools/regression/README.md
+++ b/tools/regression/README.md
@@ -14,12 +14,34 @@ The goal is to turn behavioral evaluation from subjective human agreement into r
   - Defines the structure of a benchmark case.
 - `schema/review-result.schema.json`
   - Defines the structure of a benchmark result.
+- `schema/run-manifest.schema.json`
+  - Defines the structure of the deterministic single-run execution envelope manifest.
+- `schema/history-snapshot.schema.json`
+  - Defines the structure of a persisted suite-history snapshot.
+- `validate-regression-artifacts.ps1`
+  - Validates case and result artifacts against the harness schemas and core fixture-consistency checks.
+- `new-regression-test.ps1`
+  - Writes the contributor-facing HCL test template under `tools/regression/test/`.
+- `build-regression-test.ps1`
+  - Builds the internal harness artifacts from a contributor-facing HCL test file.
+- `publish-regression-test.ps1`
+  - Maintainer-facing helper that promotes a scaffolded regression test example into the adjudicated examples corpus.
+- `test/TestSpecDefinition.ps1`
+  - Codifies the accepted contributor-facing test blocks, fields, and enum values in one place.
+- `write-regression-history-snapshot.ps1`
+  - Writes a timestamped suite-history snapshot using the stable suite JSON output and current repository metadata.
+- `summarize-regression-history.ps1`
+  - Summarizes score and pass-rate trends across saved suite-history snapshots.
+- `run-regression-harness.ps1`
+  - Orchestrates the human-friendly end-to-end flow: validation, suite scoring, history snapshotting, and history summarization.
 - `cases/`
   - Stores individual case manifests.
 - `new-regression-result-template.ps1`
   - Generates a starter result document from a case.
 - `score-regression-case.ps1`
   - Scores a result document against a case and the configured weights.
+- `run-regression-suite.ps1`
+  - Scores the adjudicated example corpus as a suite and reports direct target-skill coverage.
 - `run-regression-example.ps1`
   - Displays the fixture and sample output paths for a case and prints the score summary for the paired result.
 - `run-regression-case.ps1`
@@ -41,11 +63,11 @@ The goal is to turn behavioral evaluation from subjective human agreement into r
 
 The future runner should:
 
-- materialize or apply the fixture
-- invoke the target prompt or skill
-- capture the final output and relevant tool behavior
-- score the run against the case expectations
-- persist a result document matching `schema/review-result.schema.json`
+- Materialize or apply the fixture
+- Invoke the target prompt or skill
+- Capture the final output and relevant tool behavior
+- Score the run against the case expectations
+- Persist a result document matching `schema/review-result.schema.json`
 
 ## Current Status
 
@@ -55,21 +77,109 @@ The current case manifests define the benchmark shape and intended coverage so t
 
 The current scripts make the benchmark partially usable today:
 
-- they scaffold result files consistently
-- they compute weighted scores consistently
-- they provide a stable path from manual adjudication to repeatable scoring
-- they create repeatable single-case run directories for capturing real evaluation artifacts
-- they can populate a scaffolded run from adjudicated example artifacts for demonstration and inspection
-- they support basic cleanup of generated run directories
+- They scaffold result files consistently
+- They compute weighted scores consistently
+- They validate case and result artifacts against the benchmark schemas before scoring
+- They can score the adjudicated example corpus as a suite and report which target skills have direct case coverage
+- They provide a stable path from manual adjudication to repeatable scoring
+- They create repeatable single-case run directories with snapshotted case and weights inputs plus explicit capture metadata
+- They can populate a scaffolded run from adjudicated example artifacts for demonstration and inspection
+- They can persist suite-history snapshots for later comparison
+- They can summarize score and pass-rate trends across those saved snapshots
+- They can orchestrate the common human execution path through one top-level harness command
+- They support basic cleanup of generated run directories
 
 The repository now includes:
 
-- one synthetic adjudicated smoke case for harness mechanics
-- one sanitized adjudicated real-world case for actual review or guidance benchmarking
-- one adjudicated review-side example that pairs a scored result with a sample review Markdown output
-- one adjudicated docs-review example that pairs a scored result with a sample docs-review Markdown output
+- One synthetic adjudicated smoke case for harness mechanics
+- One sanitized adjudicated real-world case for actual review or guidance benchmarking
+- One adjudicated review-side example that pairs a scored result with a sample review Markdown output
+- One adjudicated docs-review example that pairs a scored result with a sample review Markdown output
+- One adjudicated committed-review example that pairs a scored result with a sample review Markdown output
+
+The current direct target-skill scope for the harness is:
+
+- `docs-writer`
+- `resource-implementation`
+- `acceptance-testing`
+
+The repo-only `ai-toolkit-maintenance` skill is intentionally excluded from this benchmark surface.
 
 ## Starter Commands
+
+Contributor-facing authoring entry point:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/new-regression-test.ps1 -Id my-new-case -Task resource-implementation
+```
+
+Preferred HCL contributor flow:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/new-regression-test.ps1 -Id my-new-case -Task resource-implementation
+pwsh -NoProfile -File ./tools/regression/build-regression-test.ps1 -SpecPath ./tools/regression/test/my-new-case.hcl
+```
+
+That flow lets contributors author one HCL test spec under `tools/regression/test/` while the harness tool generates the internal case, fixture, and draft result artifacts automatically.
+
+The HCL surface is intentionally shaped to feel closer to a Terraform acceptance test than a raw manifest:
+
+```hcl
+AccTest "example-case" "basic" {
+  title = "Example benchmark title"
+
+  test_case {
+    task        = "resource-implementation"
+    source_kind = "real-pr"
+    case_status = "planned"
+    notes       = "Optional scope notes."
+
+    changed_files = [
+      "internal/services/example/example_resource.go",
+    ]
+
+    config {
+      resource "azurerm_example_resource" "test" {
+        name = "example"
+      }
+    }
+  }
+
+  rules {
+    description           = "Plain-language scenario description."
+    notes                 = "Optional maintainer notes."
+    include_sample_output = false
+
+    must_catch {
+      description = "Prefer stronger validation when the accepted values are knowable."
+      severity    = "medium"
+      file        = "internal/services/example/example_resource.go"
+    }
+
+    must_not_flag {
+      description = "Do not invent unsupported schema constraints."
+    }
+  }
+}
+```
+
+The canonical shape treats `test_case { config { ... } }` as real nested HCL.
+
+Maintainer promotion entry point:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/publish-regression-test.ps1 -SpecPath ./tools/regression/test/my-new-case.hcl
+```
+
+That command promotes the reviewed draft artifacts into the adjudicated examples corpus and updates the case status.
+
+Recommended human entry point:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-harness.ps1
+```
+
+That command orchestrates the current stable harness flow in the correct order and writes the latest machine-readable and text outputs under `tools/regression/results/latest/`.
 
 Generate a result template:
 
@@ -81,6 +191,66 @@ Score a completed result:
 
 ```powershell
 pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./tools/regression/cases/harness-smoke-resource-implementation.json -ResultPath ./tools/regression/examples/harness-smoke-resource-implementation.result.json
+```
+
+Emit the score summary as JSON:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./tools/regression/cases/harness-smoke-resource-implementation.json -ResultPath ./tools/regression/examples/harness-smoke-resource-implementation.result.json -Output json
+```
+
+Validate the current case and example-result corpus against the harness schemas:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/validate-regression-artifacts.ps1
+```
+
+Emit the validation summary as JSON:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/validate-regression-artifacts.ps1 -Output json
+```
+
+Score the adjudicated example corpus and report target-skill coverage:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-suite.ps1
+```
+
+Emit the suite summary as JSON:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-suite.ps1 -Output json
+```
+
+Write a timestamped suite-history snapshot under `tools/regression/results/history/`:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/write-regression-history-snapshot.ps1
+```
+
+Write the suite-history snapshot to a specific path:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/write-regression-history-snapshot.ps1 -OutputPath ./tools/regression/results/history/latest.json
+```
+
+Summarize the saved regression-history snapshots:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/summarize-regression-history.ps1
+```
+
+Emit the history summary as JSON:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/summarize-regression-history.ps1 -Output json
+```
+
+Focus the suite output on the direct target skills only:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-suite.ps1 -Task docs-writer,resource-implementation,acceptance-testing -CaseStatus planned,ready,adjudicated
 ```
 
 Inspect an adjudicated example end to end:
@@ -98,9 +268,19 @@ pwsh -NoProfile -File ./tools/regression/run-regression-case.ps1 -Case review-do
 That command creates a new directory under `tools/regression/runs/` with:
 
 - `run-manifest.json`
+- `input/case.json`
+- `input/score-weights.json`
+- `capture/execution-metadata.json`
 - `output/review.md`
 - `output/result.json`
-- a materialized `fixture/` copy when the case defines a fixture path
+- A materialized `fixture/` copy when the case defines a fixture path
+
+The single-case scaffold now acts as a deterministic execution envelope:
+
+- It snapshots the case definition used for the run
+- It snapshots the scoring weights used for the run
+- It records the current repository branch, commit, and dirty-state metadata in the manifest and capture file
+- It keeps future scoring tied to the snapshotted inputs instead of whatever the live case or weight file may become later
 
 ## Score Configuration
 
@@ -108,10 +288,10 @@ The scoring and pass-threshold knobs live in `config/score-weights.json`.
 
 Use that file to tune:
 
-- how much each scoring dimension contributes to the weighted overall score
-- the minimum overall score required to pass
-- the minimum must-catch recall floor
-- whether any false positive is allowed in a passing run
+- How much each scoring dimension contributes to the weighted overall score
+- The minimum overall score required to pass
+- The minimum must-catch recall floor
+- Whether any false positive is allowed in a passing run
 
 The harness docs in `docs/AI_REGRESSION_HARNESS.md` explain the intent behind each knob. Change these values carefully, because they define benchmark policy rather than simple implementation detail.
 
@@ -126,3 +306,5 @@ Clean the latest generated run directory:
 ```powershell
 pwsh -NoProfile -File ./tools/regression/clean-regression-runs.ps1 -Latest
 ```
+
+The repository also includes a report-only CI workflow at `.github/workflows/regression-harness-validation.yml` that shells through `tools/validate-ai-toolkit.ps1 -SkipUpstreamDrift` and publishes the latest generated regression reports as workflow artifacts.

--- a/tools/regression/README.md
+++ b/tools/regression/README.md
@@ -1,0 +1,128 @@
+# Regression Harness Layout
+
+This directory contains the repo-only foundation for an objective regression harness for prompts, instructions, and skills.
+
+## Purpose
+
+The goal is to turn behavioral evaluation from subjective human agreement into repeatable scoring against adjudicated fixtures.
+
+## Layout
+
+- `config/score-weights.json`
+  - Defines the weighted score model.
+- `schema/review-case.schema.json`
+  - Defines the structure of a benchmark case.
+- `schema/review-result.schema.json`
+  - Defines the structure of a benchmark result.
+- `cases/`
+  - Stores individual case manifests.
+- `new-regression-result-template.ps1`
+  - Generates a starter result document from a case.
+- `score-regression-case.ps1`
+  - Scores a result document against a case and the configured weights.
+- `run-regression-example.ps1`
+  - Displays the fixture and sample output paths for a case and prints the score summary for the paired result.
+- `run-regression-case.ps1`
+  - Resolves a single case alias or case path, creates a timestamped run directory, materializes the fixture, generates a run manifest, and scaffolds output artifacts for a real evaluation run.
+- `hydrate-regression-run.ps1`
+  - Copies adjudicated example artifacts into a scaffolded run so the end-to-end run layout can be inspected without manual copying.
+- `clean-regression-runs.ps1`
+  - Deletes generated run directories for housekeeping.
+
+## Case Authoring Rules
+
+- Do not reference live PR numbers, authors, or branch names inside the final case artifact.
+- Represent the source as a sanitized fixture.
+- Focus on expected behavior, not exact wording.
+- Record must-catch outcomes and must-not-flag outcomes explicitly.
+- Keep cases narrow enough that the expected rule activation is deterministic.
+
+## Future Runner Responsibilities
+
+The future runner should:
+
+- materialize or apply the fixture
+- invoke the target prompt or skill
+- capture the final output and relevant tool behavior
+- score the run against the case expectations
+- persist a result document matching `schema/review-result.schema.json`
+
+## Current Status
+
+This directory is a starter foundation, not a complete automated harness yet.
+
+The current case manifests define the benchmark shape and intended coverage so that a runner can be added incrementally instead of inventing the model later.
+
+The current scripts make the benchmark partially usable today:
+
+- they scaffold result files consistently
+- they compute weighted scores consistently
+- they provide a stable path from manual adjudication to repeatable scoring
+- they create repeatable single-case run directories for capturing real evaluation artifacts
+- they can populate a scaffolded run from adjudicated example artifacts for demonstration and inspection
+- they support basic cleanup of generated run directories
+
+The repository now includes:
+
+- one synthetic adjudicated smoke case for harness mechanics
+- one sanitized adjudicated real-world case for actual review or guidance benchmarking
+- one adjudicated review-side example that pairs a scored result with a sample review Markdown output
+- one adjudicated docs-review example that pairs a scored result with a sample docs-review Markdown output
+
+## Starter Commands
+
+Generate a result template:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/new-regression-result-template.ps1 -CasePath ./tools/regression/cases/harness-smoke-resource-implementation.json -OutputPath ./tools/regression/results/harness-smoke-resource-implementation.result.json
+```
+
+Score a completed result:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./tools/regression/cases/harness-smoke-resource-implementation.json -ResultPath ./tools/regression/examples/harness-smoke-resource-implementation.result.json
+```
+
+Inspect an adjudicated example end to end:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -Case review-local-go-customizediff-validation
+```
+
+Scaffold a real single-case run from a case alias:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/run-regression-case.ps1 -Case review-docs-arguments-ordering
+```
+
+That command creates a new directory under `tools/regression/runs/` with:
+
+- `run-manifest.json`
+- `output/review.md`
+- `output/result.json`
+- a materialized `fixture/` copy when the case defines a fixture path
+
+## Score Configuration
+
+The scoring and pass-threshold knobs live in `config/score-weights.json`.
+
+Use that file to tune:
+
+- how much each scoring dimension contributes to the weighted overall score
+- the minimum overall score required to pass
+- the minimum must-catch recall floor
+- whether any false positive is allowed in a passing run
+
+The harness docs in `docs/AI_REGRESSION_HARNESS.md` explain the intent behind each knob. Change these values carefully, because they define benchmark policy rather than simple implementation detail.
+
+Hydrate the latest scaffolded run from adjudicated examples:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/hydrate-regression-run.ps1 -Latest
+```
+
+Clean the latest generated run directory:
+
+```powershell
+pwsh -NoProfile -File ./tools/regression/clean-regression-runs.ps1 -Latest
+```

--- a/tools/regression/build-regression-test.ps1
+++ b/tools/regression/build-regression-test.ps1
@@ -1,0 +1,971 @@
+param(
+    [string] $SpecPath,
+
+    [string] $Id,
+
+    [string] $Title,
+
+    [ValidateSet("code-review-local-changes", "code-review-committed-changes", "code-review-docs", "docs-writer", "resource-implementation", "acceptance-testing")]
+    [string] $Task,
+
+    [string] $Description,
+
+    [string[]] $ChangedFiles,
+
+    [ValidateSet("real-pr", "local-diff", "synthetic")]
+    [string] $SourceKind = "real-pr",
+
+    [ValidateSet("planned", "ready", "adjudicated", "retired")]
+    [string] $CaseStatus = "planned",
+
+    [string] $ScopeNotes,
+
+    [string] $CaseNotes,
+
+    [string[]] $MustCatchDescription,
+
+    [string[]] $MustNotFlagDescription,
+
+    [switch] $IncludeSampleOutput,
+
+    [switch] $Force,
+
+    [string] $CasesDirectory = (Join-Path $PSScriptRoot "cases"),
+
+    [string] $FixturesDirectory = (Join-Path $PSScriptRoot "fixtures"),
+
+    [string] $ResultsDirectory = (Join-Path $PSScriptRoot "results")
+)
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "test/TestSpecDefinition.ps1")
+
+function Get-HclDecodedString {
+    param([string] $Value)
+
+    $decoded = $Value -replace '\\"', '"'
+    $decoded = $decoded -replace '\\\\', '\\'
+    return $decoded
+}
+
+function Get-HclStringArrayValues {
+    param([string] $Content)
+
+    $values = @()
+    $matches = [regex]::Matches($Content, '"((?:[^"\\]|\\.)*)"')
+    foreach ($match in $matches) {
+        $values += Get-HclDecodedString -Value $match.Groups[1].Value
+    }
+
+    return $values
+}
+
+function Get-HclAssignment {
+    param([string] $Line)
+
+    if ($Line -match '^([a-z_]+)\s*=\s*"((?:[^"\\]|\\.)*)"\s*$') {
+        return [pscustomobject]@{ key = $Matches[1]; kind = 'string'; value = (Get-HclDecodedString -Value $Matches[2]) }
+    }
+
+    if ($Line -match '^([a-z_]+)\s*=\s*(true|false)\s*$') {
+        return [pscustomobject]@{ key = $Matches[1]; kind = 'bool'; value = ($Matches[2] -eq 'true') }
+    }
+
+    if ($Line -match '^([a-z_]+)\s*=\s*\[\s*\]\s*$') {
+        return [pscustomobject]@{ key = $Matches[1]; kind = 'array'; value = @() }
+    }
+
+    if ($Line -match '^([a-z_]+)\s*=\s*\[(.*)\]\s*$') {
+        return [pscustomobject]@{ key = $Matches[1]; kind = 'array'; value = @(Get-HclStringArrayValues -Content $Matches[2]) }
+    }
+
+    if ($Line -match '^([a-z_]+)\s*=\s*\[$') {
+        return [pscustomobject]@{ key = $Matches[1]; kind = 'array-start'; value = $null }
+    }
+
+    throw "unsupported HCL assignment: $Line"
+}
+
+function Get-HclBraceDelta {
+    param([string] $Line)
+
+    $sanitized = [regex]::Replace($Line, '"(?:[^"\\]|\\.)*"|''(?:[^''\\]|\\.)*''', '')
+    $openCount = ([regex]::Matches($sanitized, '\{')).Count
+    $closeCount = ([regex]::Matches($sanitized, '\}')).Count
+    return ($openCount - $closeCount)
+}
+
+function Get-ConfigBlockBody {
+    param(
+        [string[]] $Lines,
+        [int] $StartLineIndex
+    )
+
+    $bodyLines = @()
+    $braceDepth = 1
+    $lineIndex = $StartLineIndex + 1
+
+    while ($lineIndex -lt $Lines.Count) {
+        $rawLine = $Lines[$lineIndex]
+        $updatedDepth = $braceDepth + (Get-HclBraceDelta -Line $rawLine)
+
+        if ($updatedDepth -lt 0) {
+            throw "invalid brace structure inside config block"
+        }
+
+        if ($updatedDepth -eq 0 -and $rawLine.Trim() -eq '}') {
+            $braceDepth = $updatedDepth
+            break
+        }
+
+        $bodyLines += $rawLine.TrimEnd()
+        $braceDepth = $updatedDepth
+        $lineIndex++
+    }
+
+    if ($braceDepth -ne 0) {
+        throw "unterminated config block in regression test spec"
+    }
+
+    return [pscustomobject]@{
+        body = (($bodyLines -join "`n").Trim())
+        endLineIndex = $lineIndex
+    }
+}
+
+function Set-RegressionTestValue {
+    param(
+        $Spec,
+        [string] $ContextName,
+        $ContextData,
+        $Assignment
+    )
+
+    $definition = Get-RegressionTestDefinition
+
+    switch ($ContextName) {
+        'root' {
+            switch ($Assignment.key) {
+                'title' { $Spec.title = [string]$Assignment.value; break }
+                default { throw "unsupported root property '$($Assignment.key)' in regression test spec" }
+            }
+            break
+        }
+        'test_case' {
+            switch ($Assignment.key) {
+                'task' {
+                    Assert-RegressionTestAllowedValue -Definition $definition -EnumName 'task' -Value ([string]$Assignment.value) -Context 'test_case.task'
+                    $Spec.task = [string]$Assignment.value
+                    break
+                }
+                'source_kind' {
+                    Assert-RegressionTestAllowedValue -Definition $definition -EnumName 'sourceKind' -Value ([string]$Assignment.value) -Context 'test_case.source_kind'
+                    $Spec.sourceKind = [string]$Assignment.value
+                    break
+                }
+                'case_status' {
+                    Assert-RegressionTestAllowedValue -Definition $definition -EnumName 'caseStatus' -Value ([string]$Assignment.value) -Context 'test_case.case_status'
+                    $Spec.caseStatus = [string]$Assignment.value
+                    break
+                }
+                'changed_files' { $Spec.changedFiles = @($Assignment.value); break }
+                'notes' { $Spec.scopeNotes = [string]$Assignment.value; break }
+                default { throw "unsupported property '$($Assignment.key)' inside test_case block" }
+            }
+            break
+        }
+        'config' {
+            switch ($Assignment.key) {
+                'body' { $Spec.config = [string]$Assignment.value; break }
+                default { throw "unsupported property '$($Assignment.key)' inside config block" }
+            }
+            break
+        }
+        'rules' {
+            switch ($Assignment.key) {
+                'description' { $Spec.description = [string]$Assignment.value; break }
+                'notes' { $Spec.caseNotes = [string]$Assignment.value; break }
+                'include_sample_output' { $Spec.includeSampleOutput = [bool]$Assignment.value; break }
+                default { throw "unsupported property '$($Assignment.key)' inside rules block" }
+            }
+            break
+        }
+        'must_catch' {
+            switch ($Assignment.key) {
+                'description' { $ContextData.description = [string]$Assignment.value; break }
+                'severity' {
+                    Assert-RegressionTestAllowedValue -Definition $definition -EnumName 'severity' -Value ([string]$Assignment.value) -Context 'must_catch.severity'
+                    $ContextData.severity = [string]$Assignment.value
+                    break
+                }
+                'file' { $ContextData.file = [string]$Assignment.value; break }
+                default { throw "unsupported property '$($Assignment.key)' inside must_catch block" }
+            }
+            break
+        }
+        'must_not_flag' {
+            switch ($Assignment.key) {
+                'description' { $ContextData.description = [string]$Assignment.value; break }
+                default { throw "unsupported property '$($Assignment.key)' inside must_not_flag block" }
+            }
+            break
+        }
+        default {
+            throw "unsupported regression test context '$ContextName'"
+        }
+    }
+}
+
+function Get-RegressionTestSpec {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    $spec = [ordered]@{
+        id = $null
+        title = $null
+        runName = $null
+        task = $null
+        description = $null
+        config = $null
+        sourceKind = 'real-pr'
+        caseStatus = 'planned'
+        scopeNotes = $null
+        caseNotes = $null
+        changedFiles = @()
+        includeSampleOutput = $false
+        mustCatch = @()
+        mustNotFlag = @()
+    }
+
+    $lines = Get-Content -LiteralPath $Path
+    $seenRoot = $false
+    $blockStack = New-Object System.Collections.ArrayList
+    $currentArray = $null
+    $currentArrayValues = @()
+    $lineIndex = 0
+
+    while ($lineIndex -lt $lines.Count) {
+        $rawLine = $lines[$lineIndex]
+        $line = $rawLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^(#|//)') {
+            $lineIndex++
+            continue
+        }
+
+        if ($null -ne $currentArray) {
+            if ($line -eq ']') {
+                $assignment = [pscustomobject]@{ key = $currentArray.key; kind = 'array'; value = @($currentArrayValues) }
+                Set-RegressionTestValue -Spec $spec -ContextName $currentArray.contextName -ContextData $currentArray.contextData -Assignment $assignment
+                $currentArray = $null
+                $currentArrayValues = @()
+                $lineIndex++
+                continue
+            }
+
+            $currentArrayValues += @(Get-HclStringArrayValues -Content $line)
+            $lineIndex++
+            continue
+        }
+
+        if (-not $seenRoot) {
+            if ($line -match '^(AccTest)\s+"([a-zA-Z0-9-]+)"\s+"([a-zA-Z0-9_-]+)"\s*\{$') {
+                $spec.id = Convert-ToKebabCase -Value $Matches[2]
+                $spec.runName = $Matches[3]
+                $seenRoot = $true
+                [void]$blockStack.Add([pscustomobject]@{ name = 'test'; label = $spec.id; data = $null })
+                $lineIndex++
+                continue
+            }
+
+            throw "expected regression test root block, got: $line"
+        }
+
+        if ($line -eq '}') {
+            if ($blockStack.Count -eq 0) {
+                throw "unexpected closing brace in regression test spec"
+            }
+
+            $currentBlock = $blockStack[$blockStack.Count - 1]
+            $blockStack.RemoveAt($blockStack.Count - 1)
+
+            switch ($currentBlock.name) {
+                'must_catch' {
+                    if ([string]::IsNullOrWhiteSpace($currentBlock.data.description)) {
+                        throw "must_catch block requires description"
+                    }
+                    if ([string]::IsNullOrWhiteSpace($currentBlock.data.severity)) {
+                        $currentBlock.data.severity = 'medium'
+                    }
+                    $spec.mustCatch += [pscustomobject]$currentBlock.data
+                }
+                'must_not_flag' {
+                    if ([string]::IsNullOrWhiteSpace($currentBlock.data.description)) {
+                        throw "must_not_flag block requires description"
+                    }
+                    $spec.mustNotFlag += [pscustomobject]$currentBlock.data
+                }
+            }
+
+            $lineIndex++
+            continue
+        }
+
+        if ($line -match '^config\s*\{$') {
+            $currentContext = if ($blockStack.Count -gt 0) { $blockStack[$blockStack.Count - 1] } else { $null }
+            if ($null -eq $currentContext -or $currentContext.name -ne 'test_case') {
+                throw "config block must be nested inside test_case"
+            }
+            $configBlock = Get-ConfigBlockBody -Lines $lines -StartLineIndex $lineIndex
+            $spec.config = $configBlock.body
+            $lineIndex = $configBlock.endLineIndex + 1
+            continue
+        }
+
+        if ($line -match '^rules\s*\{$') {
+            $currentContext = if ($blockStack.Count -gt 0) { $blockStack[$blockStack.Count - 1] } else { $null }
+            if ($null -eq $currentContext -or $currentContext.name -ne 'test') {
+                throw "rules block must be a direct child of AccTest"
+            }
+            [void]$blockStack.Add([pscustomobject]@{ name = 'rules'; label = $spec.runName; data = $null })
+            $lineIndex++
+            continue
+        }
+
+        if ($line -match '^(test_case|must_catch|must_not_flag)\s*\{$') {
+            $blockName = $Matches[1]
+            $blockData = if ($blockName -in @('must_catch', 'must_not_flag')) { [ordered]@{} } else { $null }
+            [void]$blockStack.Add([pscustomobject]@{ name = $blockName; label = $null; data = $blockData })
+            $lineIndex++
+            continue
+        }
+
+        $currentContext = if ($blockStack.Count -gt 0) { $blockStack[$blockStack.Count - 1] } else { $null }
+        $contextName = if ($null -eq $currentContext -or $currentContext.name -eq 'test') { 'root' } else { $currentContext.name }
+        $contextData = if ($null -eq $currentContext) { $null } else { $currentContext.data }
+
+        $assignment = Get-HclAssignment -Line $line
+        if ($assignment.kind -eq 'array-start') {
+            if ($assignment.key -ne 'changed_files') {
+                throw "only changed_files supports array syntax in regression test specs"
+            }
+            $currentArray = [pscustomobject]@{
+                key = $assignment.key
+                contextName = $contextName
+                contextData = $contextData
+            }
+            $currentArrayValues = @()
+            $lineIndex++
+            continue
+        }
+
+        Set-RegressionTestValue -Spec $spec -ContextName $contextName -ContextData $contextData -Assignment $assignment
+        $lineIndex++
+    }
+
+    if (-not $seenRoot) {
+        throw "regression test spec did not define a test block"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($spec.id) -or [string]::IsNullOrWhiteSpace($spec.title) -or [string]::IsNullOrWhiteSpace($spec.task) -or [string]::IsNullOrWhiteSpace($spec.description)) {
+        throw "regression test spec is missing one of the required properties: id, title, task, description"
+    }
+
+    if ($spec.changedFiles.Count -eq 0) {
+        throw "regression test spec must define at least one changed_files entry"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($spec.task)) {
+        throw "regression test spec must define task inside test_case"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($spec.config)) {
+        throw "regression test spec must define config inside test_case"
+    }
+
+    return [pscustomobject]$spec
+}
+
+function Expand-ListParameter {
+    param([string[]] $Value)
+
+    $expanded = @()
+    foreach ($entry in $Value) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        $expanded += @($entry -split "," | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    return @($expanded | Select-Object -Unique)
+}
+
+function Initialize-Directory {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Convert-ToKebabCase {
+    param([string] $Value)
+
+    $normalized = $Value.ToLowerInvariant()
+    $normalized = [Regex]::Replace($normalized, "[^a-z0-9]+", "-")
+    return $normalized.Trim('-')
+}
+
+function Read-RequiredValue {
+    param(
+        [string] $Prompt,
+        [string] $CurrentValue
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue.Trim()
+    }
+
+    while ($true) {
+        $value = Read-Host $Prompt
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            return $value.Trim()
+        }
+    }
+}
+
+function Read-TaskValue {
+    param([string] $CurrentValue)
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue
+    }
+
+    $allowedTasks = @(
+        "code-review-local-changes",
+        "code-review-committed-changes",
+        "code-review-docs",
+        "docs-writer",
+        "resource-implementation",
+        "acceptance-testing"
+    )
+
+    Write-Output "Select task:"
+    for ($i = 0; $i -lt $allowedTasks.Count; $i++) {
+        Write-Output "  $($i + 1). $($allowedTasks[$i])"
+    }
+
+    while ($true) {
+        $selection = Read-Host "Task number"
+        $index = 0
+        if ([int]::TryParse($selection, [ref]$index) -and $index -ge 1 -and $index -le $allowedTasks.Count) {
+            return $allowedTasks[$index - 1]
+        }
+    }
+}
+
+function Read-ListValue {
+    param(
+        [string] $Prompt,
+        [string[]] $CurrentValue
+    )
+
+    $expanded = Expand-ListParameter -Value $CurrentValue
+    if ($expanded.Count -gt 0) {
+        return $expanded
+    }
+
+    while ($true) {
+        $value = Read-Host $Prompt
+        $expanded = Expand-ListParameter -Value @($value)
+        if ($expanded.Count -gt 0) {
+            return $expanded
+        }
+    }
+}
+
+function Read-OptionalValue {
+    param(
+        [string] $Prompt,
+        [string] $CurrentValue
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue.Trim()
+    }
+
+    return (Read-Host $Prompt).Trim()
+}
+
+function Read-YesNoValue {
+    param(
+        [string] $Prompt,
+        [bool] $DefaultValue
+    )
+
+    $defaultLabel = if ($DefaultValue) { "Y/n" } else { "y/N" }
+    $response = Read-Host "$Prompt [$defaultLabel]"
+    if ([string]::IsNullOrWhiteSpace($response)) {
+        return $DefaultValue
+    }
+
+    return @("y", "yes") -contains $response.Trim().ToLowerInvariant()
+}
+
+function Read-MustCatchItems {
+    param([string[]] $Descriptions)
+
+    $providedDescriptions = Expand-ListParameter -Value $Descriptions
+    if ($providedDescriptions.Count -gt 0) {
+        $items = @()
+        foreach ($description in $providedDescriptions) {
+            $key = Convert-ToKebabCase -Value $description
+            if ([string]::IsNullOrWhiteSpace($key)) {
+                $key = "must-catch-$($items.Count + 1)"
+            }
+
+            $items += [pscustomobject]@{
+                key = $key
+                severity = "medium"
+                description = $description
+            }
+        }
+
+        return $items
+    }
+
+    Write-Output "Enter must-catch findings. Leave the description empty when finished."
+
+    $items = @()
+    while ($true) {
+        $description = Read-Host "Must-catch description"
+        if ([string]::IsNullOrWhiteSpace($description)) {
+            break
+        }
+
+        $severity = Read-Host "Severity [medium]"
+        if ([string]::IsNullOrWhiteSpace($severity)) {
+            $severity = "medium"
+        }
+
+        $file = Read-Host "Related file (optional)"
+        $key = Convert-ToKebabCase -Value $description
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            $key = "must-catch-$($items.Count + 1)"
+        }
+
+        $item = [ordered]@{
+            key = $key
+            severity = $severity
+            description = $description.Trim()
+        }
+        if (-not [string]::IsNullOrWhiteSpace($file)) {
+            $item.file = $file.Trim()
+        }
+
+        $items += [pscustomobject]$item
+    }
+
+    if ($items.Count -eq 0) {
+        $items += [pscustomobject]@{
+            key = "replace-me-must-catch"
+            severity = "medium"
+            description = "Replace this placeholder with the primary behavior or issue the harness should catch."
+        }
+    }
+
+    return $items
+}
+
+function Read-MustNotFlagItems {
+    param([string[]] $Descriptions)
+
+    $providedDescriptions = Expand-ListParameter -Value $Descriptions
+    if ($providedDescriptions.Count -gt 0) {
+        $items = @()
+        foreach ($description in $providedDescriptions) {
+            $key = Convert-ToKebabCase -Value $description
+            if ([string]::IsNullOrWhiteSpace($key)) {
+                $key = "must-not-flag-$($items.Count + 1)"
+            }
+
+            $items += [pscustomobject]@{
+                key = $key
+                description = $description
+            }
+        }
+
+        return $items
+    }
+
+    Write-Output "Enter must-not-flag findings. Leave the description empty when finished."
+
+    $items = @()
+    while ($true) {
+        $description = Read-Host "Must-not-flag description"
+        if ([string]::IsNullOrWhiteSpace($description)) {
+            break
+        }
+
+        $key = Convert-ToKebabCase -Value $description
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            $key = "must-not-flag-$($items.Count + 1)"
+        }
+
+        $items += [pscustomobject]@{
+            key = $key
+            description = $description.Trim()
+        }
+    }
+
+    return $items
+}
+
+function Get-TaskProfile {
+    param([string] $Task)
+
+    $profiles = @{
+        "code-review-local-changes" = [ordered]@{
+            expectedRules = @("REVIEW-SCOPE-005", "REVIEW-LINT-*")
+            expectedTools = [ordered]@{ azurermLinter = "run" }
+            outputChecks = [ordered]@{ mustHaveSections = @("CHANGE SUMMARY", "FILES CHANGED", "AZURERM LINTER", "ISSUES") }
+            includeSampleOutput = $true
+        }
+        "code-review-committed-changes" = [ordered]@{
+            expectedRules = @("REVIEW-LINT-*", "REVIEW-SCOPE-005")
+            expectedTools = [ordered]@{ azurermLinter = "run" }
+            outputChecks = [ordered]@{ mustHaveSections = @("CHANGE SUMMARY", "FILES CHANGED", "AZURERM LINTER", "MUST FIX") }
+            includeSampleOutput = $true
+        }
+        "code-review-docs" = [ordered]@{
+            expectedRules = @("DOCS-ARG-*", "DOCS-NOTE-*", "DOCS-WORD-*")
+            expectedTools = [ordered]@{}
+            outputChecks = [ordered]@{ mustHaveSections = @("CHANGE SUMMARY", "DETAILED TECHNICAL REVIEW", "ISSUES") }
+            includeSampleOutput = $true
+        }
+        "docs-writer" = [ordered]@{
+            expectedRules = @("DOCS-ARG-*", "DOCS-WORD-*", "DOCS-EVID-001")
+            expectedTools = [ordered]@{}
+            outputChecks = [ordered]@{ mustIncludeMarkers = @("Preflight complete: yes", "Skill used: docs-writer") }
+            includeSampleOutput = $false
+        }
+        "resource-implementation" = [ordered]@{
+            expectedRules = @("IMPL-SCHEMA-*", "IMPL-ERR-*")
+            expectedTools = [ordered]@{}
+            outputChecks = [ordered]@{ mustIncludeMarkers = @("Skill used: resource-implementation") }
+            includeSampleOutput = $false
+        }
+        "acceptance-testing" = [ordered]@{
+            expectedRules = @("TEST-PATTERN-*", "TEST-WF-*", "TEST-RUN-*")
+            expectedTools = [ordered]@{}
+            outputChecks = [ordered]@{ mustIncludeMarkers = @("Skill used: acceptance-testing") }
+            includeSampleOutput = $false
+        }
+    }
+
+    return $profiles[$Task]
+}
+
+function Assert-CanWriteFile {
+    param(
+        [string] $Path,
+        [switch] $Force
+    )
+
+    if ((Test-Path -LiteralPath $Path) -and -not $Force) {
+        throw "target already exists: $Path"
+    }
+}
+
+function Get-NormalizedMustCatchItems {
+    param($Items)
+
+    $normalized = @()
+    foreach ($item in @($Items)) {
+        $key = if ($item.PSObject.Properties.Name -contains 'key' -and -not [string]::IsNullOrWhiteSpace($item.key)) {
+            $item.key
+        }
+        else {
+            Convert-ToKebabCase -Value $item.description
+        }
+
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            $key = "must-catch-$($normalized.Count + 1)"
+        }
+
+        $entry = [ordered]@{
+            key = $key
+            severity = if ($item.PSObject.Properties.Name -contains 'severity' -and -not [string]::IsNullOrWhiteSpace($item.severity)) { $item.severity } else { 'medium' }
+            description = $item.description
+        }
+        if ($item.PSObject.Properties.Name -contains 'file' -and -not [string]::IsNullOrWhiteSpace($item.file)) {
+            $entry.file = $item.file
+        }
+
+        $normalized += [pscustomobject]$entry
+    }
+
+    return $normalized
+}
+
+function Get-NormalizedMustNotFlagItems {
+    param($Items)
+
+    $normalized = @()
+    foreach ($item in @($Items)) {
+        $key = if ($item.PSObject.Properties.Name -contains 'key' -and -not [string]::IsNullOrWhiteSpace($item.key)) {
+            $item.key
+        }
+        else {
+            Convert-ToKebabCase -Value $item.description
+        }
+
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            $key = "must-not-flag-$($normalized.Count + 1)"
+        }
+
+        $normalized += [pscustomobject]@{
+            key = $key
+            description = $item.description
+        }
+    }
+
+    return $normalized
+}
+
+$parsedSpec = $null
+if (-not [string]::IsNullOrWhiteSpace($SpecPath)) {
+    $parsedSpec = Get-RegressionTestSpec -Path $SpecPath
+
+    if ([string]::IsNullOrWhiteSpace($Id)) { $Id = $parsedSpec.id }
+    if ([string]::IsNullOrWhiteSpace($Title)) { $Title = $parsedSpec.title }
+    if ([string]::IsNullOrWhiteSpace($Task)) { $Task = $parsedSpec.task }
+    if ([string]::IsNullOrWhiteSpace($Description)) { $Description = $parsedSpec.description }
+    if ($ChangedFiles.Count -eq 0) { $ChangedFiles = @($parsedSpec.changedFiles) }
+    if ([string]::IsNullOrWhiteSpace($ScopeNotes)) { $ScopeNotes = $parsedSpec.scopeNotes }
+    if ([string]::IsNullOrWhiteSpace($CaseNotes)) { $CaseNotes = $parsedSpec.caseNotes }
+    if (-not $PSBoundParameters.ContainsKey('SourceKind')) { $SourceKind = $parsedSpec.sourceKind }
+    if (-not $PSBoundParameters.ContainsKey('CaseStatus')) { $CaseStatus = $parsedSpec.caseStatus }
+    if (-not $PSBoundParameters.ContainsKey('IncludeSampleOutput') -and $parsedSpec.includeSampleOutput) { $IncludeSampleOutput = $true }
+}
+
+$Task = if ($null -ne $parsedSpec) {
+    if ([string]::IsNullOrWhiteSpace($Task)) { throw "spec did not provide task" }
+    $Task
+}
+else {
+    Read-TaskValue -CurrentValue $Task
+}
+$profile = Get-TaskProfile -Task $Task
+
+$Id = if ($null -ne $parsedSpec) {
+    if ([string]::IsNullOrWhiteSpace($Id)) { throw "spec did not provide id" }
+    $Id
+}
+else {
+    Read-RequiredValue -Prompt "Case ID (kebab-case)" -CurrentValue $Id
+}
+$Id = Convert-ToKebabCase -Value $Id
+$Title = if ($null -ne $parsedSpec) {
+    if ([string]::IsNullOrWhiteSpace($Title)) { throw "spec did not provide title" }
+    $Title.Trim()
+}
+else {
+    Read-RequiredValue -Prompt "Short title" -CurrentValue $Title
+}
+$Description = if ($null -ne $parsedSpec) {
+    if ([string]::IsNullOrWhiteSpace($Description)) { throw "spec did not provide description" }
+    $Description.Trim()
+}
+else {
+    Read-RequiredValue -Prompt "Plain-language scenario description" -CurrentValue $Description
+}
+$ChangedFiles = if ($null -ne $parsedSpec) {
+    $expandedChangedFiles = Expand-ListParameter -Value $ChangedFiles
+    if ($expandedChangedFiles.Count -eq 0) { throw "spec did not provide changed_files" }
+    $expandedChangedFiles
+}
+else {
+    Read-ListValue -Prompt "Changed file paths (comma-separated)" -CurrentValue $ChangedFiles
+}
+$ScopeNotes = if ($null -ne $parsedSpec) { $ScopeNotes } else { Read-OptionalValue -Prompt "Scope notes (optional)" -CurrentValue $ScopeNotes }
+$CaseNotes = if ($null -ne $parsedSpec) { $CaseNotes } else { Read-OptionalValue -Prompt "Maintainer notes (optional)" -CurrentValue $CaseNotes }
+
+$includeSampleOutputValue = if ($PSBoundParameters.ContainsKey("IncludeSampleOutput")) {
+    [bool]$IncludeSampleOutput
+}
+elseif ($null -ne $parsedSpec) {
+    [bool]$parsedSpec.includeSampleOutput
+}
+else {
+    Read-YesNoValue -Prompt "Create a sample human-readable output placeholder" -DefaultValue ([bool]$profile.includeSampleOutput)
+}
+
+$mustCatch = if ($null -ne $parsedSpec) {
+    if ($parsedSpec.mustCatch.Count -gt 0) {
+        Get-NormalizedMustCatchItems -Items $parsedSpec.mustCatch
+    }
+    else {
+        @([pscustomobject]@{
+            key = 'replace-me-must-catch'
+            severity = 'medium'
+            description = 'Replace this placeholder with the primary behavior or issue the harness should catch.'
+        })
+    }
+}
+else {
+    Read-MustCatchItems -Descriptions $MustCatchDescription
+}
+$mustNotFlag = if ($null -ne $parsedSpec) { Get-NormalizedMustNotFlagItems -Items $parsedSpec.mustNotFlag } else { Read-MustNotFlagItems -Descriptions $MustNotFlagDescription }
+
+Initialize-Directory -Path $CasesDirectory
+Initialize-Directory -Path $FixturesDirectory
+Initialize-Directory -Path $ResultsDirectory
+
+$casePath = Join-Path $CasesDirectory ($Id + ".json")
+$fixtureDirectory = Join-Path $FixturesDirectory $Id
+$fixturePath = Join-Path $fixtureDirectory "README.md"
+$resultPath = Join-Path $ResultsDirectory ($Id + ".result.json")
+$reviewPath = Join-Path $ResultsDirectory ($Id + ".review.md")
+
+Assert-CanWriteFile -Path $casePath -Force:$Force
+Assert-CanWriteFile -Path $fixturePath -Force:$Force
+Assert-CanWriteFile -Path $resultPath -Force:$Force
+if ($includeSampleOutputValue) {
+    Assert-CanWriteFile -Path $reviewPath -Force:$Force
+}
+
+Initialize-Directory -Path $fixtureDirectory
+
+$fixtureRunName = (Get-RegressionTestDefinition).defaultRunName
+if ($null -ne $parsedSpec -and -not [string]::IsNullOrWhiteSpace($parsedSpec.runName)) {
+    $fixtureRunName = $parsedSpec.runName
+}
+
+$fixtureContributorNote = $ScopeNotes
+if ([string]::IsNullOrWhiteSpace($fixtureContributorNote)) {
+    $fixtureContributorNote = "Replace this note with any context that helps maintainers understand the scenario."
+}
+
+$fixtureConfigLines = @()
+if ($null -ne $parsedSpec -and -not [string]::IsNullOrWhiteSpace($parsedSpec.config)) {
+    $fixtureConfigLines = @(
+        "",
+        "## Test Configuration",
+        "",
+        '```hcl',
+        $parsedSpec.config,
+        '```'
+    )
+}
+
+$fixtureLines = @(
+    "# Sanitized Fixture: $Title",
+    "",
+    "This fixture was scaffolded from the contributor-facing regression test command.",
+    "",
+    "## Named Run",
+    "",
+    ('`run "{0}"`' -f $fixtureRunName),
+    "",
+    "## Scenario",
+    "",
+    $Description,
+    "",
+    "## Modeled Changed Files",
+    ""
+)
+
+foreach ($changedFile in $ChangedFiles) {
+    $fixtureLines += ('- `{0}`' -f $changedFile)
+}
+
+$fixtureLines += $fixtureConfigLines
+
+$fixtureLines += @(
+    "",
+    "## Contributor Notes",
+    "",
+    $fixtureContributorNote,
+    "",
+    "## Expected Must-Catch Outcomes",
+    ""
+)
+
+foreach ($item in $mustCatch) {
+    $fixtureLines += ('- `{0}`' -f $item.key)
+}
+
+$fixtureLines += @(
+    "",
+    "## Expected Must-Not-Flag Outcomes",
+    ""
+)
+
+if ($mustNotFlag.Count -eq 0) {
+    $fixtureLines += "- None recorded yet"
+}
+else {
+    foreach ($item in $mustNotFlag) {
+        $fixtureLines += ('- `{0}`' -f $item.key)
+    }
+}
+
+$fixtureLines | Set-Content -LiteralPath $fixturePath
+
+$case = [ordered]@{
+    id = $Id
+    title = $Title
+    task = $Task
+    caseStatus = $CaseStatus
+    sourceKind = $SourceKind
+    sanitized = $true
+    description = $Description
+    fixture = [ordered]@{
+        mode = "files"
+        path = "tools/regression/fixtures/$Id/README.md"
+    }
+    scope = [ordered]@{
+        changedFiles = @($ChangedFiles)
+        notes = $ScopeNotes
+    }
+    expectedRules = @($profile.expectedRules)
+    mustCatch = @($mustCatch)
+    mustNotFlag = @($mustNotFlag)
+    expectedTools = $profile.expectedTools
+    outputChecks = $profile.outputChecks
+    notes = if ([string]::IsNullOrWhiteSpace($CaseNotes)) { "Scaffolded from the contributor-facing regression test command." } else { $CaseNotes }
+}
+
+$case | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $casePath
+
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "new-regression-result-template.ps1") -CasePath $casePath -OutputPath $resultPath | Out-Null
+
+if ($includeSampleOutputValue) {
+    $reviewLines = @(
+        "# Sample Output Placeholder: $Title",
+        "",
+        "Case ID: $Id",
+        "Task: $Task",
+        "",
+        "Replace this file with a captured human-readable sample output before promotion."
+    )
+    $reviewLines | Set-Content -LiteralPath $reviewPath
+}
+
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") -CasePath $casePath -ResultPath $resultPath | Out-Null
+
+Write-Output "Regression test scaffold created"
+Write-Output "  Case File        : $casePath"
+Write-Output "  Fixture File     : $fixturePath"
+Write-Output "  Result Draft     : $resultPath"
+if ($includeSampleOutputValue) {
+    Write-Output "  Output Draft     : $reviewPath"
+}
+Write-Output ""
+Write-Output "Next maintainer step:"
+Write-Output "  Review the scaffold, refine the draft files, and promote them with publish-regression-test.ps1 when ready."

--- a/tools/regression/cases/README.md
+++ b/tools/regression/cases/README.md
@@ -6,18 +6,20 @@ Each case file in this directory represents one adjudicated or planned benchmark
 
 Each case should define:
 
-- the task under test
-- the expected rule families
-- the must-catch findings or behaviors
-- the must-not-flag findings or behaviors
-- the expected tool behavior
-- the required output structure
+- The task under test
+- The expected rule families
+- The must-catch findings or behaviors
+- The must-not-flag findings or behaviors
+- The expected tool behavior
+- The required output structure
 
 ## Sanitization Rule
 
 Final case artifacts should not depend on live PR links or contributor identity.
 
 Use neutral case IDs and scenario summaries instead.
+
+Modeled changed-file paths may still use real repository locations when that is necessary to preserve realistic routing or rule activation. Keep the actual fixture content under `tools/regression/fixtures/` rather than creating benchmark-only files in the live repo surface.
 
 ## Status Progression
 
@@ -34,15 +36,15 @@ Whenever a real prompt or skill run misses an important issue, raises a recurrin
 
 When promoting a case to `adjudicated`:
 
-- attach or reference a sanitized fixture
-- ensure the final artifact does not contain a live PR link or contributor identity
-- capture at least one expected good-result example if practical
-- add a sample human-readable output artifact when the case is prompt-review-oriented and output structure matters to the benchmark
+- Attach or reference a sanitized fixture
+- Ensure the final artifact does not contain a live PR link or contributor identity
+- Capture at least one expected good-result example if practical
+- Add a sample human-readable output artifact when the case is prompt-review-oriented and output structure matters to the benchmark
 
 ## Example Pairing Rule
 
 For adjudicated review-style cases, prefer keeping three artifacts together:
 
-- the case definition
-- the sample review Markdown output
-- the sample scored result JSON
+- The case definition
+- The sample review Markdown output
+- The sample scored result JSON

--- a/tools/regression/cases/README.md
+++ b/tools/regression/cases/README.md
@@ -1,0 +1,48 @@
+# Case Authoring Guide
+
+Each case file in this directory represents one adjudicated or planned benchmark scenario.
+
+## Required Traits
+
+Each case should define:
+
+- the task under test
+- the expected rule families
+- the must-catch findings or behaviors
+- the must-not-flag findings or behaviors
+- the expected tool behavior
+- the required output structure
+
+## Sanitization Rule
+
+Final case artifacts should not depend on live PR links or contributor identity.
+
+Use neutral case IDs and scenario summaries instead.
+
+## Status Progression
+
+- `planned`
+- `ready`
+- `adjudicated`
+- `retired`
+
+## Corpus Growth Rule
+
+Whenever a real prompt or skill run misses an important issue, raises a recurring false positive, or shows a workflow regression, convert that incident into a new case here.
+
+## Adjudication Rule
+
+When promoting a case to `adjudicated`:
+
+- attach or reference a sanitized fixture
+- ensure the final artifact does not contain a live PR link or contributor identity
+- capture at least one expected good-result example if practical
+- add a sample human-readable output artifact when the case is prompt-review-oriented and output structure matters to the benchmark
+
+## Example Pairing Rule
+
+For adjudicated review-style cases, prefer keeping three artifacts together:
+
+- the case definition
+- the sample review Markdown output
+- the sample scored result JSON

--- a/tools/regression/cases/harness-smoke-resource-implementation.json
+++ b/tools/regression/cases/harness-smoke-resource-implementation.json
@@ -1,0 +1,48 @@
+{
+  "id": "harness-smoke-resource-implementation",
+  "title": "Synthetic smoke case for scoring resource-implementation guidance",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A synthetic adjudicated case used to verify that the regression harness can score a resource-implementation result deterministically.",
+  "fixture": {
+    "mode": "none"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go"
+    ],
+    "notes": "Smoke-test case only. Not a substitute for a real sanitized PR-derived fixture."
+  },
+  "expectedRules": [
+    "IMPL-SCHEMA-003",
+    "IMPL-SCHEMA-004",
+    "IMPL-ERR-002"
+  ],
+  "mustCatch": [
+    {
+      "key": "prefer-stronger-validation",
+      "severity": "medium",
+      "description": "The guidance should prefer stronger validation when the accepted values or formats are knowable."
+    },
+    {
+      "key": "avoid-redundant-parser-wrapper",
+      "severity": "medium",
+      "description": "The guidance should return comprehensive parser errors directly rather than wrapping them redundantly."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "blind-sdk-enum-usage",
+      "description": "The guidance should not require SDK enum helpers when the accepted subset is known to be narrower."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustIncludeMarkers": [
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this case as a runner smoke test while real PR-derived fixtures are being authored."
+}

--- a/tools/regression/cases/review-committed-pr-scope-linter.json
+++ b/tools/regression/cases/review-committed-pr-scope-linter.json
@@ -1,0 +1,46 @@
+{
+  "id": "review-committed-pr-scope-linter",
+  "title": "Committed review handles PR-scoped azurerm-linter execution correctly",
+  "task": "code-review-committed-changes",
+  "caseStatus": "planned",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A committed review should run azurerm-linter with deterministic PR scope when explicit PR context exists and report the result with the required section structure.",
+  "fixture": {
+    "mode": "none"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go"
+    ],
+    "notes": "Attach explicit PR context when implementing the runner case."
+  },
+  "expectedRules": [
+    "REVIEW-LINT-*",
+    "REVIEW-SCOPE-005"
+  ],
+  "mustCatch": [
+    {
+      "key": "linter-scope-reporting",
+      "severity": "medium",
+      "description": "The review should correctly report linter status, run scope, and findings from the executed committed-review scope."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "invented-pr-number",
+      "description": "The review must not invent a pull request number from branch metadata or diff text."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "AZURERM LINTER",
+      "MUST FIX"
+    ]
+  }
+}

--- a/tools/regression/cases/review-committed-pr-scope-linter.json
+++ b/tools/regression/cases/review-committed-pr-scope-linter.json
@@ -2,18 +2,19 @@
   "id": "review-committed-pr-scope-linter",
   "title": "Committed review handles PR-scoped azurerm-linter execution correctly",
   "task": "code-review-committed-changes",
-  "caseStatus": "planned",
+  "caseStatus": "adjudicated",
   "sourceKind": "synthetic",
   "sanitized": true,
   "description": "A committed review should run azurerm-linter with deterministic PR scope when explicit PR context exists and report the result with the required section structure.",
   "fixture": {
-    "mode": "none"
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-committed-pr-scope-linter/README.md"
   },
   "scope": {
     "changedFiles": [
       "internal/services/example/example_resource.go"
     ],
-    "notes": "Attach explicit PR context when implementing the runner case."
+    "notes": "Sanitized fixture models an explicit committed-review PR context without retaining live PR identity."
   },
   "expectedRules": [
     "REVIEW-LINT-*",
@@ -42,5 +43,6 @@
       "AZURERM LINTER",
       "MUST FIX"
     ]
-  }
+  },
+  "notes": "Pair this case with the sample review Markdown output and scored result to benchmark committed-review linter-scope reporting."
 }

--- a/tools/regression/cases/review-docs-arguments-ordering.json
+++ b/tools/regression/cases/review-docs-arguments-ordering.json
@@ -1,0 +1,48 @@
+{
+  "id": "review-docs-arguments-ordering",
+  "title": "Docs review enforces arguments, attributes, and notes structure from the docs contract",
+  "task": "code-review-docs",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized docs-review scenario where a page drifts on argument wording and note structure, and the correct review should apply docs-contract rules without inventing unsupported schema claims.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-docs-arguments-ordering/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/r/example_gateway.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a real docs review scenario without retaining live PR identity."
+  },
+  "expectedRules": [
+    "DOCS-ARG-*",
+    "DOCS-ATTR-*",
+    "DOCS-NOTE-*",
+    "DOCS-WORD-*"
+  ],
+  "mustCatch": [
+    {
+      "key": "docs-ordering-or-wording-regression",
+      "severity": "high",
+      "file": "website/docs/r/example_gateway.html.markdown",
+      "description": "The review should catch contract-backed docs structure or wording regressions."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "guessed-schema-claim",
+      "description": "The review must not invent schema or enum claims that are not supported by the available code evidence."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "DETAILED TECHNICAL REVIEW",
+      "ISSUES"
+    ]
+  },
+  "notes": "Pair this case with the sample docs-review markdown output to benchmark both review content and score artifact shape."
+}

--- a/tools/regression/cases/review-local-go-customizediff-validation.json
+++ b/tools/regression/cases/review-local-go-customizediff-validation.json
@@ -1,0 +1,52 @@
+{
+  "id": "review-local-go-customizediff-validation",
+  "title": "Local code review catches Go validation and test-coverage regressions",
+  "task": "code-review-local-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized local-review scenario where a Go implementation change introduces validation behavior but does not add matching acceptance-test coverage.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-local-go-customizediff-validation/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/network/example_gateway_resource.go",
+      "internal/services/network/example_gateway_resource_test.go"
+    ],
+    "notes": "Sanitized fixture models a real local review scenario without retaining live PR identity."
+  },
+  "expectedRules": [
+    "REVIEW-SCOPE-005",
+    "IMPL-SCHEMA-*",
+    "IMPL-TEST-*",
+    "TEST-PATTERN-*"
+  ],
+  "mustCatch": [
+    {
+      "key": "missing-validation-coverage",
+      "severity": "high",
+      "file": "internal/services/network/example_gateway_resource_test.go",
+      "description": "Validation or CustomizeDiff changes should not ship without appropriate test coverage."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "stringisnotempty-alone-without-context",
+      "description": "Do not escalate generic StringIsNotEmpty usage unless stronger validation is clearly required by the fixture evidence."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "AZURERM LINTER",
+      "ISSUES"
+    ]
+  },
+  "notes": "Pair this case with the example review markdown output to benchmark both scoring and output-shape expectations."
+}

--- a/tools/regression/cases/skill-acceptance-testing-importstep.json
+++ b/tools/regression/cases/skill-acceptance-testing-importstep.json
@@ -2,21 +2,23 @@
   "id": "skill-acceptance-testing-importstep",
   "title": "Acceptance-testing guidance applies requiresImport and ImportStep expectations consistently",
   "task": "acceptance-testing",
-  "caseStatus": "planned",
+  "caseStatus": "adjudicated",
   "sourceKind": "real-pr",
   "sanitized": true,
-  "description": "An acceptance-test guidance request should use the testing contract, preserve requiresImport expectations, and avoid replacing existence checks with weaker substitutes.",
+  "description": "A sanitized historical acceptance-test guidance scenario where the correct output should restore requiresImport coverage, keep ExistsInAzure as the primary basic assertion, and avoid redundant ImportStep assertions.",
   "fixture": {
-    "mode": "none"
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-acceptance-testing-importstep/README.md"
   },
   "scope": {
     "changedFiles": [
       "internal/services/example/example_resource_test.go"
     ],
-    "notes": "Future fixture should include a resource acctest that changed lifecycle coverage."
+    "notes": "Sanitized fixture models a real acceptance-test guidance incident without retaining live PR identity."
   },
   "expectedRules": [
     "TEST-PATTERN-004",
+    "TEST-PATTERN-*",
     "TEST-WF-*",
     "TEST-RUN-*"
   ],
@@ -25,6 +27,11 @@
       "key": "requiresimport-regression",
       "severity": "high",
       "description": "The guidance should preserve default requiresImport expectations when they apply."
+    },
+    {
+      "key": "weakened-basic-existence-check",
+      "severity": "medium",
+      "description": "The guidance should restore ExistsInAzure as the primary basic existence check instead of using a weaker substitute."
     }
   ],
   "mustNotFlag": [
@@ -38,5 +45,6 @@
     "mustIncludeMarkers": [
       "Skill used: acceptance-testing"
     ]
-  }
+  },
+  "notes": "Use this as the first direct acceptance-testing skill benchmark for lifecycle-coverage guidance."
 }

--- a/tools/regression/cases/skill-acceptance-testing-importstep.json
+++ b/tools/regression/cases/skill-acceptance-testing-importstep.json
@@ -1,0 +1,42 @@
+{
+  "id": "skill-acceptance-testing-importstep",
+  "title": "Acceptance-testing guidance applies requiresImport and ImportStep expectations consistently",
+  "task": "acceptance-testing",
+  "caseStatus": "planned",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "An acceptance-test guidance request should use the testing contract, preserve requiresImport expectations, and avoid replacing existence checks with weaker substitutes.",
+  "fixture": {
+    "mode": "none"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource_test.go"
+    ],
+    "notes": "Future fixture should include a resource acctest that changed lifecycle coverage."
+  },
+  "expectedRules": [
+    "TEST-PATTERN-004",
+    "TEST-WF-*",
+    "TEST-RUN-*"
+  ],
+  "mustCatch": [
+    {
+      "key": "requiresimport-regression",
+      "severity": "high",
+      "description": "The guidance should preserve default requiresImport expectations when they apply."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "redundant-importstep-assertions",
+      "description": "The guidance should not require redundant assertions already covered by ImportStep unless a case-specific exception exists."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustIncludeMarkers": [
+      "Skill used: acceptance-testing"
+    ]
+  }
+}

--- a/tools/regression/cases/skill-docs-writer-argument-note-shape.json
+++ b/tools/regression/cases/skill-docs-writer-argument-note-shape.json
@@ -1,0 +1,57 @@
+{
+  "id": "skill-docs-writer-argument-note-shape",
+  "title": "Docs-writer guidance fixes canonical argument wording and note placement",
+  "task": "docs-writer",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized direct docs-writer scenario where an existing resource page drifts on canonical enum wording and default placement, and the correct output should edit the page in place without inventing unsupported schema claims.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-docs-writer-argument-note-shape/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/r/example_gateway.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a real docs-writer request against an existing docs page without retaining live PR identity. The modeled changed path stays under `website/docs/` for realistic skill routing, while the fixture content lives under `tools/regression/fixtures/`."
+  },
+  "expectedRules": [
+    "DOCS-ARG-*",
+    "DOCS-NOTE-*",
+    "DOCS-WORD-*",
+    "DOCS-EVID-001"
+  ],
+  "mustCatch": [
+    {
+      "key": "canonical-enum-phrasing",
+      "severity": "high",
+      "file": "website/docs/r/example_gateway.html.markdown",
+      "description": "The docs-writer response should restore canonical `Possible values are` phrasing for the argument bullet."
+    },
+    {
+      "key": "inline-default-placement",
+      "severity": "medium",
+      "file": "website/docs/r/example_gateway.html.markdown",
+      "description": "The docs-writer response should keep the default value inline in the argument bullet rather than moving it into a detached note."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "guessed-schema-claim",
+      "description": "The response must not invent schema, enum, or import-ID claims that are not supported by implementation evidence."
+    },
+    {
+      "key": "scaffold-existing-page",
+      "description": "The response must not treat scaffolding as the default remediation for an existing docs page."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustIncludeMarkers": [
+      "Preflight complete: yes",
+      "Skill used: docs-writer"
+    ]
+  },
+  "notes": "Use this as the direct docs-writer skill benchmark for existing-page remediation without scaffold drift."
+}

--- a/tools/regression/cases/skill-resource-implementation-validation.json
+++ b/tools/regression/cases/skill-resource-implementation-validation.json
@@ -1,0 +1,63 @@
+{
+  "id": "skill-resource-implementation-validation",
+  "title": "Resource implementation guidance applies contract-backed schema and error rules",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized historical implementation-guidance scenario where the correct output should prefer stronger evidence-backed validation, avoid blind SDK-enum expansion, and return comprehensive parser errors directly.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-validation/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/cdn/example_frontdoor_resource.go",
+      "internal/services/cdn/parse.go"
+    ],
+    "notes": "Sanitized fixture models a real implementation-review incident without retaining live PR identity."
+  },
+  "expectedRules": [
+    "IMPL-SCHEMA-003",
+    "IMPL-SCHEMA-004",
+    "IMPL-ERR-001",
+    "IMPL-ERR-002"
+  ],
+  "mustCatch": [
+    {
+      "key": "fallback-validator-overuse",
+      "severity": "medium",
+      "file": "internal/services/cdn/example_frontdoor_resource.go",
+      "description": "The guidance should prefer stronger validation when the real constraints are knowable."
+    },
+    {
+      "key": "redundant-parser-wrapper",
+      "severity": "medium",
+      "file": "internal/services/cdn/parse.go",
+      "description": "The guidance should avoid wrapping comprehensive parser errors with redundant context."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "blind-sdk-enum-usage",
+      "description": "The guidance must not require SDK PossibleValues helpers when the accepted subset is demonstrably narrower."
+    },
+    {
+      "key": "parser-error-needs-more-context",
+      "description": "The guidance must not insist on adding flattening or field-name context when the parser error already gives the user the meaningful failure details."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this as the first adjudicated real-world case pattern for future sanitized implementation-guidance fixtures."
+}

--- a/tools/regression/clean-regression-runs.ps1
+++ b/tools/regression/clean-regression-runs.ps1
@@ -1,0 +1,62 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string] $RunId,
+
+    [switch] $Latest,
+
+    [switch] $All,
+
+    [string] $RunsDirectory = (Join-Path $PSScriptRoot "runs")
+)
+
+$ErrorActionPreference = "Stop"
+
+$selectedModeCount = 0
+if ($Latest) {
+    $selectedModeCount++
+}
+if ($All) {
+    $selectedModeCount++
+}
+if (-not [string]::IsNullOrWhiteSpace($RunId)) {
+    $selectedModeCount++
+}
+
+if ($selectedModeCount -ne 1) {
+    throw "specify exactly one of -RunId, -Latest, or -All"
+}
+
+if (-not (Test-Path -LiteralPath $RunsDirectory)) {
+    Write-Output "No regression runs directory found: $RunsDirectory"
+    return
+}
+
+$targets = @()
+
+if ($All) {
+    $targets = @(Get-ChildItem -LiteralPath $RunsDirectory -Directory)
+}
+elseif ($Latest) {
+    $latestRun = Get-ChildItem -LiteralPath $RunsDirectory -Directory | Sort-Object Name -Descending | Select-Object -First 1
+    if ($latestRun) {
+        $targets = @($latestRun)
+    }
+}
+else {
+    $explicitTarget = Get-ChildItem -LiteralPath $RunsDirectory -Directory | Where-Object { $_.Name -eq $RunId }
+    if ($explicitTarget) {
+        $targets = @($explicitTarget)
+    }
+}
+
+if ($targets.Count -eq 0) {
+    Write-Output "No matching regression run directories found."
+    return
+}
+
+foreach ($target in $targets) {
+    if ($PSCmdlet.ShouldProcess($target.FullName, "Remove regression run directory")) {
+        Remove-Item -LiteralPath $target.FullName -Recurse -Force
+        Write-Output "Removed: $($target.FullName)"
+    }
+}

--- a/tools/regression/config/score-weights.json
+++ b/tools/regression/config/score-weights.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "weights": {
+    "mustCatchRecall": 40,
+    "falsePositiveControl": 25,
+    "severityCorrectness": 15,
+    "scopeAndToolCorrectness": 10,
+    "outputCompliance": 5,
+    "determinism": 5
+  },
+  "passGuidance": {
+    "minimumOverallScore": 85,
+    "minimumMustCatchRecall": 90,
+    "allowFalsePositives": false
+  }
+}

--- a/tools/regression/examples/harness-smoke-resource-implementation.result.json
+++ b/tools/regression/examples/harness-smoke-resource-implementation.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "harness-smoke-resource-implementation",
+  "runId": "sample-run-001",
+  "timestampUtc": "2026-04-26T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "prefer-stronger-validation",
+      "avoid-redundant-parser-wrapper"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Synthetic perfect-score example used to smoke test harness scoring."
+}

--- a/tools/regression/examples/review-committed-pr-scope-linter.result.json
+++ b/tools/regression/examples/review-committed-pr-scope-linter.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-committed-pr-scope-linter",
+  "runId": "sample-committed-review-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "code-review-committed-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "linter-scope-reporting"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the committed-review PR-scoped linter regression case."
+}

--- a/tools/regression/examples/review-committed-pr-scope-linter.review.md
+++ b/tools/regression/examples/review-committed-pr-scope-linter.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: committed-review linter scope reporting
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 0 deleted, 1 modified)
+- **Line Changes**: 6 insertions, 1 deletion
+- **Branch**: fixture/committed-review-example
+- **Type**: committed pull request review
+- **Scope**: reviews a provider Go change with explicit PR context and a PR-scoped linter run
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `internal/services/example/example_resource.go`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The modeled PR contains a bounded provider Go change. The benchmarked requirement is that the review report the committed-review linter scope accurately when explicit PR context exists.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: committed-review path applied for explicit PR context
+- **Scope Rules**: `REVIEW-SCOPE-005` and `REVIEW-LINT-*` were directly relevant because the review runs against a pull request diff rather than local unstaged changes
+- **Docs Contract**: not applicable
+- **Notes**: the review stays within the provided PR context and does not infer missing metadata from branch naming
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: PR-scoped diff for the committed review context
+- **Issue Count**: 0
+- **Summary**: linter completed successfully for the modeled pull request changes with no findings
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review reports the linter execution path in a way that is specific to the committed-review scope instead of falling back to generic wording.
+
+### 🟡 **OBSERVATIONS**
+- The review correctly avoids inventing a pull request number from unrelated branch or diff metadata.
+
+### 🔴 **ISSUES**
+- The review body should explicitly state that the linter ran against the PR-scoped diff so maintainers can distinguish it from local-diff or full-repo execution.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Keep the `AZURERM LINTER` section explicit about the PR-scoped committed-review execution path and its zero-finding result.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve explicit PR-context reporting in future committed-review fixtures so benchmark coverage does not drift toward local-review wording.
+
+## 🏆 **OVERALL ASSESSMENT**
+The committed-review flow is acceptable when it reports the PR-scoped linter execution path clearly and avoids fabricating metadata.

--- a/tools/regression/examples/review-docs-arguments-ordering.result.json
+++ b/tools/regression/examples/review-docs-arguments-ordering.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "review-docs-arguments-ordering",
+  "runId": "sample-docs-review-001",
+  "timestampUtc": "2026-04-26T00:00:00Z",
+  "task": "code-review-docs",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "docs-ordering-or-wording-regression"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the docs-review regression case."
+}

--- a/tools/regression/examples/review-docs-arguments-ordering.review.md
+++ b/tools/regression/examples/review-docs-arguments-ordering.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: docs argument wording and note-shape regression
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 1 modified, 0 deleted)
+- **Scale**: 4 insertions, 2 deletions
+- **Branch**: fixture/docs-review-example vs origin/main
+- **Scope**: updates resource documentation but drifts on canonical argument wording and note placement
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `website/docs/r/example_gateway.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The docs update changes a field description and default wording, but it moves default information into a note block and uses non-canonical enum phrasing.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: docs compliance contract applied
+- **Repo Guidance**: documentation guidance loaded
+- **Scope Rules**: docs-only review path applied
+- **Docs Contract**: `DOCS-ARG-*`, `DOCS-NOTE-*`, and `DOCS-WORD-*` were directly relevant
+- **Notes**: the review stays within the available docs and schema evidence and does not invent unsupported schema claims
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: 0
+- **Summary**: docs-only scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The page stays focused on the changed argument rather than introducing unrelated docs churn.
+
+### 🟡 **OBSERVATIONS**
+- The review correctly avoids turning missing implementation evidence into a guessed schema claim.
+
+### 🔴 **ISSUES**
+- The argument wording should use the canonical `Possible values are` phrasing instead of `Valid values are`.
+- The default value belongs inline in the argument bullet for this scenario rather than as a detached note block.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Rewrite the argument bullet to use canonical enum phrasing and include the default inline.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Keep future docs fixtures grounded in code evidence so the docs review benchmark does not reward invented schema claims.
+
+## 🏆 **OVERALL ASSESSMENT**
+The docs update is close, but it should be corrected for canonical wording and note placement before merge.

--- a/tools/regression/examples/review-local-go-customizediff-validation.result.json
+++ b/tools/regression/examples/review-local-go-customizediff-validation.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-local-go-customizediff-validation",
+  "runId": "sample-review-001",
+  "timestampUtc": "2026-04-26T00:00:00Z",
+  "task": "code-review-local-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "missing-validation-coverage"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the first review-side local Go regression case."
+}

--- a/tools/regression/examples/review-local-go-customizediff-validation.review.md
+++ b/tools/regression/examples/review-local-go-customizediff-validation.review.md
@@ -1,0 +1,60 @@
+# 📋 **Code Review**: local Go validation change without matching test coverage
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 2 files (0 tracked new, 0 untracked, 2 modified, 0 deleted)
+- **Line Changes**: 18 insertions, 2 deletions (tracked files only)
+- **Branch**: fixture/local-review-example
+- **Type**: unstaged local changes
+- **Scope**: updates validation behavior in a network resource and leaves test coverage unchanged
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `internal/services/network/example_gateway_resource.go`
+- `internal/services/network/example_gateway_resource_test.go`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The implementation adds validation behavior for a Premium SKU path, but the acceptance-test file still only exercises the existing lifecycle path and does not add a targeted validation scenario.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: implementation and testing guidance loaded for `internal/**/*.go` scope
+- **Scope Rules**: `REVIEW-SCOPE-005` was directly relevant because the change touched provider Go and test files
+- **Docs Contract**: not applicable
+- **Notes**: the implementation changed validation behavior, so test expectations are part of the review scope
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: filtered local-diff scope
+- **Issue Count**: 0
+- **Summary**: linter completed successfully with no findings for the changed packages
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The implementation-side validation path is explicit and easy to reason about.
+- The linter scope is correct and does not add noise.
+
+### 🟡 **OBSERVATIONS**
+- `validation.StringIsNotEmpty` alone is not a standalone issue here because the fixture does not prove that a stronger field-specific validator is required for `sku_name`.
+
+### 🔴 **ISSUES**
+- The change adds validation behavior in the implementation but does not add a targeted acceptance test that proves the invalid `Premium` plus non-zone-redundant combination is rejected. That leaves the new validation path regression-prone.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Add a targeted acceptance test that exercises the invalid configuration and verifies the expected validation failure.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- If future evidence shows `sku_name` accepts a smaller explicit set, tighten its field validation separately.
+
+## 🏆 **OVERALL ASSESSMENT**
+The implementation change is directionally correct, but it should not merge without targeted test coverage for the new validation path.

--- a/tools/regression/examples/skill-acceptance-testing-importstep.result.json
+++ b/tools/regression/examples/skill-acceptance-testing-importstep.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-acceptance-testing-importstep",
+  "runId": "sample-acctest-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "acceptance-testing",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "requiresimport-regression",
+      "weakened-basic-existence-check"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the first direct acceptance-testing skill regression case."
+}

--- a/tools/regression/examples/skill-docs-writer-argument-note-shape.result.json
+++ b/tools/regression/examples/skill-docs-writer-argument-note-shape.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-docs-writer-argument-note-shape",
+  "runId": "sample-docswriter-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "docs-writer",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "canonical-enum-phrasing",
+      "inline-default-placement"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the first direct docs-writer skill regression case."
+}

--- a/tools/regression/examples/skill-resource-implementation-validation.result.json
+++ b/tools/regression/examples/skill-resource-implementation-validation.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-resource-implementation-validation",
+  "runId": "sample-realcase-001",
+  "timestampUtc": "2026-04-26T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "fallback-validator-overuse",
+      "redundant-parser-wrapper"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the first sanitized real-world resource-implementation case."
+}

--- a/tools/regression/fixtures/review-committed-pr-scope-linter/README.md
+++ b/tools/regression/fixtures/review-committed-pr-scope-linter/README.md
@@ -1,0 +1,36 @@
+# Sanitized Fixture: Committed Review PR-Scoped Linter Reporting
+
+This fixture is derived from a real committed-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A committed review runs against an explicit pull request context with a known PR number and a bounded diff.
+
+The changed provider Go file is modeled as `internal/services/example/example_resource.go`.
+
+The benchmarked behavior is not about a deep implementation bug. It is about whether the review correctly reports the committed-review linter execution path for the PR-scoped diff instead of guessing or fabricating scope details.
+
+## Simplified PR Shape
+
+```text
+PR Number: 4821
+Changed Files:
+- internal/services/example/example_resource.go
+```
+
+## Expected Review Behavior
+
+A correct committed review should:
+
+- Recognize that explicit PR context exists and keep the review in committed-review mode
+- Report that `azurerm-linter` was run for the PR-scoped diff rather than a local-diff or full-repo scope
+- Include the required `AZURERM LINTER` reporting section in the human-readable review body
+- Avoid inventing a pull request number from branch naming or diff text when the fixture does not supply one
+
+## Expected Must-Catch Outcomes
+
+- `linter-scope-reporting`
+
+## Expected Must-Not-Flag Outcomes
+
+- `invented-pr-number`

--- a/tools/regression/fixtures/review-docs-arguments-ordering/README.md
+++ b/tools/regression/fixtures/review-docs-arguments-ordering/README.md
@@ -1,0 +1,37 @@
+# Sanitized Fixture: Docs Review For Argument Wording And Note Shape
+
+This fixture is derived from a real docs-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A docs page under `website/docs/r/` is updated after a schema change.
+
+The page introduces two review-relevant problems:
+
+- argument wording drifts away from the contract's canonical phrasing
+- note content that should remain inline in the argument bullet is pushed into a note block instead
+
+## Simplified Docs Shape
+
+```markdown
+* `sku_name` - (Optional) Valid values are `Standard` and `Premium`.
+
+~> **Note:** Defaults to `Standard`.
+```
+
+## Expected Review Behavior
+
+A correct docs review should:
+
+- load and apply the docs contract
+- flag the wording drift from `Valid values are` to the canonical `Possible values are`
+- flag that the default belongs in the field bullet rather than in a detached note block for this scenario
+- avoid inventing schema or enum claims that are not supported by the available evidence
+
+## Expected Must-Catch Outcomes
+
+- `docs-ordering-or-wording-regression`
+
+## Expected Must-Not-Flag Outcomes
+
+- `guessed-schema-claim`

--- a/tools/regression/fixtures/review-docs-arguments-ordering/README.md
+++ b/tools/regression/fixtures/review-docs-arguments-ordering/README.md
@@ -4,12 +4,14 @@ This fixture is derived from a real docs-review pattern, but the final artifact 
 
 ## Scenario
 
-A docs page under `website/docs/r/` is updated after a schema change.
+A docs page modeled as `website/docs/r/example_gateway.html.markdown` is updated after a schema change.
 
-The page introduces two review-relevant problems:
+The fixture content for this benchmark lives under `tools/regression/fixtures/`; the `website/docs/...` path is the modeled changed-file path used to preserve realistic review scope and docs-rule activation.
 
-- argument wording drifts away from the contract's canonical phrasing
-- note content that should remain inline in the argument bullet is pushed into a note block instead
+The modeled page introduces two review-relevant problems:
+
+- Argument wording drifts away from the contract's canonical phrasing
+- Note content that should remain inline in the argument bullet is pushed into a note block instead
 
 ## Simplified Docs Shape
 
@@ -23,10 +25,10 @@ The page introduces two review-relevant problems:
 
 A correct docs review should:
 
-- load and apply the docs contract
-- flag the wording drift from `Valid values are` to the canonical `Possible values are`
-- flag that the default belongs in the field bullet rather than in a detached note block for this scenario
-- avoid inventing schema or enum claims that are not supported by the available evidence
+- Load and apply the docs contract
+- Flag the wording drift from `Valid values are` to the canonical `Possible values are`
+- Flag that the default belongs in the field bullet rather than in a detached note block for this scenario
+- Avoid inventing schema or enum claims that are not supported by the available evidence
 
 ## Expected Must-Catch Outcomes
 

--- a/tools/regression/fixtures/review-local-go-customizediff-validation/README.md
+++ b/tools/regression/fixtures/review-local-go-customizediff-validation/README.md
@@ -40,11 +40,11 @@ func TestAccExampleGateway_basic(t *testing.T) {
 
 A correct local code review should:
 
-- activate the Go and test review scope rules
-- recognize that implementation-side validation behavior changed
-- flag the missing targeted acceptance-test coverage as the primary issue
-- avoid turning generic `StringIsNotEmpty` usage into a separate issue unless the fixture evidence proves stronger validation is required for that field
-- report azurerm-linter execution in its dedicated section
+- Activate the Go and test review scope rules
+- Recognize that implementation-side validation behavior changed
+- Flag the missing targeted acceptance-test coverage as the primary issue
+- Avoid turning generic `StringIsNotEmpty` usage into a separate issue unless the fixture evidence proves stronger validation is required for that field
+- Report azurerm-linter execution in its dedicated section
 
 ## Expected Must-Catch Outcomes
 

--- a/tools/regression/fixtures/review-local-go-customizediff-validation/README.md
+++ b/tools/regression/fixtures/review-local-go-customizediff-validation/README.md
@@ -1,0 +1,55 @@
+# Sanitized Fixture: Local Go Review For Validation Coverage
+
+This fixture is derived from a real review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A local Go change updates resource validation behavior in a provider resource under `internal/services/network/`.
+
+The change adds or tightens validation logic in the implementation, but the paired acceptance-test file does not add a targeted test that exercises the new invalid combination or validation path.
+
+## Simplified Code Shape
+
+```go
+"sku_name": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: validation.StringIsNotEmpty,
+}
+
+CustomizeDiff: pluginsdk.CustomDiffWithAll(
+    pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
+        if diff.Get("sku_name").(string) == "Premium" && !diff.Get("zone_redundant").(bool) {
+            return fmt.Errorf("`zone_redundant` must be `true` for `Premium` SKU")
+        }
+
+        return nil
+    }),
+)
+```
+
+Test file shape:
+
+```go
+func TestAccExampleGateway_basic(t *testing.T) {
+    // existing lifecycle coverage only
+}
+```
+
+## Expected Review Behavior
+
+A correct local code review should:
+
+- activate the Go and test review scope rules
+- recognize that implementation-side validation behavior changed
+- flag the missing targeted acceptance-test coverage as the primary issue
+- avoid turning generic `StringIsNotEmpty` usage into a separate issue unless the fixture evidence proves stronger validation is required for that field
+- report azurerm-linter execution in its dedicated section
+
+## Expected Must-Catch Outcomes
+
+- `missing-validation-coverage`
+
+## Expected Must-Not-Flag Outcomes
+
+- `stringisnotempty-alone-without-context`

--- a/tools/regression/fixtures/skill-acceptance-testing-importstep/README.md
+++ b/tools/regression/fixtures/skill-acceptance-testing-importstep/README.md
@@ -1,0 +1,51 @@
+# Sanitized Fixture: Acceptance-Testing ImportStep Coverage
+
+This fixture is derived from a real historical acceptance-test guidance incident, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer asks `acceptance-testing` to repair lifecycle coverage in `internal/services/example/example_resource_test.go` after a resource change introduced validation behavior.
+
+The current test drift does two things:
+
+- It drops the default `requiresImport` coverage even though the resource still supports import
+- It weakens the basic existence check from `ExistsInAzure(r)` to a lighter attribute-only assertion
+
+The request is about restoring the expected acceptance-test shape, not inventing extra assertions on top of `ImportStep()`.
+
+## Simplified Test Shape
+
+```go
+func TestAccExampleResource_basic(t *testing.T) {
+    data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
+    r := ExampleResource{}
+
+    data.ResourceTest(t, r, []acceptance.TestStep{
+        {
+            Config: r.basic(data),
+            Check: acceptance.ComposeTestCheckFunc(
+                check.That(data.ResourceName).Key("name").Exists(),
+            ),
+        },
+        data.ImportStep(),
+    })
+}
+```
+
+## Expected Guidance
+
+A correct `acceptance-testing` response should:
+
+- Load the testing contract rather than treating the problem as generic Go test cleanup
+- Preserve default `requiresImport` expectations when the resource supports import
+- Keep `check.That(data.ResourceName).ExistsInAzure(r)` as the primary basic existence check
+- Keep `data.ImportStep()` for import validation without adding redundant assertions unless the case gives a concrete reason
+
+## Expected Must-Catch Outcomes
+
+- `requiresimport-regression`
+- `weakened-basic-existence-check`
+
+## Expected Must-Not-Flag Outcomes
+
+- `redundant-importstep-assertions`

--- a/tools/regression/fixtures/skill-docs-writer-argument-note-shape/README.md
+++ b/tools/regression/fixtures/skill-docs-writer-argument-note-shape/README.md
@@ -1,0 +1,44 @@
+# Sanitized Fixture: Docs-Writer Argument Note Shape
+
+This fixture is derived from a real historical docs-remediation request, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer asks `docs-writer` to fix an existing resource page modeled as `website/docs/r/example_gateway.html.markdown`.
+
+The fixture content for this benchmark lives under `tools/regression/fixtures/`; the `website/docs/...` path is the modeled changed-file path used to preserve realistic docs-writer routing and rule activation.
+
+The current page has two contract-relevant drifts:
+
+- The argument bullet uses `Valid values are` instead of the canonical `Possible values are` phrasing
+- The default value was moved into a detached note block even though it belongs inline in the argument bullet for this case
+
+The modeled page already exists, so the correct workflow is to edit it in place rather than regenerate it from scaffolding.
+
+## Simplified Docs Shape
+
+```markdown
+* `sku_name` - (Required) Valid values are `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`.
+
+-> **Note:** Defaults to `Standard_AzureFrontDoor`.
+```
+
+## Expected Guidance
+
+A correct `docs-writer` response should:
+
+- Complete docs preflight and apply the docs contract rather than generic prose cleanup
+- Edit the existing page in place instead of treating scaffolding as the default remediation
+- Restore canonical `Possible values are` wording
+- Move the default value back inline in the argument bullet for this scenario
+- Avoid inventing enum, schema, or import-ID claims that are not proven by implementation evidence
+
+## Expected Must-Catch Outcomes
+
+- `canonical-enum-phrasing`
+- `inline-default-placement`
+
+## Expected Must-Not-Flag Outcomes
+
+- `guessed-schema-claim`
+- `scaffold-existing-page`

--- a/tools/regression/fixtures/skill-resource-implementation-validation/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-validation/README.md
@@ -8,8 +8,8 @@ A maintainer or contributor is updating a provider resource under `internal/serv
 
 The change introduces two review-relevant behaviors:
 
-- a configurable field is validated with a weak fallback validator even though a narrower accepted set is knowable from the implementation context
-- a flatten or parse path wraps an already comprehensive parser error with redundant `flattening` context
+- A configurable field is validated with a weak fallback validator even though a narrower accepted set is knowable from the implementation context
+- A flatten or parse path wraps an already comprehensive parser error with redundant `flattening` context
 
 ## Simplified Code Shape
 
@@ -32,10 +32,10 @@ if err != nil {
 
 A correct resource-implementation response should:
 
-- load the implementation contract rather than relying on generic Go instincts
-- prefer stronger validation when the accepted values are knowable
-- avoid blindly requiring a full SDK `PossibleValuesFor...` helper if the resource only accepts a narrower subset
-- return comprehensive parser errors directly when extra wrapping adds no meaningful information
+- Load the implementation contract rather than relying on generic Go instincts
+- Prefer stronger validation when the accepted values are knowable
+- Avoid blindly requiring a full SDK `PossibleValuesFor...` helper if the resource only accepts a narrower subset
+- Return comprehensive parser errors directly when extra wrapping adds no meaningful information
 
 ## Expected Must-Catch Outcomes
 

--- a/tools/regression/fixtures/skill-resource-implementation-validation/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-validation/README.md
@@ -1,0 +1,48 @@
+# Sanitized Fixture: Resource Implementation Validation
+
+This fixture is derived from a real historical implementation-guidance incident, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer or contributor is updating a provider resource under `internal/services/cdn/`.
+
+The change introduces two review-relevant behaviors:
+
+- a configurable field is validated with a weak fallback validator even though a narrower accepted set is knowable from the implementation context
+- a flatten or parse path wraps an already comprehensive parser error with redundant `flattening` context
+
+## Simplified Code Shape
+
+```go
+"match_variable": {
+    Type:         pluginsdk.TypeString,
+    Required:     true,
+    ValidateFunc: validation.StringIsNotEmpty,
+}
+
+...
+
+id, err := parse.FrontDoorFirewallPolicyID(input)
+if err != nil {
+    return results, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+}
+```
+
+## Expected Guidance
+
+A correct resource-implementation response should:
+
+- load the implementation contract rather than relying on generic Go instincts
+- prefer stronger validation when the accepted values are knowable
+- avoid blindly requiring a full SDK `PossibleValuesFor...` helper if the resource only accepts a narrower subset
+- return comprehensive parser errors directly when extra wrapping adds no meaningful information
+
+## Expected Must-Catch Outcomes
+
+- `fallback-validator-overuse`
+- `redundant-parser-wrapper`
+
+## Expected Must-Not-Flag Outcomes
+
+- `blind-sdk-enum-usage`
+- `parser-error-needs-more-context`

--- a/tools/regression/hydrate-regression-run.ps1
+++ b/tools/regression/hydrate-regression-run.ps1
@@ -1,0 +1,76 @@
+[CmdletBinding()]
+param(
+    [string] $RunDirectory,
+
+    [switch] $Latest,
+
+    [string] $RunsDirectory = (Join-Path $PSScriptRoot "runs")
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Resolve-RunDirectory {
+    param(
+        [string] $RunDirectory,
+        [bool] $Latest,
+        [string] $RunsDirectory
+    )
+
+    if (($Latest -and -not [string]::IsNullOrWhiteSpace($RunDirectory)) -or (-not $Latest -and [string]::IsNullOrWhiteSpace($RunDirectory))) {
+        throw "specify exactly one of -RunDirectory or -Latest"
+    }
+
+    if ($Latest) {
+        $latestRun = Get-ChildItem -LiteralPath $RunsDirectory -Directory | Sort-Object Name -Descending | Select-Object -First 1
+        if (-not $latestRun) {
+            throw "no regression run directories found under $RunsDirectory"
+        }
+
+        return $latestRun.FullName
+    }
+
+    return (Resolve-Path -LiteralPath $RunDirectory).Path
+}
+
+$resolvedRunDirectory = Resolve-RunDirectory -RunDirectory $RunDirectory -Latest:$Latest -RunsDirectory $RunsDirectory
+$manifestPath = Join-Path $resolvedRunDirectory "run-manifest.json"
+$manifest = Get-JsonFile -Path $manifestPath
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$examplesDirectory = Join-Path $PSScriptRoot "examples"
+
+$reviewSource = Join-Path $examplesDirectory ($manifest.case.id + ".review.md")
+$resultSource = Join-Path $examplesDirectory ($manifest.case.id + ".result.json")
+
+if (-not (Test-Path -LiteralPath $reviewSource)) {
+    throw "review example not found for case '$($manifest.case.id)': $reviewSource"
+}
+
+if (-not (Test-Path -LiteralPath $resultSource)) {
+    throw "result example not found for case '$($manifest.case.id)': $resultSource"
+}
+
+$reviewDestination = Join-Path $repoRoot $manifest.artifacts.reviewOutputPath
+$resultDestination = Join-Path $repoRoot $manifest.artifacts.resultOutputPath
+
+Copy-Item -LiteralPath $reviewSource -Destination $reviewDestination -Force
+Copy-Item -LiteralPath $resultSource -Destination $resultDestination -Force
+
+Write-Output "Regression run hydrated from adjudicated example"
+Write-Output "  Run Directory : $resolvedRunDirectory"
+Write-Output "  Case ID       : $($manifest.case.id)"
+Write-Output "  Review Source : $reviewSource"
+Write-Output "  Result Source : $resultSource"
+Write-Output ""
+Write-Output "Next command:"
+Write-Output "  $($manifest.commands.score)"

--- a/tools/regression/new-regression-result-template.ps1
+++ b/tools/regression/new-regression-result-template.ps1
@@ -3,7 +3,9 @@ param(
     [string] $CasePath,
 
     [Parameter(Mandatory)]
-    [string] $OutputPath
+    [string] $OutputPath,
+
+    [string] $RunId
 )
 
 $ErrorActionPreference = "Stop"
@@ -27,7 +29,7 @@ foreach ($property in $case.expectedTools.PSObject.Properties) {
 
 $result = [ordered]@{
     caseId = $case.id
-    runId = [guid]::NewGuid().Guid
+    runId = if ([string]::IsNullOrWhiteSpace($RunId)) { [guid]::NewGuid().Guid } else { $RunId }
     timestampUtc = [DateTime]::UtcNow.ToString("o")
     task = $case.task
     model = ""

--- a/tools/regression/new-regression-result-template.ps1
+++ b/tools/regression/new-regression-result-template.ps1
@@ -1,0 +1,75 @@
+param(
+    [Parameter(Mandatory)]
+    [string] $CasePath,
+
+    [Parameter(Mandatory)]
+    [string] $OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+$case = Get-JsonFile -Path $CasePath
+
+$toolExecution = [ordered]@{}
+foreach ($property in $case.expectedTools.PSObject.Properties) {
+    $toolExecution[$property.Name] = ""
+}
+
+$result = [ordered]@{
+    caseId = $case.id
+    runId = [guid]::NewGuid().Guid
+    timestampUtc = [DateTime]::UtcNow.ToString("o")
+    task = $case.task
+    model = ""
+    pass = $false
+    overallScore = 0
+    scores = [ordered]@{
+        mustCatchRecall = 0
+        falsePositiveControl = 0
+        severityCorrectness = 0
+        scopeAndToolCorrectness = 0
+        outputCompliance = 0
+        determinism = 0
+    }
+    findings = [ordered]@{
+        caught = @()
+        missed = @()
+        falsePositives = @()
+    }
+    severityChecks = [ordered]@{
+        matched = 0
+        total = $case.mustCatch.Count
+    }
+    scopeChecks = [ordered]@{
+        ruleFamiliesAppliedCorrectly = $false
+        toolingBehaviorCorrect = $false
+    }
+    toolExecution = $toolExecution
+    outputChecks = [ordered]@{
+        requiredSectionsPresent = $false
+        requiredMarkersPresent = $false
+    }
+    determinismChecks = [ordered]@{
+        materiallyEquivalentAcrossRuns = $false
+    }
+    notes = ""
+}
+
+$directory = Split-Path -Parent $OutputPath
+if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+}
+
+$result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $OutputPath
+
+Write-Output "Created regression result template: $OutputPath"

--- a/tools/regression/new-regression-test.ps1
+++ b/tools/regression/new-regression-test.ps1
@@ -1,0 +1,100 @@
+param(
+    [Parameter(Mandatory)]
+    [string] $Id,
+
+    [string] $Title,
+
+    [ValidateSet("code-review-local-changes", "code-review-committed-changes", "code-review-docs", "docs-writer", "resource-implementation", "acceptance-testing")]
+    [string] $Task = "resource-implementation",
+
+    [string] $SpecDirectory = (Join-Path $PSScriptRoot "test"),
+
+    [switch] $Force
+)
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "test/TestSpecDefinition.ps1")
+
+$definition = Get-RegressionTestDefinition
+
+function Initialize-Directory {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Convert-ToKebabCase {
+    param([string] $Value)
+
+    $normalized = $Value.ToLowerInvariant()
+    $normalized = [Regex]::Replace($normalized, "[^a-z0-9]+", "-")
+    return $normalized.Trim('-')
+}
+
+$Id = Convert-ToKebabCase -Value $Id
+if ([string]::IsNullOrWhiteSpace($Id)) {
+    throw "id must contain at least one alphanumeric character"
+}
+
+if ([string]::IsNullOrWhiteSpace($Title)) {
+    $Title = "Replace with a short human-readable benchmark title"
+}
+
+Assert-RegressionTestAllowedValue -Definition $definition -EnumName "task" -Value $Task -Context "task"
+
+Initialize-Directory -Path $SpecDirectory
+
+$specPath = Join-Path $SpecDirectory ($Id + ".hcl")
+if ((Test-Path -LiteralPath $specPath) -and -not $Force) {
+    throw "spec already exists: $specPath"
+}
+
+$content = @(
+    ('{0} "{1}" "{2}" {{' -f $definition.defaultRootBlock, $Id, $definition.defaultRootSecondaryLabel),
+    ('  title       = "{0}"' -f $Title),
+    '',
+    '  test_case {',
+    ('    task        = "{0}"' -f $Task),
+    '    source_kind = "real-pr"',
+    '    case_status = "planned"',
+    '    notes       = "Replace with optional scope notes."',
+    '',
+    '    changed_files = [',
+    '      "path/to/changed/file.ext",',
+    '    ]',
+    '',
+    '    config {',
+    '      resource "azurerm_example_resource" "test" {',
+    '        name = "example"',
+    '      }',
+    '    }',
+    '  }',
+    '',
+    '  rules {',
+    '    description           = "Replace with a plain-language scenario description."',
+    '    notes                 = "Replace with optional maintainer notes."',
+    '    include_sample_output = false',
+    '',
+    '    must_catch {',
+    '      description = "Replace with the primary behavior or issue the harness should catch."',
+    '      severity    = "medium"',
+    '      file        = "path/to/changed/file.ext"',
+    '    }',
+    '',
+    '    must_not_flag {',
+    '      description = "Replace with a behavior the harness must not flag."',
+    '    }',
+    '  }',
+    '}'
+)
+
+$content | Set-Content -LiteralPath $specPath
+
+Write-Output "Regression test HCL scaffold created"
+Write-Output "  Spec File        : $specPath"
+Write-Output ""
+Write-Output "Next step:"
+Write-Output "  Edit the HCL file, then run build-regression-test.ps1 -SpecPath $specPath"

--- a/tools/regression/publish-regression-test.ps1
+++ b/tools/regression/publish-regression-test.ps1
@@ -1,0 +1,122 @@
+param(
+    [string] $CaseId,
+
+    [string] $SpecPath,
+
+    [string] $CasePath,
+
+    [string] $ResultPath,
+
+    [string] $ReviewPath,
+
+    [ValidateSet("ready", "adjudicated")]
+    [string] $TargetStatus = "adjudicated",
+
+    [switch] $Force,
+
+    [string] $CasesDirectory = (Join-Path $PSScriptRoot "cases"),
+
+    [string] $ExamplesDirectory = (Join-Path $PSScriptRoot "examples"),
+
+    [string] $ResultsDirectory = (Join-Path $PSScriptRoot "results")
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Resolve-CasePath {
+    param(
+        [string] $CaseId,
+        [string] $SpecPath,
+        [string] $CasePath,
+        [string] $CasesDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($CaseId) -and [string]::IsNullOrWhiteSpace($CasePath) -and [string]::IsNullOrWhiteSpace($SpecPath)) {
+        throw "specify -CaseId, -SpecPath, or -CasePath"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($CasePath)) {
+        return (Resolve-Path -LiteralPath $CasePath).Path
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SpecPath)) {
+        if (-not (Test-Path -LiteralPath $SpecPath)) {
+            throw "file not found: $SpecPath"
+        }
+
+        $specRoot = Select-String -Path $SpecPath -Pattern '^\s*AccTest\s+"([a-zA-Z0-9-]+)"\s+"([a-zA-Z0-9_-]+)"\s*\{' | Select-Object -First 1
+        if ($null -eq $specRoot) {
+            throw "could not resolve test id from spec: $SpecPath"
+        }
+
+        $CaseId = $specRoot.Matches[0].Groups[1].Value
+    }
+
+    return (Resolve-Path -LiteralPath (Join-Path $CasesDirectory ($CaseId + ".json"))).Path
+}
+
+function Assert-CanWriteFile {
+    param(
+        [string] $Path,
+        [switch] $Force
+    )
+
+    if ((Test-Path -LiteralPath $Path) -and -not $Force) {
+        throw "target already exists: $Path"
+    }
+}
+
+$resolvedCasePath = Resolve-CasePath -CaseId $CaseId -SpecPath $SpecPath -CasePath $CasePath -CasesDirectory $CasesDirectory
+$case = Get-JsonFile -Path $resolvedCasePath
+
+if ([string]::IsNullOrWhiteSpace($ResultPath)) {
+    $ResultPath = Join-Path $ResultsDirectory ($case.id + ".result.json")
+}
+
+if ([string]::IsNullOrWhiteSpace($ReviewPath)) {
+    $candidateReviewPath = Join-Path $ResultsDirectory ($case.id + ".review.md")
+    if (Test-Path -LiteralPath $candidateReviewPath) {
+        $ReviewPath = $candidateReviewPath
+    }
+}
+
+$exampleResultPath = Join-Path $ExamplesDirectory ($case.id + ".result.json")
+$exampleReviewPath = Join-Path $ExamplesDirectory ($case.id + ".review.md")
+
+Assert-CanWriteFile -Path $exampleResultPath -Force:$Force
+if (-not [string]::IsNullOrWhiteSpace($ReviewPath)) {
+    Assert-CanWriteFile -Path $exampleReviewPath -Force:$Force
+}
+
+Copy-Item -LiteralPath $ResultPath -Destination $exampleResultPath -Force
+if (-not [string]::IsNullOrWhiteSpace($ReviewPath)) {
+    Copy-Item -LiteralPath $ReviewPath -Destination $exampleReviewPath -Force
+}
+
+$updatedCase = [ordered]@{}
+foreach ($property in $case.PSObject.Properties) {
+    $updatedCase[$property.Name] = $property.Value
+}
+$updatedCase.caseStatus = $TargetStatus
+
+$updatedCase | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $resolvedCasePath
+
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") -CasePath $resolvedCasePath -ResultPath $exampleResultPath | Out-Null
+
+Write-Output "Regression test published"
+Write-Output "  Case File        : $resolvedCasePath"
+Write-Output "  Result Example   : $exampleResultPath"
+if (-not [string]::IsNullOrWhiteSpace($ReviewPath)) {
+    Write-Output "  Review Example   : $exampleReviewPath"
+}
+Write-Output "  Updated Status   : $TargetStatus"

--- a/tools/regression/run-regression-case.ps1
+++ b/tools/regression/run-regression-case.ps1
@@ -116,6 +116,64 @@ function Copy-Fixture {
     return $destinationPath
 }
 
+function Copy-SnapshotFile {
+    param(
+        [string] $SourcePath,
+        [string] $DestinationPath
+    )
+
+    $destinationDirectory = Split-Path -Parent $DestinationPath
+    Initialize-Directory -Path $destinationDirectory
+    Copy-Item -LiteralPath $SourcePath -Destination $DestinationPath -Force
+}
+
+function Get-FileSha256 {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path) -or (Get-Item -LiteralPath $Path).PSIsContainer) {
+        return $null
+    }
+
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+}
+
+function Get-RepositorySnapshot {
+    param([string] $RepoRoot)
+
+    $snapshot = [ordered]@{
+        headBranch = $null
+        headCommit = $null
+        worktreeHasChanges = $null
+        worktreeHasUntrackedChanges = $null
+    }
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return $snapshot
+    }
+
+    try {
+        $snapshot.headCommit = (& git -C $RepoRoot rev-parse HEAD).Trim()
+    }
+    catch {
+    }
+
+    try {
+        $snapshot.headBranch = (& git -C $RepoRoot rev-parse --abbrev-ref HEAD).Trim()
+    }
+    catch {
+    }
+
+    try {
+        $statusLines = @(& git -C $RepoRoot status --porcelain)
+        $snapshot.worktreeHasChanges = $statusLines.Count -gt 0
+        $snapshot.worktreeHasUntrackedChanges = @($statusLines | Where-Object { $_ -like '??*' }).Count -gt 0
+    }
+    catch {
+    }
+
+    return $snapshot
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $casesDirectory = Join-Path $PSScriptRoot "cases"
 $resolvedCasePath = Resolve-CaseFile -Case $Case -CasePath $CasePath -CasesDirectory $casesDirectory -RepoRoot $repoRoot
@@ -124,15 +182,26 @@ $caseDefinition = Get-JsonFile -Path $resolvedCasePath
 $runTimestamp = Get-Date -Format "yyyyMMdd-HHmmss"
 $runId = "$runTimestamp-$($caseDefinition.id)"
 $runDirectory = Join-Path $RunsDirectory $runId
+$inputDirectory = Join-Path $runDirectory "input"
+$captureDirectory = Join-Path $runDirectory "capture"
 $outputDirectory = Join-Path $runDirectory "output"
 $fixtureDirectory = Join-Path $runDirectory "fixture"
 
 Initialize-Directory -Path $runDirectory
+Initialize-Directory -Path $inputDirectory
+Initialize-Directory -Path $captureDirectory
 Initialize-Directory -Path $outputDirectory
 
+$caseSnapshotPath = Join-Path $inputDirectory "case.json"
+$weightsSourcePath = Join-Path $PSScriptRoot "config/score-weights.json"
+$weightsSnapshotPath = Join-Path $inputDirectory "score-weights.json"
 $resultOutputPath = Join-Path $outputDirectory "result.json"
 $reviewOutputPath = Join-Path $outputDirectory "review.md"
+$executionMetadataPath = Join-Path $captureDirectory "execution-metadata.json"
 $manifestPath = Join-Path $runDirectory "run-manifest.json"
+
+Copy-SnapshotFile -SourcePath $resolvedCasePath.Path -DestinationPath $caseSnapshotPath
+Copy-SnapshotFile -SourcePath $weightsSourcePath -DestinationPath $weightsSnapshotPath
 
 $fixtureSourcePath = $null
 $fixtureMaterializedPath = $null
@@ -141,7 +210,7 @@ if ($caseDefinition.fixture.mode -ne "none" -and $caseDefinition.fixture.path) {
     $fixtureMaterializedPath = Copy-Fixture -SourcePath $fixtureSourcePath -FixtureDirectory $fixtureDirectory
 }
 
-& pwsh -NoProfile -File (Join-Path $PSScriptRoot "new-regression-result-template.ps1") -CasePath $resolvedCasePath -OutputPath $resultOutputPath | Out-Null
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "new-regression-result-template.ps1") -CasePath $resolvedCasePath -OutputPath $resultOutputPath -RunId $runId | Out-Null
 
 $reviewPlaceholder = @(
     "# Review Output Placeholder",
@@ -155,14 +224,41 @@ $reviewPlaceholder | Set-Content -LiteralPath $reviewOutputPath
 
 $resolvedCaseAbsolutePath = $resolvedCasePath.Path
 $relativeCasePath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $resolvedCaseAbsolutePath
+$relativeCaseSnapshotPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $caseSnapshotPath
+$relativeWeightsSnapshotPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $weightsSnapshotPath
 $relativeManifestPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $manifestPath
 $relativeReviewOutputPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $reviewOutputPath
 $relativeResultOutputPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $resultOutputPath
+$relativeExecutionMetadataPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $executionMetadataPath
 $relativeFixtureSourcePath = if ($fixtureSourcePath) { Get-RelativeRepoPath -RepoRoot $repoRoot -Path $fixtureSourcePath } else { $null }
 $relativeFixtureMaterializedPath = if ($fixtureMaterializedPath) { Get-RelativeRepoPath -RepoRoot $repoRoot -Path $fixtureMaterializedPath } else { $null }
+$repositorySnapshot = Get-RepositorySnapshot -RepoRoot $repoRoot
+
+$executionMetadata = [ordered]@{
+    version = 1
+    runId = $runId
+    captureStatus = "scaffolded"
+    executionMode = "fixture-driven"
+    liveRepoStateUsed = $false
+    repositorySnapshot = $repositorySnapshot
+    modeledContext = [ordered]@{
+        task = $caseDefinition.task
+        changedFiles = @($caseDefinition.scope.changedFiles)
+        scopeNotes = $caseDefinition.scope.notes
+    }
+    invocation = [ordered]@{
+        executor = ""
+        target = ""
+        source = ""
+        commandLine = ""
+        notes = ""
+    }
+}
+
+$executionMetadata | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $executionMetadataPath
 
 $manifest = [ordered]@{
-    version = 1
+    version = 2
     runId = $runId
     createdUtc = [DateTime]::UtcNow.ToString("o")
     case = [ordered]@{
@@ -176,6 +272,23 @@ $manifest = [ordered]@{
         sourcePath = $relativeFixtureSourcePath
         materializedPath = $relativeFixtureMaterializedPath
     }
+    repositorySnapshot = $repositorySnapshot
+    inputs = [ordered]@{
+        caseSnapshotPath = $relativeCaseSnapshotPath
+        caseSnapshotSha256 = Get-FileSha256 -Path $caseSnapshotPath
+        weightsSnapshotPath = $relativeWeightsSnapshotPath
+        weightsSnapshotSha256 = Get-FileSha256 -Path $weightsSnapshotPath
+    }
+    capture = [ordered]@{
+        executionMetadataPath = $relativeExecutionMetadataPath
+    }
+    executionEnvelope = [ordered]@{
+        mode = "fixture-driven"
+        liveRepoStateRequired = $false
+        captureStatus = "scaffolded"
+        modeledChangedFiles = @($caseDefinition.scope.changedFiles)
+        modeledScopeNotes = $caseDefinition.scope.notes
+    }
     artifacts = [ordered]@{
         reviewOutputPath = $relativeReviewOutputPath
         resultOutputPath = $relativeResultOutputPath
@@ -183,18 +296,27 @@ $manifest = [ordered]@{
     }
     commands = [ordered]@{
         hydrateExample = "pwsh -NoProfile -File ./tools/regression/hydrate-regression-run.ps1 -RunDirectory ./$([System.IO.Path]::GetRelativePath($repoRoot, $runDirectory))"
-        score = "pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./$relativeCasePath -ResultPath ./$relativeResultOutputPath"
-        previewExample = "pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -CasePath ./$relativeCasePath -ShowFixture -ShowReview"
+        validate = "pwsh -NoProfile -File ./tools/regression/validate-regression-artifacts.ps1 -CasePath ./$relativeCaseSnapshotPath -ResultPath ./$relativeResultOutputPath"
+        score = "pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./$relativeCaseSnapshotPath -ResultPath ./$relativeResultOutputPath -WeightsPath ./$relativeWeightsSnapshotPath"
+        previewExample = "pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -CasePath ./$relativeCaseSnapshotPath -ShowFixture -ShowReview"
     }
     nextSteps = @(
         "optionally hydrate the run from adjudicated example artifacts using the hydrateExample command",
+        "fill in capture/execution-metadata.json with the exact executor, command, and invocation notes for the real run",
         "replace the review file with the captured human-readable output for a real run",
         "update the generated result file with the adjudicated outcome for the run",
-        "run the score command from this manifest to compute the weighted benchmark result"
+        "run the validate command from this manifest before scoring to confirm the captured artifacts are still structurally valid",
+        "run the score command from this manifest to compute the weighted benchmark result against the snapshotted case and weights"
     )
 }
 
 $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath
+
+$runManifestSchemaPath = Join-Path $PSScriptRoot "schema/run-manifest.schema.json"
+$manifestIsValid = (Get-Content -LiteralPath $manifestPath -Raw) | Test-Json -SchemaFile $runManifestSchemaPath
+if (-not $manifestIsValid) {
+    throw "generated run manifest failed schema validation: $manifestPath"
+}
 
 Write-Output "Regression run scaffold created"
 Write-Output "  Case ID         : $($caseDefinition.id)"
@@ -204,9 +326,12 @@ Write-Output "  Run Directory   : $runDirectory"
 if ($fixtureMaterializedPath) {
     Write-Output "  Fixture Copy    : $fixtureMaterializedPath"
 }
+Write-Output "  Case Snapshot   : $caseSnapshotPath"
+Write-Output "  Weights Snapshot: $weightsSnapshotPath"
+Write-Output "  Capture Metadata: $executionMetadataPath"
 Write-Output "  Review Output   : $reviewOutputPath"
 Write-Output "  Result Template : $resultOutputPath"
 Write-Output "  Run Manifest    : $manifestPath"
 Write-Output ""
 Write-Output "Next command:"
-Write-Output "  $($manifest.commands.hydrateExample)"
+Write-Output "  $($manifest.commands.validate)"

--- a/tools/regression/run-regression-case.ps1
+++ b/tools/regression/run-regression-case.ps1
@@ -1,0 +1,212 @@
+param(
+    [string] $Case,
+
+    [string] $CasePath,
+
+    [string] $RunsDirectory = (Join-Path $PSScriptRoot "runs")
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Get-RelativeRepoPath {
+    param(
+        [string] $RepoRoot,
+        [string] $Path
+    )
+
+    return [System.IO.Path]::GetRelativePath($RepoRoot, $Path)
+}
+
+function Get-AvailableCases {
+    param([string] $CasesDirectory)
+
+    if (-not (Test-Path -LiteralPath $CasesDirectory)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $CasesDirectory -Filter *.json | Sort-Object BaseName)
+}
+
+function Show-Usage {
+    param(
+        [string[]] $AvailableCases
+    )
+
+    Write-Output "Usage: pwsh -NoProfile -File ./tools/regression/run-regression-case.ps1 -Case <case-id>"
+    Write-Output "   or: pwsh -NoProfile -File ./tools/regression/run-regression-case.ps1 -CasePath <case.json>"
+    Write-Output ""
+    Write-Output "Available case aliases:"
+
+    foreach ($availableCase in $AvailableCases) {
+        Write-Output "  - $availableCase"
+    }
+}
+
+function Resolve-CaseFile {
+    param(
+        [string] $Case,
+        [string] $CasePath,
+        [string] $CasesDirectory,
+        [string] $RepoRoot
+    )
+
+    $availableCaseFiles = Get-AvailableCases -CasesDirectory $CasesDirectory
+    $availableAliases = @($availableCaseFiles | ForEach-Object { $_.BaseName })
+
+    if (([string]::IsNullOrWhiteSpace($Case) -and [string]::IsNullOrWhiteSpace($CasePath)) -or
+        (-not [string]::IsNullOrWhiteSpace($Case) -and -not [string]::IsNullOrWhiteSpace($CasePath))) {
+        Show-Usage -AvailableCases $availableAliases
+        throw "specify exactly one of -Case or -CasePath"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($CasePath)) {
+        return Resolve-Path -LiteralPath $CasePath
+    }
+
+    $matches = @($availableCaseFiles | Where-Object { $_.BaseName -eq $Case -or $_.Name -eq $Case })
+    if ($matches.Count -eq 0) {
+        Show-Usage -AvailableCases $availableAliases
+        throw "unknown case alias: $Case"
+    }
+
+    if ($matches.Count -gt 1) {
+        throw "case alias is ambiguous: $Case"
+    }
+
+    return Resolve-Path -LiteralPath $matches[0].FullName
+}
+
+function Initialize-Directory {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Copy-Fixture {
+    param(
+        [string] $SourcePath,
+        [string] $FixtureDirectory
+    )
+
+    if (-not (Test-Path -LiteralPath $SourcePath)) {
+        throw "fixture source not found: $SourcePath"
+    }
+
+    Initialize-Directory -Path $FixtureDirectory
+
+    if ((Get-Item -LiteralPath $SourcePath).PSIsContainer) {
+        Copy-Item -LiteralPath $SourcePath -Destination $FixtureDirectory -Recurse -Force
+        return Join-Path $FixtureDirectory (Split-Path -Leaf $SourcePath)
+    }
+
+    $destinationPath = Join-Path $FixtureDirectory (Split-Path -Leaf $SourcePath)
+    Copy-Item -LiteralPath $SourcePath -Destination $destinationPath -Force
+    return $destinationPath
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$casesDirectory = Join-Path $PSScriptRoot "cases"
+$resolvedCasePath = Resolve-CaseFile -Case $Case -CasePath $CasePath -CasesDirectory $casesDirectory -RepoRoot $repoRoot
+$caseDefinition = Get-JsonFile -Path $resolvedCasePath
+
+$runTimestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$runId = "$runTimestamp-$($caseDefinition.id)"
+$runDirectory = Join-Path $RunsDirectory $runId
+$outputDirectory = Join-Path $runDirectory "output"
+$fixtureDirectory = Join-Path $runDirectory "fixture"
+
+Initialize-Directory -Path $runDirectory
+Initialize-Directory -Path $outputDirectory
+
+$resultOutputPath = Join-Path $outputDirectory "result.json"
+$reviewOutputPath = Join-Path $outputDirectory "review.md"
+$manifestPath = Join-Path $runDirectory "run-manifest.json"
+
+$fixtureSourcePath = $null
+$fixtureMaterializedPath = $null
+if ($caseDefinition.fixture.mode -ne "none" -and $caseDefinition.fixture.path) {
+    $fixtureSourcePath = Join-Path $repoRoot $caseDefinition.fixture.path
+    $fixtureMaterializedPath = Copy-Fixture -SourcePath $fixtureSourcePath -FixtureDirectory $fixtureDirectory
+}
+
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "new-regression-result-template.ps1") -CasePath $resolvedCasePath -OutputPath $resultOutputPath | Out-Null
+
+$reviewPlaceholder = @(
+    "# Review Output Placeholder",
+    "",
+    "Case ID: $($caseDefinition.id)",
+    "Task: $($caseDefinition.task)",
+    "",
+    "Replace this file with the captured human-readable prompt or skill output for this run."
+)
+$reviewPlaceholder | Set-Content -LiteralPath $reviewOutputPath
+
+$resolvedCaseAbsolutePath = $resolvedCasePath.Path
+$relativeCasePath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $resolvedCaseAbsolutePath
+$relativeManifestPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $manifestPath
+$relativeReviewOutputPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $reviewOutputPath
+$relativeResultOutputPath = Get-RelativeRepoPath -RepoRoot $repoRoot -Path $resultOutputPath
+$relativeFixtureSourcePath = if ($fixtureSourcePath) { Get-RelativeRepoPath -RepoRoot $repoRoot -Path $fixtureSourcePath } else { $null }
+$relativeFixtureMaterializedPath = if ($fixtureMaterializedPath) { Get-RelativeRepoPath -RepoRoot $repoRoot -Path $fixtureMaterializedPath } else { $null }
+
+$manifest = [ordered]@{
+    version = 1
+    runId = $runId
+    createdUtc = [DateTime]::UtcNow.ToString("o")
+    case = [ordered]@{
+        id = $caseDefinition.id
+        task = $caseDefinition.task
+        status = $caseDefinition.caseStatus
+        casePath = $relativeCasePath
+    }
+    fixture = [ordered]@{
+        mode = $caseDefinition.fixture.mode
+        sourcePath = $relativeFixtureSourcePath
+        materializedPath = $relativeFixtureMaterializedPath
+    }
+    artifacts = [ordered]@{
+        reviewOutputPath = $relativeReviewOutputPath
+        resultOutputPath = $relativeResultOutputPath
+        manifestPath = $relativeManifestPath
+    }
+    commands = [ordered]@{
+        hydrateExample = "pwsh -NoProfile -File ./tools/regression/hydrate-regression-run.ps1 -RunDirectory ./$([System.IO.Path]::GetRelativePath($repoRoot, $runDirectory))"
+        score = "pwsh -NoProfile -File ./tools/regression/score-regression-case.ps1 -CasePath ./$relativeCasePath -ResultPath ./$relativeResultOutputPath"
+        previewExample = "pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -CasePath ./$relativeCasePath -ShowFixture -ShowReview"
+    }
+    nextSteps = @(
+        "optionally hydrate the run from adjudicated example artifacts using the hydrateExample command",
+        "replace the review file with the captured human-readable output for a real run",
+        "update the generated result file with the adjudicated outcome for the run",
+        "run the score command from this manifest to compute the weighted benchmark result"
+    )
+}
+
+$manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath
+
+Write-Output "Regression run scaffold created"
+Write-Output "  Case ID         : $($caseDefinition.id)"
+Write-Output "  Task            : $($caseDefinition.task)"
+Write-Output "  Run ID          : $runId"
+Write-Output "  Run Directory   : $runDirectory"
+if ($fixtureMaterializedPath) {
+    Write-Output "  Fixture Copy    : $fixtureMaterializedPath"
+}
+Write-Output "  Review Output   : $reviewOutputPath"
+Write-Output "  Result Template : $resultOutputPath"
+Write-Output "  Run Manifest    : $manifestPath"
+Write-Output ""
+Write-Output "Next command:"
+Write-Output "  $($manifest.commands.hydrateExample)"

--- a/tools/regression/run-regression-example.ps1
+++ b/tools/regression/run-regression-example.ps1
@@ -1,0 +1,140 @@
+param(
+    [string] $Case,
+
+    [string] $CasePath,
+
+    [string] $ResultPath,
+
+    [string] $ReviewPath,
+
+    [switch] $ShowFixture,
+
+    [switch] $ShowReview
+)
+
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+    param([string[]] $AvailableCases)
+
+    Write-Output "Usage: pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -Case <case-id> [-ShowFixture] [-ShowReview]"
+    Write-Output "   or: pwsh -NoProfile -File ./tools/regression/run-regression-example.ps1 -CasePath <case.json> [-ShowFixture] [-ShowReview]"
+    Write-Output ""
+    Write-Output "Available case aliases:"
+
+    foreach ($case in $AvailableCases) {
+        Write-Output "  - $case"
+    }
+}
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Resolve-DefaultArtifactPath {
+    param(
+        [string] $BaseDirectory,
+        [string] $CaseId,
+        [string] $Extension
+    )
+
+    $candidate = Join-Path $BaseDirectory ($CaseId + $Extension)
+    if (Test-Path -LiteralPath $candidate) {
+        return $candidate
+    }
+
+    return $null
+}
+
+function Resolve-CaseFile {
+    param(
+        [string] $Case,
+        [string] $CasePath,
+        [string] $CasesDirectory,
+        [string] $RepoRoot
+    )
+
+    $availableCaseFiles = @()
+    if (Test-Path -LiteralPath $CasesDirectory) {
+        $availableCaseFiles = @(Get-ChildItem -LiteralPath $CasesDirectory -Filter *.json | Sort-Object BaseName)
+    }
+
+    $availableAliases = @($availableCaseFiles | ForEach-Object { $_.BaseName })
+
+    if (([string]::IsNullOrWhiteSpace($Case) -and [string]::IsNullOrWhiteSpace($CasePath)) -or
+        (-not [string]::IsNullOrWhiteSpace($Case) -and -not [string]::IsNullOrWhiteSpace($CasePath))) {
+        Show-Usage -AvailableCases $availableAliases
+        throw "specify exactly one of -Case or -CasePath"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($CasePath)) {
+        return Resolve-Path -LiteralPath $CasePath
+    }
+
+    $matches = @($availableCaseFiles | Where-Object { $_.BaseName -eq $Case -or $_.Name -eq $Case })
+    if ($matches.Count -eq 0) {
+        Show-Usage -AvailableCases $availableAliases
+        throw "unknown case alias: $Case"
+    }
+
+    if ($matches.Count -gt 1) {
+        throw "case alias is ambiguous: $Case"
+    }
+
+    return Resolve-Path -LiteralPath $matches[0].FullName
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$casesDirectory = Join-Path $PSScriptRoot "cases"
+$resolvedCasePath = Resolve-CaseFile -Case $Case -CasePath $CasePath -CasesDirectory $casesDirectory -RepoRoot $repoRoot
+$caseDefinition = Get-JsonFile -Path $resolvedCasePath
+
+if (-not $ResultPath) {
+    $ResultPath = Resolve-DefaultArtifactPath -BaseDirectory (Join-Path $PSScriptRoot "examples") -CaseId $caseDefinition.id -Extension ".result.json"
+}
+
+if (-not $ReviewPath) {
+    $ReviewPath = Resolve-DefaultArtifactPath -BaseDirectory (Join-Path $PSScriptRoot "examples") -CaseId $caseDefinition.id -Extension ".review.md"
+}
+
+Write-Output "Regression example"
+Write-Output "  Case ID    : $($caseDefinition.id)"
+Write-Output "  Task       : $($caseDefinition.task)"
+Write-Output "  Status     : $($caseDefinition.caseStatus)"
+Write-Output "  Case Path  : $resolvedCasePath"
+
+if ($caseDefinition.fixture.mode -ne "none" -and $caseDefinition.fixture.path) {
+    $fixturePath = Join-Path $repoRoot $caseDefinition.fixture.path
+    Write-Output "  Fixture    : $fixturePath"
+    if ($ShowFixture -and (Test-Path -LiteralPath $fixturePath)) {
+        Write-Output ""
+        Write-Output "--- Fixture Preview ---"
+        Get-Content -LiteralPath $fixturePath
+        Write-Output ""
+    }
+}
+
+if ($ReviewPath) {
+    Write-Output "  Review     : $ReviewPath"
+    if ($ShowReview -and (Test-Path -LiteralPath $ReviewPath)) {
+        Write-Output ""
+        Write-Output "--- Review Preview ---"
+        Get-Content -LiteralPath $ReviewPath
+        Write-Output ""
+    }
+}
+
+if ($ResultPath) {
+    Write-Output "  Result     : $ResultPath"
+    Write-Output ""
+    & pwsh -NoProfile -File (Join-Path $PSScriptRoot "score-regression-case.ps1") -CasePath $resolvedCasePath -ResultPath $ResultPath
+}
+else {
+    Write-Output "  Result     : not found"
+}

--- a/tools/regression/run-regression-harness.ps1
+++ b/tools/regression/run-regression-harness.ps1
@@ -1,0 +1,146 @@
+param(
+    [string[]] $Task,
+
+    [string[]] $CaseStatus = @("adjudicated"),
+
+    [string] $LatestDirectory = (Join-Path $PSScriptRoot "results/latest"),
+
+    [string] $HistoryDirectory = (Join-Path $PSScriptRoot "results/history"),
+
+    [ValidateSet("text", "json")]
+    [string] $Output = "text"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Expand-ListParameter {
+    param([string[]] $Value)
+
+    $expanded = @()
+    foreach ($entry in $Value) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        $expanded += @($entry -split "," | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    return @($expanded | Select-Object -Unique)
+}
+
+function Initialize-Directory {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Remove-LatestOutputs {
+    param([string] $LatestDirectory)
+
+    if (-not (Test-Path -LiteralPath $LatestDirectory)) {
+        return
+    }
+
+    Get-ChildItem -LiteralPath $LatestDirectory -File | Remove-Item -Force
+}
+
+$Task = Expand-ListParameter -Value $Task
+$CaseStatus = Expand-ListParameter -Value $CaseStatus
+
+Initialize-Directory -Path $LatestDirectory
+Initialize-Directory -Path $HistoryDirectory
+Remove-LatestOutputs -LatestDirectory $LatestDirectory
+
+$validationJsonPath = Join-Path $LatestDirectory "validation.json"
+$suiteTextPath = Join-Path $LatestDirectory "regression-suite.txt"
+$suiteJsonPath = Join-Path $LatestDirectory "regression-suite.json"
+$historySnapshotLatestPath = Join-Path $LatestDirectory "regression-history-snapshot.json"
+$historySummaryTextPath = Join-Path $LatestDirectory "regression-history-summary.txt"
+$historySummaryJsonPath = Join-Path $LatestDirectory "regression-history-summary.json"
+$harnessSummaryJsonPath = Join-Path $LatestDirectory "regression-harness-summary.json"
+
+$sharedArguments = @{}
+if ($Task.Count -gt 0) {
+    $sharedArguments.Task = $Task
+}
+if ($CaseStatus.Count -gt 0) {
+    $sharedArguments.CaseStatus = $CaseStatus
+}
+
+$validationJson = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") -Output json | ConvertFrom-Json
+$validationJson | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $validationJsonPath
+
+$suiteText = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "run-regression-suite.ps1") @sharedArguments
+$suiteText | Set-Content -LiteralPath $suiteTextPath
+
+$suiteJson = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "run-regression-suite.ps1") @sharedArguments -Output json | ConvertFrom-Json
+$suiteJson | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $suiteJsonPath
+
+$existingHistoryFiles = @()
+if (Test-Path -LiteralPath $HistoryDirectory) {
+    $existingHistoryFiles = @(Get-ChildItem -LiteralPath $HistoryDirectory -Filter *.json | ForEach-Object { $_.FullName })
+}
+
+$historySnapshotJson = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "write-regression-history-snapshot.ps1") @sharedArguments -HistoryDirectory $HistoryDirectory -Output json | ConvertFrom-Json
+$historySnapshotJson | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $historySnapshotLatestPath
+
+$newHistoryFiles = @(Get-ChildItem -LiteralPath $HistoryDirectory -Filter *.json | Where-Object { $existingHistoryFiles -notcontains $_.FullName } | Sort-Object Name)
+$createdHistorySnapshotPath = if ($newHistoryFiles.Count -gt 0) { $newHistoryFiles[-1].FullName } else { $null }
+
+$historySummaryText = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "summarize-regression-history.ps1") -HistoryDirectory $HistoryDirectory
+$historySummaryText | Set-Content -LiteralPath $historySummaryTextPath
+
+$historySummaryJson = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "summarize-regression-history.ps1") -HistoryDirectory $HistoryDirectory -Output json | ConvertFrom-Json
+$historySummaryJson | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $historySummaryJsonPath
+
+$summary = [ordered]@{
+    validation = [ordered]@{
+        path = $validationJsonPath
+        caseFileCount = [int]$validationJson.caseFileCount
+        resultFileCount = [int]$validationJson.resultFileCount
+    }
+    suite = [ordered]@{
+        textPath = $suiteTextPath
+        jsonPath = $suiteJsonPath
+        selectedCaseCount = [int]$suiteJson.selectedCaseCount
+        scoredCaseCount = [int]$suiteJson.scoredCaseCount
+        skippedCaseCount = [int]$suiteJson.skippedCaseCount
+    }
+    history = [ordered]@{
+        snapshotPath = $historySnapshotLatestPath
+        persistedSnapshotPath = $createdHistorySnapshotPath
+        summaryTextPath = $historySummaryTextPath
+        summaryJsonPath = $historySummaryJsonPath
+        snapshotId = $historySnapshotJson.snapshotId
+        snapshotCount = [int]$historySummaryJson.snapshotCount
+    }
+    filters = [ordered]@{
+        task = @($Task)
+        caseStatus = @($CaseStatus)
+    }
+}
+
+$summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $harnessSummaryJsonPath
+
+if ($Output -eq "json") {
+    $summary | ConvertTo-Json -Depth 20
+    return
+}
+
+Write-Output "Regression harness run complete"
+Write-Output "  Latest Directory : $LatestDirectory"
+Write-Output "  Validation JSON  : $validationJsonPath"
+Write-Output "  Suite Text       : $suiteTextPath"
+Write-Output "  Suite JSON       : $suiteJsonPath"
+Write-Output "  History Snapshot : $historySnapshotLatestPath"
+if (-not [string]::IsNullOrWhiteSpace($createdHistorySnapshotPath)) {
+    Write-Output "  History Archive  : $createdHistorySnapshotPath"
+}
+Write-Output "  History Summary  : $historySummaryTextPath"
+Write-Output ""
+Write-Output "Latest metrics"
+Write-Output "  Cases Selected   : $($summary.suite.selectedCaseCount)"
+Write-Output "  Cases Scored     : $($summary.suite.scoredCaseCount)"
+Write-Output "  Snapshots Saved  : $($summary.history.snapshotCount)"

--- a/tools/regression/run-regression-suite.ps1
+++ b/tools/regression/run-regression-suite.ps1
@@ -1,0 +1,220 @@
+param(
+    [string[]] $Task,
+
+    [string[]] $CaseStatus = @("adjudicated"),
+
+    [string] $CasesDirectory = (Join-Path $PSScriptRoot "cases"),
+
+    [string] $ExamplesDirectory = (Join-Path $PSScriptRoot "examples"),
+
+    [ValidateSet("text", "json")]
+    [string] $Output = "text",
+
+    [switch] $AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($AsJson) {
+    $Output = "json"
+}
+
+$targetSkillTasks = @(
+    "docs-writer",
+    "resource-implementation",
+    "acceptance-testing"
+)
+
+function Expand-ListParameter {
+    param([string[]] $Value)
+
+    $expanded = @()
+    foreach ($entry in $Value) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        $expanded += @($entry -split "," | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    return @($expanded | Select-Object -Unique)
+}
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Get-CaseFiles {
+    param([string] $CasesDirectory)
+
+    if (-not (Test-Path -LiteralPath $CasesDirectory)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $CasesDirectory -Filter *.json | Sort-Object BaseName)
+}
+
+function Resolve-ExampleArtifactPath {
+    param(
+        [string] $ExamplesDirectory,
+        [string] $CaseId,
+        [string] $Extension
+    )
+
+    $candidate = Join-Path $ExamplesDirectory ($CaseId + $Extension)
+    if (Test-Path -LiteralPath $candidate) {
+        return $candidate
+    }
+
+    return $null
+}
+
+function Get-SkillCoverageStatus {
+    param(
+        [int] $CaseCount,
+        [int] $AdjudicatedCount,
+        [int] $ExampleResultCount
+    )
+
+    if ($ExampleResultCount -gt 0) {
+        return "covered"
+    }
+
+    if ($AdjudicatedCount -gt 0) {
+        return "missing-example-result"
+    }
+
+    if ($CaseCount -gt 0) {
+        return "not-yet-adjudicated"
+    }
+
+    return "no-direct-case"
+}
+
+$Task = Expand-ListParameter -Value $Task
+$CaseStatus = Expand-ListParameter -Value $CaseStatus
+
+$allCaseFiles = Get-CaseFiles -CasesDirectory $CasesDirectory
+$allCases = @()
+
+foreach ($caseFile in $allCaseFiles) {
+    $case = Get-JsonFile -Path $caseFile.FullName
+    $allCases += [pscustomobject]@{
+        definition = $case
+        casePath = $caseFile.FullName
+        exampleResultPath = Resolve-ExampleArtifactPath -ExamplesDirectory $ExamplesDirectory -CaseId $case.id -Extension ".result.json"
+        exampleReviewPath = Resolve-ExampleArtifactPath -ExamplesDirectory $ExamplesDirectory -CaseId $case.id -Extension ".review.md"
+    }
+}
+
+$selectedCases = @($allCases | Where-Object {
+        ($Task.Count -eq 0 -or $Task -contains $_.definition.task) -and
+        ($CaseStatus.Count -eq 0 -or $CaseStatus -contains $_.definition.caseStatus)
+    })
+
+if ($selectedCases.Count -gt 0) {
+    $validatorArguments = @{
+        CasePath = @($selectedCases | ForEach-Object { $_.casePath } | Select-Object -Unique)
+    }
+
+    $selectedResultPaths = @($selectedCases | Where-Object { $_.exampleResultPath } | ForEach-Object { $_.exampleResultPath } | Select-Object -Unique)
+    if ($selectedResultPaths.Count -gt 0) {
+        $validatorArguments.ResultPath = $selectedResultPaths
+    }
+
+    & pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") @validatorArguments | Out-Null
+}
+
+$caseResults = @()
+foreach ($selectedCase in $selectedCases) {
+    $scoreSummary = $null
+    $skipReason = $null
+
+    if ($selectedCase.definition.caseStatus -ne "adjudicated") {
+        $skipReason = "case status '$($selectedCase.definition.caseStatus)' is not runnable"
+    }
+    elseif (-not $selectedCase.exampleResultPath) {
+        $skipReason = "example result artifact not found"
+    }
+    else {
+        $scoreSummary = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "score-regression-case.ps1") -CasePath $selectedCase.casePath -ResultPath $selectedCase.exampleResultPath -Output json | ConvertFrom-Json
+    }
+
+    $caseResults += [pscustomobject]@{
+        id = $selectedCase.definition.id
+        task = $selectedCase.definition.task
+        caseStatus = $selectedCase.definition.caseStatus
+        scored = [bool]$scoreSummary
+        pass = if ($scoreSummary) { [bool]$scoreSummary.pass } else { $null }
+        overallScore = if ($scoreSummary) { [double]$scoreSummary.overallScore } else { $null }
+        exampleResultPath = $selectedCase.exampleResultPath
+        exampleReviewPath = $selectedCase.exampleReviewPath
+        skipReason = $skipReason
+    }
+}
+
+$targetSkillCoverage = @()
+foreach ($skillTask in $targetSkillTasks) {
+    $taskCases = @($allCases | Where-Object { $_.definition.task -eq $skillTask })
+    $adjudicatedCases = @($taskCases | Where-Object { $_.definition.caseStatus -eq "adjudicated" })
+    $exampleResultCases = @($taskCases | Where-Object { $_.exampleResultPath })
+
+    $targetSkillCoverage += [pscustomobject]@{
+        task = $skillTask
+        caseCount = $taskCases.Count
+        adjudicatedCount = $adjudicatedCases.Count
+        exampleResultCount = $exampleResultCases.Count
+        status = Get-SkillCoverageStatus -CaseCount $taskCases.Count -AdjudicatedCount $adjudicatedCases.Count -ExampleResultCount $exampleResultCases.Count
+    }
+}
+
+$summary = [ordered]@{
+    selectedCaseCount = $selectedCases.Count
+    scoredCaseCount = @($caseResults | Where-Object { $_.scored }).Count
+    skippedCaseCount = @($caseResults | Where-Object { -not $_.scored }).Count
+    filters = [ordered]@{
+        task = if ($Task.Count -gt 0) { @($Task) } else { @() }
+        caseStatus = if ($CaseStatus.Count -gt 0) { @($CaseStatus) } else { @() }
+    }
+    targetSkillCoverage = $targetSkillCoverage
+    caseResults = $caseResults
+}
+
+if ($Output -eq "json") {
+    $summary | ConvertTo-Json -Depth 10
+    return
+}
+
+Write-Output "Regression suite summary"
+Write-Output "  Selected Cases  : $($summary.selectedCaseCount)"
+Write-Output "  Scored Cases    : $($summary.scoredCaseCount)"
+Write-Output "  Skipped Cases   : $($summary.skippedCaseCount)"
+Write-Output "  Task Filter     : $(if ($Task.Count -gt 0) { $Task -join ', ' } else { 'all' })"
+Write-Output "  Status Filter   : $(if ($CaseStatus.Count -gt 0) { $CaseStatus -join ', ' } else { 'all' })"
+Write-Output ""
+Write-Output "Target skill coverage"
+foreach ($coverage in $targetSkillCoverage) {
+    Write-Output "  $($coverage.task): cases=$($coverage.caseCount), adjudicated=$($coverage.adjudicatedCount), exampleResults=$($coverage.exampleResultCount), status=$($coverage.status)"
+}
+
+Write-Output ""
+Write-Output "Case results"
+if ($caseResults.Count -eq 0) {
+    Write-Output "  No cases matched the requested filters."
+}
+else {
+    foreach ($caseResult in $caseResults) {
+        if ($caseResult.scored) {
+            Write-Output "  $(if ($caseResult.pass) { 'PASS' } else { 'FAIL' })  $($caseResult.overallScore)  $($caseResult.id)  [$($caseResult.task)]"
+        }
+        else {
+            Write-Output "  SKIP  $($caseResult.id)  [$($caseResult.task)]  $($caseResult.skipReason)"
+        }
+    }
+}

--- a/tools/regression/schema/history-snapshot.schema.json
+++ b/tools/regression/schema/history-snapshot.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wodansson.github.io/terraform-azurerm-ai-assisted-development/tools/regression/schema/history-snapshot.schema.json",
+  "title": "AI Regression History Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "snapshotId",
+    "createdUtc",
+    "repositorySnapshot",
+    "filters",
+    "metrics",
+    "suite"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "snapshotId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "createdUtc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repositorySnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "headBranch",
+        "headCommit",
+        "worktreeHasChanges",
+        "worktreeHasUntrackedChanges"
+      ],
+      "properties": {
+        "headBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headCommit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "worktreeHasChanges": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "worktreeHasUntrackedChanges": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task",
+        "caseStatus"
+      ],
+      "properties": {
+        "task": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "caseStatus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selectedCaseCount",
+        "scoredCaseCount",
+        "passCount",
+        "failCount",
+        "skippedCaseCount",
+        "passRate",
+        "averageOverallScore",
+        "minimumOverallScore",
+        "maximumOverallScore",
+        "coveredSkillCount"
+      ],
+      "properties": {
+        "selectedCaseCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scoredCaseCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skippedCaseCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passRate": {
+          "type": "number"
+        },
+        "averageOverallScore": {
+          "type": "number"
+        },
+        "minimumOverallScore": {
+          "type": "number"
+        },
+        "maximumOverallScore": {
+          "type": "number"
+        },
+        "coveredSkillCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "suite": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "selectedCaseCount",
+        "scoredCaseCount",
+        "skippedCaseCount",
+        "targetSkillCoverage",
+        "caseResults"
+      ],
+      "properties": {
+        "selectedCaseCount": {
+          "type": "integer"
+        },
+        "scoredCaseCount": {
+          "type": "integer"
+        },
+        "skippedCaseCount": {
+          "type": "integer"
+        },
+        "targetSkillCoverage": {
+          "type": "array"
+        },
+        "caseResults": {
+          "type": "array"
+        }
+      }
+    }
+  }
+}

--- a/tools/regression/schema/review-case.schema.json
+++ b/tools/regression/schema/review-case.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wodansson.github.io/terraform-azurerm-ai-assisted-development/tools/regression/schema/review-case.schema.json",
+  "title": "AI Regression Review Case",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "title",
+    "task",
+    "caseStatus",
+    "sourceKind",
+    "sanitized",
+    "fixture",
+    "scope",
+    "expectedRules",
+    "mustCatch",
+    "mustNotFlag",
+    "expectedTools",
+    "outputChecks"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task": {
+      "type": "string",
+      "enum": [
+        "code-review-local-changes",
+        "code-review-committed-changes",
+        "code-review-docs",
+        "resource-implementation",
+        "acceptance-testing",
+        "ai-toolkit-maintenance"
+      ]
+    },
+    "caseStatus": {
+      "type": "string",
+      "enum": [
+        "planned",
+        "ready",
+        "adjudicated",
+        "retired"
+      ]
+    },
+    "sourceKind": {
+      "type": "string",
+      "enum": [
+        "real-pr",
+        "local-diff",
+        "synthetic"
+      ]
+    },
+    "sanitized": {
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string"
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "patch",
+            "files",
+            "none"
+          ]
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changedFiles"
+      ],
+      "properties": {
+        "changedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "expectedRules": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "mustCatch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "severity",
+          "description"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low",
+              "observation"
+            ]
+          },
+          "file": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "mustNotFlag": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "description"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "expectedTools": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "azurermLinter": {
+          "type": "string",
+          "enum": [
+            "run",
+            "not-applicable",
+            "not-run"
+          ]
+        },
+        "upstreamDrift": {
+          "type": "string",
+          "enum": [
+            "run",
+            "not-applicable"
+          ]
+        }
+      }
+    },
+    "outputChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mustHaveSections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mustIncludeMarkers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/tools/regression/schema/review-case.schema.json
+++ b/tools/regression/schema/review-case.schema.json
@@ -34,9 +34,9 @@
         "code-review-local-changes",
         "code-review-committed-changes",
         "code-review-docs",
+        "docs-writer",
         "resource-implementation",
-        "acceptance-testing",
-        "ai-toolkit-maintenance"
+        "acceptance-testing"
       ]
     },
     "caseStatus": {
@@ -168,13 +168,6 @@
             "run",
             "not-applicable",
             "not-run"
-          ]
-        },
-        "upstreamDrift": {
-          "type": "string",
-          "enum": [
-            "run",
-            "not-applicable"
           ]
         }
       }

--- a/tools/regression/schema/review-result.schema.json
+++ b/tools/regression/schema/review-result.schema.json
@@ -142,9 +142,6 @@
       "properties": {
         "azurermLinter": {
           "type": "string"
-        },
-        "upstreamDrift": {
-          "type": "string"
         }
       }
     },

--- a/tools/regression/schema/review-result.schema.json
+++ b/tools/regression/schema/review-result.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wodansson.github.io/terraform-azurerm-ai-assisted-development/tools/regression/schema/review-result.schema.json",
+  "title": "AI Regression Review Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "caseId",
+    "runId",
+    "timestampUtc",
+    "task",
+    "pass",
+    "overallScore",
+    "scores",
+    "findings",
+    "severityChecks",
+    "scopeChecks",
+    "toolExecution",
+    "outputChecks",
+    "determinismChecks"
+  ],
+  "properties": {
+    "caseId": {
+      "type": "string"
+    },
+    "runId": {
+      "type": "string"
+    },
+    "timestampUtc": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "model": {
+      "type": "string"
+    },
+    "pass": {
+      "type": "boolean"
+    },
+    "overallScore": {
+      "type": "number"
+    },
+    "scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mustCatchRecall",
+        "falsePositiveControl",
+        "severityCorrectness",
+        "scopeAndToolCorrectness",
+        "outputCompliance",
+        "determinism"
+      ],
+      "properties": {
+        "mustCatchRecall": {
+          "type": "number"
+        },
+        "falsePositiveControl": {
+          "type": "number"
+        },
+        "severityCorrectness": {
+          "type": "number"
+        },
+        "scopeAndToolCorrectness": {
+          "type": "number"
+        },
+        "outputCompliance": {
+          "type": "number"
+        },
+        "determinism": {
+          "type": "number"
+        }
+      }
+    },
+    "findings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caught",
+        "missed",
+        "falsePositives"
+      ],
+      "properties": {
+        "caught": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "missed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "falsePositives": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "severityChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "matched",
+        "total"
+      ],
+      "properties": {
+        "matched": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "scopeChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ruleFamiliesAppliedCorrectly",
+        "toolingBehaviorCorrect"
+      ],
+      "properties": {
+        "ruleFamiliesAppliedCorrectly": {
+          "type": "boolean"
+        },
+        "toolingBehaviorCorrect": {
+          "type": "boolean"
+        }
+      }
+    },
+    "toolExecution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "azurermLinter": {
+          "type": "string"
+        },
+        "upstreamDrift": {
+          "type": "string"
+        }
+      }
+    },
+    "outputChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requiredSectionsPresent",
+        "requiredMarkersPresent"
+      ],
+      "properties": {
+        "requiredSectionsPresent": {
+          "type": "boolean"
+        },
+        "requiredMarkersPresent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "determinismChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "materiallyEquivalentAcrossRuns"
+      ],
+      "properties": {
+        "materiallyEquivalentAcrossRuns": {
+          "type": "boolean"
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/tools/regression/schema/run-manifest.schema.json
+++ b/tools/regression/schema/run-manifest.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wodansson.github.io/terraform-azurerm-ai-assisted-development/tools/regression/schema/run-manifest.schema.json",
+  "title": "AI Regression Run Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "runId",
+    "createdUtc",
+    "case",
+    "fixture",
+    "repositorySnapshot",
+    "inputs",
+    "capture",
+    "executionEnvelope",
+    "artifacts",
+    "commands",
+    "nextSteps"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 2
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "createdUtc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "task",
+        "status",
+        "casePath"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "casePath": {
+          "type": "string"
+        }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "sourcePath",
+        "materializedPath"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "sourcePath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "materializedPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "repositorySnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "headBranch",
+        "headCommit",
+        "worktreeHasChanges",
+        "worktreeHasUntrackedChanges"
+      ],
+      "properties": {
+        "headBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headCommit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "worktreeHasChanges": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "worktreeHasUntrackedChanges": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caseSnapshotPath",
+        "caseSnapshotSha256",
+        "weightsSnapshotPath",
+        "weightsSnapshotSha256"
+      ],
+      "properties": {
+        "caseSnapshotPath": {
+          "type": "string"
+        },
+        "caseSnapshotSha256": {
+          "type": "string"
+        },
+        "weightsSnapshotPath": {
+          "type": "string"
+        },
+        "weightsSnapshotSha256": {
+          "type": "string"
+        }
+      }
+    },
+    "capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionMetadataPath"
+      ],
+      "properties": {
+        "executionMetadataPath": {
+          "type": "string"
+        }
+      }
+    },
+    "executionEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "liveRepoStateRequired",
+        "captureStatus",
+        "modeledChangedFiles",
+        "modeledScopeNotes"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "liveRepoStateRequired": {
+          "type": "boolean"
+        },
+        "captureStatus": {
+          "type": "string"
+        },
+        "modeledChangedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "modeledScopeNotes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reviewOutputPath",
+        "resultOutputPath",
+        "manifestPath"
+      ],
+      "properties": {
+        "reviewOutputPath": {
+          "type": "string"
+        },
+        "resultOutputPath": {
+          "type": "string"
+        },
+        "manifestPath": {
+          "type": "string"
+        }
+      }
+    },
+    "commands": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hydrateExample",
+        "validate",
+        "score",
+        "previewExample"
+      ],
+      "properties": {
+        "hydrateExample": {
+          "type": "string"
+        },
+        "validate": {
+          "type": "string"
+        },
+        "score": {
+          "type": "string"
+        },
+        "previewExample": {
+          "type": "string"
+        }
+      }
+    },
+    "nextSteps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/tools/regression/score-regression-case.ps1
+++ b/tools/regression/score-regression-case.ps1
@@ -7,10 +7,19 @@ param(
 
     [string] $WeightsPath = (Join-Path $PSScriptRoot "config/score-weights.json"),
 
+    [ValidateSet("text", "json")]
+    [string] $Output = "text",
+
     [switch] $AsJson
 )
 
 $ErrorActionPreference = "Stop"
+
+if ($AsJson) {
+    $Output = "json"
+}
+
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") -CasePath $CasePath -ResultPath $ResultPath | Out-Null
 
 function Get-JsonFile {
     param([string] $Path)
@@ -145,7 +154,7 @@ $summary = [ordered]@{
     }
 }
 
-if ($AsJson) {
+if ($Output -eq "json") {
     $summary | ConvertTo-Json -Depth 10
     return
 }

--- a/tools/regression/score-regression-case.ps1
+++ b/tools/regression/score-regression-case.ps1
@@ -1,0 +1,163 @@
+param(
+    [Parameter(Mandatory)]
+    [string] $CasePath,
+
+    [Parameter(Mandatory)]
+    [string] $ResultPath,
+
+    [string] $WeightsPath = (Join-Path $PSScriptRoot "config/score-weights.json"),
+
+    [switch] $AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Get-PercentScore {
+    param(
+        [double] $Numerator,
+        [double] $Denominator
+    )
+
+    if ($Denominator -le 0) {
+        return 100.0
+    }
+
+    return [Math]::Round(($Numerator / $Denominator) * 100.0, 2)
+}
+
+function Get-BoolScore {
+    param([bool] $Value)
+    if ($Value) {
+        return 100.0
+    }
+
+    return 0.0
+}
+
+$case = Get-JsonFile -Path $CasePath
+$result = Get-JsonFile -Path $ResultPath
+$weights = Get-JsonFile -Path $WeightsPath
+
+if ($case.id -ne $result.caseId) {
+    throw "case id mismatch: case '$($case.id)' vs result '$($result.caseId)'"
+}
+
+if ($case.task -ne $result.task) {
+    throw "task mismatch: case '$($case.task)' vs result '$($result.task)'"
+}
+
+$mustCatchKeys = @($case.mustCatch | ForEach-Object { $_.key })
+$caughtKeys = @($result.findings.caught)
+$falsePositiveKeys = @($result.findings.falsePositives)
+
+$caughtMustCatchCount = @($caughtKeys | Where-Object { $mustCatchKeys -contains $_ } | Select-Object -Unique).Count
+$mustCatchRecall = Get-PercentScore -Numerator $caughtMustCatchCount -Denominator $mustCatchKeys.Count
+
+$mustNotFlagCount = @($case.mustNotFlag).Count
+$falsePositiveCount = @($falsePositiveKeys | Select-Object -Unique).Count
+$falsePositiveControl = if ($falsePositiveCount -eq 0) {
+    100.0
+}
+elseif ($mustNotFlagCount -gt 0) {
+    [Math]::Round([Math]::Max(0.0, 100.0 - (($falsePositiveCount / $mustNotFlagCount) * 100.0)), 2)
+}
+else {
+    0.0
+}
+
+$severityCorrectness = Get-PercentScore -Numerator $result.severityChecks.matched -Denominator $result.severityChecks.total
+
+$expectedToolChecks = @()
+foreach ($property in $case.expectedTools.PSObject.Properties) {
+    $actualValue = $result.toolExecution.PSObject.Properties[$property.Name].Value
+    $expectedToolChecks += [bool]($actualValue -eq $property.Value)
+}
+
+$toolExpectationScore = if ($expectedToolChecks.Count -eq 0) {
+    100.0
+}
+else {
+    Get-PercentScore -Numerator (@($expectedToolChecks | Where-Object { $_ }).Count) -Denominator $expectedToolChecks.Count
+}
+
+$scopeAndToolCorrectness = [Math]::Round((
+        (Get-BoolScore -Value $result.scopeChecks.ruleFamiliesAppliedCorrectly) +
+        (Get-BoolScore -Value $result.scopeChecks.toolingBehaviorCorrect) +
+        $toolExpectationScore
+    ) / 3.0, 2)
+
+$outputCompliance = [Math]::Round((
+        (Get-BoolScore -Value $result.outputChecks.requiredSectionsPresent) +
+        (Get-BoolScore -Value $result.outputChecks.requiredMarkersPresent)
+    ) / 2.0, 2)
+
+$determinism = Get-BoolScore -Value $result.determinismChecks.materiallyEquivalentAcrossRuns
+
+$weightedOverall = [Math]::Round((
+        ($mustCatchRecall * $weights.weights.mustCatchRecall) +
+        ($falsePositiveControl * $weights.weights.falsePositiveControl) +
+        ($severityCorrectness * $weights.weights.severityCorrectness) +
+        ($scopeAndToolCorrectness * $weights.weights.scopeAndToolCorrectness) +
+        ($outputCompliance * $weights.weights.outputCompliance) +
+        ($determinism * $weights.weights.determinism)
+    ) / 100.0, 2)
+
+$pass = $true
+if ($weightedOverall -lt $weights.passGuidance.minimumOverallScore) {
+    $pass = $false
+}
+
+if ($mustCatchRecall -lt $weights.passGuidance.minimumMustCatchRecall) {
+    $pass = $false
+}
+
+if (-not $weights.passGuidance.allowFalsePositives -and $falsePositiveCount -gt 0) {
+    $pass = $false
+}
+
+$summary = [ordered]@{
+    caseId = $case.id
+    task = $case.task
+    pass = $pass
+    overallScore = $weightedOverall
+    scores = [ordered]@{
+        mustCatchRecall = $mustCatchRecall
+        falsePositiveControl = $falsePositiveControl
+        severityCorrectness = $severityCorrectness
+        scopeAndToolCorrectness = $scopeAndToolCorrectness
+        outputCompliance = $outputCompliance
+        determinism = $determinism
+    }
+    counts = [ordered]@{
+        mustCatch = $mustCatchKeys.Count
+        caughtMustCatch = $caughtMustCatchCount
+        falsePositives = $falsePositiveCount
+    }
+}
+
+if ($AsJson) {
+    $summary | ConvertTo-Json -Depth 10
+    return
+}
+
+Write-Output "Regression score summary"
+Write-Output "  Case             : $($summary.caseId)"
+Write-Output "  Task             : $($summary.task)"
+Write-Output "  Pass             : $($summary.pass)"
+Write-Output "  Overall Score    : $($summary.overallScore)"
+Write-Output "  Must-catch Recall: $($summary.scores.mustCatchRecall)"
+Write-Output "  False Positives  : $($summary.scores.falsePositiveControl)"
+Write-Output "  Severity         : $($summary.scores.severityCorrectness)"
+Write-Output "  Scope/Tool       : $($summary.scores.scopeAndToolCorrectness)"
+Write-Output "  Output           : $($summary.scores.outputCompliance)"
+Write-Output "  Determinism      : $($summary.scores.determinism)"

--- a/tools/regression/summarize-regression-history.ps1
+++ b/tools/regression/summarize-regression-history.ps1
@@ -1,0 +1,196 @@
+param(
+    [string] $HistoryDirectory = (Join-Path $PSScriptRoot "results/history"),
+
+    [int] $Latest = 10,
+
+    [ValidateSet("text", "json")]
+    [string] $Output = "text"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Get-SnapshotFiles {
+    param([string] $HistoryDirectory)
+
+    if (-not (Test-Path -LiteralPath $HistoryDirectory)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $HistoryDirectory -Filter *.json | Sort-Object Name)
+}
+
+function Convert-ToCaseResultMap {
+    param($CaseResults)
+
+    $map = @{}
+    foreach ($caseResult in @($CaseResults)) {
+        $map[$caseResult.id] = $caseResult
+    }
+
+    return $map
+}
+
+$snapshotFiles = Get-SnapshotFiles -HistoryDirectory $HistoryDirectory
+if ($snapshotFiles.Count -eq 0) {
+    throw "no regression history snapshots found under $HistoryDirectory"
+}
+
+$schemaPath = Join-Path $PSScriptRoot "schema/history-snapshot.schema.json"
+$snapshots = @()
+foreach ($snapshotFile in $snapshotFiles) {
+    $content = Get-Content -LiteralPath $snapshotFile.FullName -Raw
+    $isValid = $content | Test-Json -SchemaFile $schemaPath
+    if (-not $isValid) {
+        throw "history snapshot schema validation failed: $($snapshotFile.FullName)"
+    }
+
+    $snapshot = $content | ConvertFrom-Json
+    $snapshots += [pscustomobject]@{
+        path = $snapshotFile.FullName
+        data = $snapshot
+    }
+}
+
+$orderedSnapshots = @($snapshots | Sort-Object { [DateTime]$_.data.createdUtc })
+$windowSnapshots = if ($Latest -gt 0 -and $orderedSnapshots.Count -gt $Latest) {
+    @($orderedSnapshots | Select-Object -Last $Latest)
+}
+else {
+    $orderedSnapshots
+}
+
+$latestSnapshot = $windowSnapshots[-1]
+$previousSnapshot = if ($windowSnapshots.Count -gt 1) { $windowSnapshots[-2] } else { $null }
+
+$regressions = @()
+$improvements = @()
+
+if ($previousSnapshot) {
+    $previousCaseResults = Convert-ToCaseResultMap -CaseResults $previousSnapshot.data.suite.caseResults
+    $latestCaseResults = Convert-ToCaseResultMap -CaseResults $latestSnapshot.data.suite.caseResults
+
+    $caseIds = @($previousCaseResults.Keys + $latestCaseResults.Keys | Sort-Object -Unique)
+    foreach ($caseId in $caseIds) {
+        if (-not $previousCaseResults.ContainsKey($caseId) -or -not $latestCaseResults.ContainsKey($caseId)) {
+            continue
+        }
+
+        $previousCase = $previousCaseResults[$caseId]
+        $latestCase = $latestCaseResults[$caseId]
+        $previousScore = if ($null -ne $previousCase.overallScore) { [double]$previousCase.overallScore } else { 0.0 }
+        $latestScore = if ($null -ne $latestCase.overallScore) { [double]$latestCase.overallScore } else { 0.0 }
+        $delta = [Math]::Round(($latestScore - $previousScore), 2)
+
+        if ($previousCase.scored -and $latestCase.scored) {
+            if (($previousCase.pass -and -not $latestCase.pass) -or $delta -lt 0) {
+                $regressions += [pscustomobject]@{
+                    caseId = $caseId
+                    previousPass = [bool]$previousCase.pass
+                    latestPass = [bool]$latestCase.pass
+                    previousScore = $previousScore
+                    latestScore = $latestScore
+                    delta = $delta
+                }
+            }
+            elseif ((-not $previousCase.pass -and $latestCase.pass) -or $delta -gt 0) {
+                $improvements += [pscustomobject]@{
+                    caseId = $caseId
+                    previousPass = [bool]$previousCase.pass
+                    latestPass = [bool]$latestCase.pass
+                    previousScore = $previousScore
+                    latestScore = $latestScore
+                    delta = $delta
+                }
+            }
+        }
+    }
+}
+
+$summary = [ordered]@{
+    snapshotCount = $orderedSnapshots.Count
+    windowCount = $windowSnapshots.Count
+    latestSnapshot = [ordered]@{
+        snapshotId = $latestSnapshot.data.snapshotId
+        createdUtc = $latestSnapshot.data.createdUtc
+        headBranch = $latestSnapshot.data.repositorySnapshot.headBranch
+        headCommit = $latestSnapshot.data.repositorySnapshot.headCommit
+        metrics = $latestSnapshot.data.metrics
+    }
+    previousSnapshot = if ($previousSnapshot) {
+        [ordered]@{
+            snapshotId = $previousSnapshot.data.snapshotId
+            createdUtc = $previousSnapshot.data.createdUtc
+            headBranch = $previousSnapshot.data.repositorySnapshot.headBranch
+            headCommit = $previousSnapshot.data.repositorySnapshot.headCommit
+            metrics = $previousSnapshot.data.metrics
+        }
+    }
+    else {
+        $null
+    }
+    deltas = if ($previousSnapshot) {
+        [ordered]@{
+            averageOverallScore = [Math]::Round(([double]$latestSnapshot.data.metrics.averageOverallScore - [double]$previousSnapshot.data.metrics.averageOverallScore), 2)
+            passRate = [Math]::Round(([double]$latestSnapshot.data.metrics.passRate - [double]$previousSnapshot.data.metrics.passRate), 2)
+            selectedCaseCount = [int]$latestSnapshot.data.metrics.selectedCaseCount - [int]$previousSnapshot.data.metrics.selectedCaseCount
+        }
+    }
+    else {
+        $null
+    }
+    regressions = $regressions
+    improvements = $improvements
+    latestCoverage = $latestSnapshot.data.suite.targetSkillCoverage
+}
+
+if ($Output -eq "json") {
+    $summary | ConvertTo-Json -Depth 20
+    return
+}
+
+Write-Output "Regression history summary"
+Write-Output "  Snapshot Count   : $($summary.snapshotCount)"
+Write-Output "  Window Count     : $($summary.windowCount)"
+Write-Output "  Latest Snapshot  : $($summary.latestSnapshot.snapshotId)"
+Write-Output "  Latest Avg Score : $($summary.latestSnapshot.metrics.averageOverallScore)"
+Write-Output "  Latest Pass Rate : $($summary.latestSnapshot.metrics.passRate)"
+if ($summary.previousSnapshot) {
+    Write-Output "  Previous Snapshot: $($summary.previousSnapshot.snapshotId)"
+    Write-Output "  Avg Score Delta  : $($summary.deltas.averageOverallScore)"
+    Write-Output "  Pass Rate Delta  : $($summary.deltas.passRate)"
+}
+else {
+    Write-Output "  Previous Snapshot: none"
+}
+
+Write-Output ""
+Write-Output "Regressions"
+if ($summary.regressions.Count -eq 0) {
+    Write-Output "  None"
+}
+else {
+    foreach ($regression in $summary.regressions) {
+        Write-Output "  $($regression.caseId): $($regression.previousScore) -> $($regression.latestScore)"
+    }
+}
+
+Write-Output ""
+Write-Output "Improvements"
+if ($summary.improvements.Count -eq 0) {
+    Write-Output "  None"
+}
+else {
+    foreach ($improvement in $summary.improvements) {
+        Write-Output "  $($improvement.caseId): $($improvement.previousScore) -> $($improvement.latestScore)"
+    }
+}

--- a/tools/regression/test/README.md
+++ b/tools/regression/test/README.md
@@ -1,0 +1,65 @@
+# Regression Test
+
+This directory stores contributor-facing HCL test specs for the regression harness.
+
+Terraform contributors should be able to read this directory as the harness equivalent of an acceptance-test surface: author one HCL test spec here, then let the scaffolding tools generate the internal JSON and Markdown artifacts.
+
+The accepted blocks, fields, and enum values for this DSL are codified in `tools/regression/test/TestSpecDefinition.ps1`.
+
+The canonical form uses real nested HCL inside `test_case { config { ... } }`.
+
+## Minimal Shape
+
+```hcl
+AccTest "example-case" "basic" {
+  title       = "Example benchmark title"
+
+  test_case {
+    task        = "resource-implementation"
+    source_kind = "real-pr"
+    case_status = "planned"
+    notes       = "Optional scope notes."
+
+    changed_files = [
+      "internal/services/example/example_resource.go",
+    ]
+
+    config {
+      resource "azurerm_example_resource" "test" {
+        name = "example"
+      }
+    }
+  }
+
+  rules {
+    description           = "Plain-language scenario description."
+    notes                 = "Optional maintainer notes."
+    include_sample_output = false
+
+    must_catch {
+      description = "Prefer stronger validation when the accepted values are knowable."
+      severity    = "medium"
+      file        = "internal/services/example/example_resource.go"
+    }
+
+    must_not_flag {
+      description = "Do not invent unsupported schema constraints."
+    }
+  }
+}
+```
+
+## Shape Notes
+
+- `AccTest "case-id" "run-name"` is the canonical top-level block for this DSL.
+- `test_case` holds the benchmark metadata and the test configuration in one normal HCL section instead of hanging them off a synthetic runner block.
+- The second top-level label carries the run name, so the inner `test_case` and `rules` blocks stay unlabeled.
+- `config` lives under `test_case` and holds real nested HCL blocks instead of wrapping Terraform configuration in a string attribute.
+- `rules` describes what that named config should or should not trigger in the harness result.
+
+## Build Flow
+
+1. Create a template with `new-regression-test.ps1` or write the HCL test manually.
+2. Materialize the internal harness artifacts with `build-regression-test.ps1 -SpecPath ...`.
+3. Review and refine the generated drafts.
+4. Promote the reviewed drafts with `publish-regression-test.ps1`.

--- a/tools/regression/test/TestSpecDefinition.ps1
+++ b/tools/regression/test/TestSpecDefinition.ps1
@@ -1,0 +1,50 @@
+function Get-RegressionTestDefinition {
+    return [ordered]@{
+        rootBlocks = @("AccTest")
+        defaultRootBlock = "AccTest"
+        defaultRootSecondaryLabel = "basic"
+        defaultRunName = "basic"
+        enums = [ordered]@{
+            task = @(
+                "code-review-local-changes",
+                "code-review-committed-changes",
+                "code-review-docs",
+                "docs-writer",
+                "resource-implementation",
+                "acceptance-testing"
+            )
+            sourceKind = @("real-pr", "local-diff", "synthetic")
+            caseStatus = @("planned", "ready", "adjudicated", "retired")
+            severity = @("low", "medium", "high")
+        }
+        allowedFields = [ordered]@{
+            root = @("title")
+            test_case = @("task", "source_kind", "case_status", "changed_files", "notes")
+            config = @()
+            rules = @("description", "notes", "include_sample_output")
+            must_catch = @("description", "severity", "file")
+            must_not_flag = @("description")
+        }
+    }
+}
+
+function Assert-RegressionTestAllowedValue {
+    param(
+        $Definition,
+        [string] $EnumName,
+        [string] $Value,
+        [string] $Context
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return
+    }
+
+    if ($Definition.enums.Keys -notcontains $EnumName) {
+        throw "unknown regression test enum '$EnumName'"
+    }
+
+    if ($Definition.enums[$EnumName] -notcontains $Value) {
+        throw "$Context must be one of: $($Definition.enums[$EnumName] -join ', ')"
+    }
+}

--- a/tools/regression/validate-regression-artifacts.ps1
+++ b/tools/regression/validate-regression-artifacts.ps1
@@ -1,0 +1,153 @@
+param(
+    [string[]] $CasePath,
+
+    [string[]] $ResultPath,
+
+    [string] $CasesDirectory = (Join-Path $PSScriptRoot "cases"),
+
+    [string] $ExamplesDirectory = (Join-Path $PSScriptRoot "examples"),
+
+    [string] $CaseSchemaPath = (Join-Path $PSScriptRoot "schema/review-case.schema.json"),
+
+    [string] $ResultSchemaPath = (Join-Path $PSScriptRoot "schema/review-result.schema.json"),
+
+    [ValidateSet("text", "json")]
+    [string] $Output = "text",
+
+    [switch] $AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($AsJson) {
+    $Output = "json"
+}
+
+function Expand-ListParameter {
+    param([string[]] $Value)
+
+    $expanded = @()
+    foreach ($entry in $Value) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        $expanded += @($entry -split "," | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    return @($expanded | Select-Object -Unique)
+}
+
+function Resolve-ArtifactPaths {
+    param(
+        [string[]] $ExplicitPaths,
+        [string] $DefaultDirectory,
+        [string] $Filter
+    )
+
+    if ($ExplicitPaths.Count -gt 0) {
+        return @($ExplicitPaths | ForEach-Object { (Resolve-Path -LiteralPath $_).Path } | Select-Object -Unique)
+    }
+
+    if (-not (Test-Path -LiteralPath $DefaultDirectory)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $DefaultDirectory -Filter $Filter | Sort-Object Name | ForEach-Object { $_.FullName })
+}
+
+function Get-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Test-JsonSchemaFile {
+    param(
+        [string] $Path,
+        [string] $SchemaPath,
+        [string] $Kind
+    )
+
+    $content = Get-Content -LiteralPath $Path -Raw
+    $isValid = $content | Test-Json -SchemaFile $SchemaPath
+    if (-not $isValid) {
+        throw "$Kind schema validation failed: $Path"
+    }
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$CasePath = Expand-ListParameter -Value $CasePath
+$ResultPath = Expand-ListParameter -Value $ResultPath
+
+$resolvedCasePaths = Resolve-ArtifactPaths -ExplicitPaths $CasePath -DefaultDirectory $CasesDirectory -Filter *.json
+$resolvedResultPaths = Resolve-ArtifactPaths -ExplicitPaths $ResultPath -DefaultDirectory $ExamplesDirectory -Filter *.result.json
+
+$validatedCases = @{}
+$validatedResults = @()
+
+foreach ($casePathItem in $resolvedCasePaths) {
+    Test-JsonSchemaFile -Path $casePathItem -SchemaPath $CaseSchemaPath -Kind "case file"
+    $case = Get-JsonFile -Path $casePathItem
+
+    if ($validatedCases.ContainsKey($case.id)) {
+        throw "duplicate case id '$($case.id)' found in '$casePathItem'"
+    }
+
+    if ($case.fixture.mode -ne "none" -and [string]::IsNullOrWhiteSpace($case.fixture.path)) {
+        throw "case file '$casePathItem' requires fixture.path when fixture.mode is '$($case.fixture.mode)'"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($case.fixture.path)) {
+        $fixtureAbsolutePath = Join-Path $repoRoot $case.fixture.path
+        if (-not (Test-Path -LiteralPath $fixtureAbsolutePath)) {
+            throw "fixture path not found for case '$($case.id)': $fixtureAbsolutePath"
+        }
+    }
+
+    $validatedCases[$case.id] = [pscustomobject]@{
+        definition = $case
+        path = $casePathItem
+    }
+}
+
+foreach ($resultPathItem in $resolvedResultPaths) {
+    Test-JsonSchemaFile -Path $resultPathItem -SchemaPath $ResultSchemaPath -Kind "result file"
+    $result = Get-JsonFile -Path $resultPathItem
+
+    if (-not $validatedCases.ContainsKey($result.caseId)) {
+        throw "result file '$resultPathItem' references unknown case id '$($result.caseId)'"
+    }
+
+    $matchingCase = $validatedCases[$result.caseId].definition
+    if ($matchingCase.task -ne $result.task) {
+        throw "result file '$resultPathItem' task '$($result.task)' does not match case '$($matchingCase.id)' task '$($matchingCase.task)'"
+    }
+
+    $validatedResults += [pscustomobject]@{
+        caseId = $result.caseId
+        path = $resultPathItem
+    }
+}
+
+$summary = [ordered]@{
+    caseFileCount = $resolvedCasePaths.Count
+    resultFileCount = $resolvedResultPaths.Count
+    validatedCaseIds = @($validatedCases.Keys | Sort-Object)
+    validatedResultCaseIds = @($validatedResults | ForEach-Object { $_.caseId } | Sort-Object -Unique)
+}
+
+if ($Output -eq "json") {
+    $summary | ConvertTo-Json -Depth 10
+    return
+}
+
+Write-Output "Regression artifact validation summary"
+Write-Output "  Case Files       : $($summary.caseFileCount)"
+Write-Output "  Result Files     : $($summary.resultFileCount)"
+Write-Output "  Validated Cases  : $(if ($summary.validatedCaseIds.Count -gt 0) { $summary.validatedCaseIds -join ', ' } else { 'none' })"
+Write-Output "  Validated Results: $(if ($summary.validatedResultCaseIds.Count -gt 0) { $summary.validatedResultCaseIds -join ', ' } else { 'none' })"

--- a/tools/regression/write-regression-history-snapshot.ps1
+++ b/tools/regression/write-regression-history-snapshot.ps1
@@ -1,0 +1,165 @@
+param(
+    [string[]] $Task,
+
+    [string[]] $CaseStatus = @("adjudicated"),
+
+    [string] $HistoryDirectory = (Join-Path $PSScriptRoot "results/history"),
+
+    [string] $OutputPath,
+
+    [ValidateSet("text", "json")]
+    [string] $Output = "text"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Expand-ListParameter {
+    param([string[]] $Value)
+
+    $expanded = @()
+    foreach ($entry in $Value) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        $expanded += @($entry -split "," | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    return @($expanded | Select-Object -Unique)
+}
+
+function Initialize-Directory {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Get-RepositorySnapshot {
+    param([string] $RepoRoot)
+
+    $snapshot = [ordered]@{
+        headBranch = $null
+        headCommit = $null
+        worktreeHasChanges = $null
+        worktreeHasUntrackedChanges = $null
+    }
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return $snapshot
+    }
+
+    try {
+        $snapshot.headCommit = (& git -C $RepoRoot rev-parse HEAD).Trim()
+    }
+    catch {
+    }
+
+    try {
+        $snapshot.headBranch = (& git -C $RepoRoot rev-parse --abbrev-ref HEAD).Trim()
+    }
+    catch {
+    }
+
+    try {
+        $statusLines = @(& git -C $RepoRoot status --porcelain)
+        $snapshot.worktreeHasChanges = $statusLines.Count -gt 0
+        $snapshot.worktreeHasUntrackedChanges = @($statusLines | Where-Object { $_ -like '??*' }).Count -gt 0
+    }
+    catch {
+    }
+
+    return $snapshot
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$Task = Expand-ListParameter -Value $Task
+$CaseStatus = Expand-ListParameter -Value $CaseStatus
+
+$suiteArguments = @{}
+if ($Task.Count -gt 0) {
+    $suiteArguments.Task = $Task
+}
+if ($CaseStatus.Count -gt 0) {
+    $suiteArguments.CaseStatus = $CaseStatus
+}
+
+$suiteSummary = & pwsh -NoProfile -File (Join-Path $PSScriptRoot "run-regression-suite.ps1") @suiteArguments -Output json | ConvertFrom-Json
+$repositorySnapshot = Get-RepositorySnapshot -RepoRoot $repoRoot
+
+$scoredCases = @($suiteSummary.caseResults | Where-Object { $_.scored })
+$passCount = @($scoredCases | Where-Object { $_.pass }).Count
+$failCount = @($scoredCases | Where-Object { -not $_.pass }).Count
+$scoreValues = @($scoredCases | ForEach-Object { [double]$_.overallScore })
+$averageOverallScore = if ($scoreValues.Count -gt 0) { [Math]::Round((($scoreValues | Measure-Object -Average).Average), 2) } else { 0.0 }
+$minimumOverallScore = if ($scoreValues.Count -gt 0) { [Math]::Round((($scoreValues | Measure-Object -Minimum).Minimum), 2) } else { 0.0 }
+$maximumOverallScore = if ($scoreValues.Count -gt 0) { [Math]::Round((($scoreValues | Measure-Object -Maximum).Maximum), 2) } else { 0.0 }
+$passRate = if ($scoredCases.Count -gt 0) { [Math]::Round(($passCount / $scoredCases.Count) * 100.0, 2) } else { 0.0 }
+$coveredSkillCount = @($suiteSummary.targetSkillCoverage | Where-Object { $_.status -eq "covered" }).Count
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$commitSuffix = if (-not [string]::IsNullOrWhiteSpace($repositorySnapshot.headCommit)) {
+    $repositorySnapshot.headCommit.Substring(0, [Math]::Min(8, $repositorySnapshot.headCommit.Length))
+}
+else {
+    "local"
+}
+$snapshotId = "$timestamp-$commitSuffix"
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    Initialize-Directory -Path $HistoryDirectory
+    $OutputPath = Join-Path $HistoryDirectory ($snapshotId + ".json")
+}
+else {
+    $outputDirectory = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+        Initialize-Directory -Path $outputDirectory
+    }
+}
+
+$snapshot = [ordered]@{
+    version = 1
+    snapshotId = $snapshotId
+    createdUtc = [DateTime]::UtcNow.ToString("o")
+    repositorySnapshot = $repositorySnapshot
+    filters = [ordered]@{
+        task = @($Task)
+        caseStatus = @($CaseStatus)
+    }
+    metrics = [ordered]@{
+        selectedCaseCount = [int]$suiteSummary.selectedCaseCount
+        scoredCaseCount = [int]$suiteSummary.scoredCaseCount
+        passCount = $passCount
+        failCount = $failCount
+        skippedCaseCount = [int]$suiteSummary.skippedCaseCount
+        passRate = $passRate
+        averageOverallScore = $averageOverallScore
+        minimumOverallScore = $minimumOverallScore
+        maximumOverallScore = $maximumOverallScore
+        coveredSkillCount = $coveredSkillCount
+    }
+    suite = $suiteSummary
+}
+
+$snapshot | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $OutputPath
+
+$schemaPath = Join-Path $PSScriptRoot "schema/history-snapshot.schema.json"
+$isValid = (Get-Content -LiteralPath $OutputPath -Raw) | Test-Json -SchemaFile $schemaPath
+if (-not $isValid) {
+    throw "generated regression history snapshot failed schema validation: $OutputPath"
+}
+
+if ($Output -eq "json") {
+    $snapshot | ConvertTo-Json -Depth 20
+    return
+}
+
+Write-Output "Regression history snapshot created"
+Write-Output "  Snapshot ID      : $snapshotId"
+Write-Output "  Output Path      : $OutputPath"
+Write-Output "  Selected Cases   : $($snapshot.metrics.selectedCaseCount)"
+Write-Output "  Scored Cases     : $($snapshot.metrics.scoredCaseCount)"
+Write-Output "  Pass Count       : $($snapshot.metrics.passCount)"
+Write-Output "  Fail Count       : $($snapshot.metrics.failCount)"
+Write-Output "  Average Score    : $($snapshot.metrics.averageOverallScore)"

--- a/tools/validate-ai-toolkit.ps1
+++ b/tools/validate-ai-toolkit.ps1
@@ -1,0 +1,336 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Text', 'Json')]
+    [string]$OutputFormat = 'Text',
+
+    [switch]$SkipChangelog,
+
+    [switch]$ChangelogNotRequired,
+
+    [string]$ChangelogReason,
+
+    [switch]$SkipRegressionHarness,
+
+    [switch]$SkipUpstreamDrift,
+
+    [switch]$AllowCatalogIssues,
+
+    [switch]$AllowDrift
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$contractsScriptPath = Join-Path $PSScriptRoot 'validate-contracts.ps1'
+$driftScriptPath = Join-Path $PSScriptRoot 'check-upstream-contributor-drift.ps1'
+$regressionHarnessScriptPath = Join-Path $PSScriptRoot 'regression/run-regression-harness.ps1'
+$changelogPath = Join-Path $repoRoot 'CHANGELOG.md'
+
+$npxCommand = Get-Command 'npx.cmd' -ErrorAction SilentlyContinue
+if ($null -eq $npxCommand) {
+    $npxCommand = Get-Command 'npx' -ErrorAction SilentlyContinue
+}
+
+$gitCommand = Get-Command 'git' -ErrorAction SilentlyContinue
+
+function Invoke-ValidationStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Command,
+
+        [string]$Detail,
+
+        [switch]$Skipped
+    )
+
+    if ($Skipped) {
+        return [pscustomobject]@{
+            name = $Name
+            status = 'skipped'
+            success = $true
+            exitCode = 0
+            durationSeconds = 0
+            detail = $Detail
+            output = ''
+        }
+    }
+
+    $started = Get-Date
+    $outputLines = @()
+    $exitCode = 0
+
+    try {
+        $global:LASTEXITCODE = 0
+        $outputLines = & $Command 2>&1
+        $exitCode = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 0 }
+    }
+    catch {
+        $outputLines = @($_)
+        $exitCode = 1
+    }
+
+    $durationSeconds = [Math]::Round(((Get-Date) - $started).TotalSeconds, 2)
+    $outputText = ($outputLines | Out-String).Trim()
+
+    return [pscustomobject]@{
+        name = $Name
+        status = if ($exitCode -eq 0) { 'passed' } else { 'failed' }
+        success = ($exitCode -eq 0)
+        exitCode = $exitCode
+        durationSeconds = $durationSeconds
+        detail = $Detail
+        output = $outputText
+    }
+}
+
+function Get-TextMatchValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern
+    )
+
+    $match = [regex]::Match($Text, $Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return $match.Groups[1].Value
+}
+
+function Get-ChangedRepositoryPaths {
+    param([string]$RepoRoot)
+
+    if ($null -eq $gitCommand) {
+        return @()
+    }
+
+    $paths = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+
+    try {
+        $statusLines = @(& $gitCommand.Source -C $RepoRoot status --porcelain)
+        foreach ($statusLine in $statusLines) {
+            if ([string]::IsNullOrWhiteSpace($statusLine) -or $statusLine.Length -lt 4) {
+                continue
+            }
+
+            $pathValue = $statusLine.Substring(3).Trim()
+            if ($pathValue -match ' -> ') {
+                $pathValue = ($pathValue -split ' -> ')[-1]
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($pathValue)) {
+                [void]$paths.Add($pathValue.Replace('\', '/'))
+            }
+        }
+    }
+    catch {
+    }
+
+    $candidateRefs = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
+        $candidateRefs += @("origin/$($env:GITHUB_BASE_REF)", $env:GITHUB_BASE_REF)
+    }
+    $candidateRefs += @('origin/main', 'upstream/main', 'main')
+    $candidateRefs = @($candidateRefs | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    foreach ($candidateRef in $candidateRefs) {
+        try {
+            & $gitCommand.Source -C $RepoRoot rev-parse --verify $candidateRef *> $null
+            $diffPaths = @(& $gitCommand.Source -C $RepoRoot diff --name-only "$candidateRef...HEAD")
+            foreach ($diffPath in $diffPaths) {
+                if (-not [string]::IsNullOrWhiteSpace($diffPath)) {
+                    [void]$paths.Add($diffPath.Replace('\', '/'))
+                }
+            }
+            break
+        }
+        catch {
+        }
+    }
+
+    return @($paths | Sort-Object)
+}
+
+function Test-PathMatchesAnyPattern {
+    param(
+        [string]$Path,
+        [string[]]$Patterns
+    )
+
+    foreach ($pattern in $Patterns) {
+        if ($Path -like $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+Push-Location $repoRoot
+try {
+    $steps = @()
+
+    $steps += Invoke-ValidationStep -Name 'changelog' -Detail 'Confirm the current branch has an explicit changelog decision: either CHANGELOG.md is updated or a maintainer explicitly marks the branch as changelog-not-required.' -Skipped:$SkipChangelog -Command {
+        if ($null -eq $gitCommand) {
+            Write-Output 'git not found on PATH; changelog alignment could not be evaluated'
+            return
+        }
+
+        $changedPaths = @(Get-ChangedRepositoryPaths -RepoRoot $repoRoot)
+        if ($changedPaths.Count -eq 0) {
+            Write-Output 'No branch changes detected; changelog validation is not applicable.'
+            return
+        }
+
+        if ($changedPaths -contains 'CHANGELOG.md') {
+            Write-Output 'CHANGELOG.md is updated for the current branch.'
+            return
+        }
+
+        if ($ChangelogNotRequired) {
+            if ([string]::IsNullOrWhiteSpace($ChangelogReason)) {
+                throw 'ChangelogNotRequired was specified without ChangelogReason'
+            }
+
+            Write-Output ("Explicit changelog waiver recorded for current branch changes: {0}" -f $ChangelogReason.Trim())
+            return
+        }
+
+        throw 'CHANGELOG.md is not updated for the current branch. Update CHANGELOG.md or rerun with -ChangelogNotRequired -ChangelogReason "<reason>".'
+    }
+
+    $steps += Invoke-ValidationStep -Name 'contracts' -Detail 'Validate AI-toolkit contracts, companion guidance, and consumer wiring.' -Command {
+        & pwsh -NoProfile -File $contractsScriptPath
+    }
+
+    $steps += Invoke-ValidationStep -Name 'markdown' -Detail 'Lint .github, docs, and CHANGELOG markdown using the repo markdownlint configuration.' -Command {
+        if ($null -eq $npxCommand) {
+            throw 'npx was not found on PATH'
+        }
+
+        & $npxCommand.Source -y markdownlint-cli2 '.github/**/*.md' 'docs/**/*.md' 'CHANGELOG.md' --config '.github/.markdownlint.json'
+    }
+
+    $steps += Invoke-ValidationStep -Name 'regression-harness' -Detail 'Run the regression harness validation, suite scoring, and history snapshot flow.' -Skipped:$SkipRegressionHarness -Command {
+        & pwsh -NoProfile -File $regressionHarnessScriptPath
+    }
+
+    $driftArguments = @(
+        '-NoProfile',
+        '-File',
+        $driftScriptPath,
+        '-OutputFormat',
+        'Text'
+    )
+    if (-not $AllowDrift -and -not $AllowCatalogIssues) {
+        $driftArguments += '-FailOnDrift'
+    }
+
+    $steps += Invoke-ValidationStep -Name 'upstream-drift' -Detail 'Check tracked upstream contributor guidance drift and explicit topic coverage.' -Skipped:$SkipUpstreamDrift -Command {
+        & pwsh @driftArguments
+    }
+
+    $driftStep = @($steps | Where-Object { $_.name -eq 'upstream-drift' })[0]
+    if ($driftStep.status -ne 'skipped') {
+        $driftChangedSources = [int](Get-TextMatchValue -Text $driftStep.output -Pattern 'Changed:\s*([0-9]+)')
+        $driftCatalogIssues = [int](Get-TextMatchValue -Text $driftStep.output -Pattern 'Catalog Issues:\s*([0-9]+)')
+        $driftRuleIssues = [int](Get-TextMatchValue -Text $driftStep.output -Pattern 'Rule Issues:\s*([0-9]+)')
+
+        $hasBlockingDrift = $driftChangedSources -gt 0 -or $driftRuleIssues -gt 0
+        if (-not $AllowCatalogIssues) {
+            $hasBlockingDrift = $hasBlockingDrift -or $driftCatalogIssues -gt 0
+        }
+
+        if (-not $AllowDrift -and $hasBlockingDrift) {
+            $driftStep.status = 'failed'
+            $driftStep.success = $false
+            $driftStep.exitCode = 1
+            if ($AllowCatalogIssues -and $driftCatalogIssues -gt 0 -and -not ($driftChangedSources -gt 0 -or $driftRuleIssues -gt 0)) {
+                $driftStep.detail = 'Check tracked upstream contributor guidance drift and explicit topic coverage. Changed sources and rule issues are clean; unresolved catalog coverage still requires separate maintainer review.'
+            }
+            else {
+                $driftStep.detail = 'Check tracked upstream contributor guidance drift and explicit topic coverage. Unresolved drift requires maintainer review.'
+            }
+        }
+    }
+
+    $overallSuccess = @($steps | Where-Object { -not $_.success }).Count -eq 0
+    $regressionStep = @($steps | Where-Object { $_.name -eq 'regression-harness' })[0]
+
+    $summary = [ordered]@{
+        overallStatus = if ($overallSuccess) { 'passed' } else { 'failed' }
+        repoRoot = $repoRoot
+        steps = $steps
+        highlights = [ordered]@{
+            changelogStatus = @($steps | Where-Object { $_.name -eq 'changelog' })[0].status
+            regressionCasesSelected = if ($regressionStep.status -eq 'passed') { Get-TextMatchValue -Text $regressionStep.output -Pattern 'Cases Selected\s*:\s*([0-9]+)' } else { $null }
+            regressionCasesScored = if ($regressionStep.status -eq 'passed') { Get-TextMatchValue -Text $regressionStep.output -Pattern 'Cases Scored\s*:\s*([0-9]+)' } else { $null }
+            upstreamChangedSources = if ($driftStep.status -ne 'skipped') { Get-TextMatchValue -Text $driftStep.output -Pattern 'Changed:\s*([0-9]+)' } else { $null }
+            upstreamCatalogIssues = if ($driftStep.status -ne 'skipped') { Get-TextMatchValue -Text $driftStep.output -Pattern 'Catalog Issues:\s*([0-9]+)' } else { $null }
+            upstreamRuleIssues = if ($driftStep.status -ne 'skipped') { Get-TextMatchValue -Text $driftStep.output -Pattern 'Rule Issues:\s*([0-9]+)' } else { $null }
+        }
+    }
+
+    if ($OutputFormat -eq 'Json') {
+        $summary | ConvertTo-Json -Depth 10
+    }
+    else {
+        Write-Output "AI toolkit validation summary"
+        Write-Output "  Overall Status   : $($summary.overallStatus)"
+        Write-Output "  Repository Root  : $repoRoot"
+        Write-Output ""
+        Write-Output "Validation steps"
+        foreach ($step in $steps) {
+            Write-Output "  $($step.name): $($step.status) ($($step.durationSeconds)s)"
+            if (-not [string]::IsNullOrWhiteSpace($step.detail)) {
+                Write-Output "    $($step.detail)"
+            }
+        }
+
+        Write-Output ""
+        Write-Output "Highlights"
+        if ($null -ne $summary.highlights.changelogStatus) {
+            Write-Output "  Changelog Status         : $($summary.highlights.changelogStatus)"
+        }
+        if ($null -ne $summary.highlights.regressionCasesSelected) {
+            Write-Output "  Regression Cases Selected : $($summary.highlights.regressionCasesSelected)"
+        }
+        if ($null -ne $summary.highlights.regressionCasesScored) {
+            Write-Output "  Regression Cases Scored   : $($summary.highlights.regressionCasesScored)"
+        }
+        if ($null -ne $summary.highlights.upstreamChangedSources) {
+            Write-Output "  Upstream Changed Sources  : $($summary.highlights.upstreamChangedSources)"
+        }
+        if ($null -ne $summary.highlights.upstreamCatalogIssues) {
+            Write-Output "  Upstream Catalog Issues   : $($summary.highlights.upstreamCatalogIssues)"
+        }
+        if ($null -ne $summary.highlights.upstreamRuleIssues) {
+            Write-Output "  Upstream Rule Issues      : $($summary.highlights.upstreamRuleIssues)"
+        }
+
+        if (-not $overallSuccess) {
+            Write-Output ""
+            Write-Output "Failures"
+            foreach ($failedStep in @($steps | Where-Object { -not $_.success })) {
+                Write-Output "  [$($failedStep.name)] exit=$($failedStep.exitCode)"
+                if (-not [string]::IsNullOrWhiteSpace($failedStep.output)) {
+                    Write-Output $failedStep.output
+                }
+            }
+        }
+    }
+
+    if (-not $overallSuccess) {
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+}

--- a/tools/validate-ai-toolkit.ps1
+++ b/tools/validate-ai-toolkit.ps1
@@ -25,7 +25,6 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $contractsScriptPath = Join-Path $PSScriptRoot 'validate-contracts.ps1'
 $driftScriptPath = Join-Path $PSScriptRoot 'check-upstream-contributor-drift.ps1'
 $regressionHarnessScriptPath = Join-Path $PSScriptRoot 'regression/run-regression-harness.ps1'
-$changelogPath = Join-Path $repoRoot 'CHANGELOG.md'
 
 $npxCommand = Get-Command 'npx.cmd' -ErrorAction SilentlyContinue
 if ($null -eq $npxCommand) {
@@ -104,6 +103,37 @@ function Get-TextMatchValue {
     return $match.Groups[1].Value
 }
 
+function Invoke-GitCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [switch]$AllowFailure
+    )
+
+    if ($null -eq $gitCommand) {
+        return $null
+    }
+
+    $global:LASTEXITCODE = 0
+    $output = @(& $gitCommand.Source -C $RepoRoot @Arguments 2>$null)
+    $exitCode = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 0 }
+    $global:LASTEXITCODE = 0
+
+    if ($exitCode -ne 0) {
+        if ($AllowFailure) {
+            return $null
+        }
+
+        throw ("git command failed ({0}): git -C {1} {2}" -f $exitCode, $RepoRoot, ($Arguments -join ' '))
+    }
+
+    return $output
+}
+
 function Get-ChangedRepositoryPaths {
     param([string]$RepoRoot)
 
@@ -113,24 +143,20 @@ function Get-ChangedRepositoryPaths {
 
     $paths = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 
-    try {
-        $statusLines = @(& $gitCommand.Source -C $RepoRoot status --porcelain)
-        foreach ($statusLine in $statusLines) {
-            if ([string]::IsNullOrWhiteSpace($statusLine) -or $statusLine.Length -lt 4) {
-                continue
-            }
-
-            $pathValue = $statusLine.Substring(3).Trim()
-            if ($pathValue -match ' -> ') {
-                $pathValue = ($pathValue -split ' -> ')[-1]
-            }
-
-            if (-not [string]::IsNullOrWhiteSpace($pathValue)) {
-                [void]$paths.Add($pathValue.Replace('\', '/'))
-            }
+    $statusLines = @(Invoke-GitCommand -RepoRoot $RepoRoot -Arguments @('status', '--porcelain') -AllowFailure)
+    foreach ($statusLine in $statusLines) {
+        if ([string]::IsNullOrWhiteSpace($statusLine) -or $statusLine.Length -lt 4) {
+            continue
         }
-    }
-    catch {
+
+        $pathValue = $statusLine.Substring(3).Trim()
+        if ($pathValue -match ' -> ') {
+            $pathValue = ($pathValue -split ' -> ')[-1]
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($pathValue)) {
+            [void]$paths.Add($pathValue.Replace('\', '/'))
+        }
     }
 
     $candidateRefs = @()
@@ -141,36 +167,26 @@ function Get-ChangedRepositoryPaths {
     $candidateRefs = @($candidateRefs | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 
     foreach ($candidateRef in $candidateRefs) {
-        try {
-            & $gitCommand.Source -C $RepoRoot rev-parse --verify $candidateRef *> $null
-            $diffPaths = @(& $gitCommand.Source -C $RepoRoot diff --name-only "$candidateRef...HEAD")
-            foreach ($diffPath in $diffPaths) {
-                if (-not [string]::IsNullOrWhiteSpace($diffPath)) {
-                    [void]$paths.Add($diffPath.Replace('\', '/'))
-                }
+        $verifiedRef = Invoke-GitCommand -RepoRoot $RepoRoot -Arguments @('rev-parse', '--verify', $candidateRef) -AllowFailure
+        if ($null -eq $verifiedRef) {
+            continue
+        }
+
+        $diffPaths = @(Invoke-GitCommand -RepoRoot $RepoRoot -Arguments @('diff', '--name-only', "$candidateRef...HEAD") -AllowFailure)
+        if ($null -eq $diffPaths) {
+            continue
+        }
+
+        foreach ($diffPath in $diffPaths) {
+            if (-not [string]::IsNullOrWhiteSpace($diffPath)) {
+                [void]$paths.Add($diffPath.Replace('\', '/'))
             }
-            break
         }
-        catch {
-        }
+
+        break
     }
 
     return @($paths | Sort-Object)
-}
-
-function Test-PathMatchesAnyPattern {
-    param(
-        [string]$Path,
-        [string[]]$Patterns
-    )
-
-    foreach ($pattern in $Patterns) {
-        if ($Path -like $pattern) {
-            return $true
-        }
-    }
-
-    return $false
 }
 
 Push-Location $repoRoot
@@ -282,11 +298,11 @@ try {
         $summary | ConvertTo-Json -Depth 10
     }
     else {
-        Write-Output "AI toolkit validation summary"
+        Write-Output 'AI toolkit validation summary'
         Write-Output "  Overall Status   : $($summary.overallStatus)"
         Write-Output "  Repository Root  : $repoRoot"
-        Write-Output ""
-        Write-Output "Validation steps"
+        Write-Output ''
+        Write-Output 'Validation steps'
         foreach ($step in $steps) {
             Write-Output "  $($step.name): $($step.status) ($($step.durationSeconds)s)"
             if (-not [string]::IsNullOrWhiteSpace($step.detail)) {
@@ -294,8 +310,8 @@ try {
             }
         }
 
-        Write-Output ""
-        Write-Output "Highlights"
+        Write-Output ''
+        Write-Output 'Highlights'
         if ($null -ne $summary.highlights.changelogStatus) {
             Write-Output "  Changelog Status         : $($summary.highlights.changelogStatus)"
         }
@@ -316,8 +332,8 @@ try {
         }
 
         if (-not $overallSuccess) {
-            Write-Output ""
-            Write-Output "Failures"
+            Write-Output ''
+            Write-Output 'Failures'
             foreach ($failedStep in @($steps | Where-Object { -not $_.success })) {
                 Write-Output "  [$($failedStep.name)] exit=$($failedStep.exitCode)"
                 if (-not [string]::IsNullOrWhiteSpace($failedStep.output)) {


### PR DESCRIPTION
# Summary

Expand the regression harness into a fuller fixture-driven benchmark workflow, add a one-shot AI toolkit maintainer validator, and tighten upstream contributor drift alignment so local AI guidance stays current with reviewed HashiCorp contributor guidance.

## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

This PR moves the repo from a starter regression-harness foundation to a more complete maintainer workflow.

On the regression side, it adds schema validation, suite scoring, history snapshots, history summaries, a top-level harness runner, additional adjudicated examples, and a contributor-facing HCL authoring flow that materializes the internal benchmark artifacts from a single test spec.

On the AI-toolkit maintenance side, it adds a one-shot `tools/validate-ai-toolkit.ps1` command that runs changelog validation, contract validation, markdown lint, regression-harness validation, and upstream contributor drift checks through a single entry point. The changelog policy is now explicit by default: update `CHANGELOG.md`, or pass an explicit waiver with a reason when no release-note entry is warranted.

This PR also expands the tracked upstream contributor source set and local companion guidance so the repo can detect and review drift against more of HashiCorp's contributor guidance instead of relying on ad hoc manual checks. The drift work stays deterministic: it detects drift and missing explicit references, then leaves semantic review to maintainers rather than trying to auto-correct with heuristics.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [ ] Installer
- [ ] Bash
- [x] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [x] AI instructions (`.github/instructions/`)
- [x] AI skills (`.github/skills/`)
- [x] GitHub Actions

## Related Issue(s)

- None

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

- Ran `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1`
- Ran `npx -y markdownlint-cli2 ".github/**/*.md" "docs/**/*.md" "CHANGELOG.md" "tools/regression/**/*.md" --config .github/.markdownlint.json`
- Confirmed upstream drift was clean through the one-shot validator:
  - Changed Sources: `0`
  - Catalog Issues: `0`
  - Rule Issues: `0`

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

- AI assistance was used for code edits, documentation updates, maintainer-workflow alignment, and validation-oriented refactoring. Final repository-specific decisions, changelog policy direction, and commit/PR shaping were reviewed and directed by the maintainer.

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [x] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github_actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
