### PR TITLE
[BUG:] Tighten committed review scope and align docs example rules

### DIFF
--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -155,6 +155,18 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If the active review prompt file itself is part of the reviewed change-set, skip only that specific file.
 - Rule: The skip must be disclosed explicitly in the review output.
 
+### REVIEW-FILE-004: Committed review scope must prefer authoritative PR context
+- Rule: When authoritative pull request metadata exists, committed review must use the pull request changed-file set and diff as the authoritative review scope.
+- Rule: Do not treat unrelated branch-only commits as committed-review findings when active or viewed pull request context exists.
+- Rule: Fall back to `origin/main...HEAD` only when no authoritative pull request metadata exists or when the user explicitly requests a branch-wide committed review.
+- Rule: When authoritative pull request metadata exists, retrieve the authoritative PR changed-file set from GitHub-backed pull request metadata.
+- Rule: Acceptable authoritative PR file sources include environment-provided PR metadata and the GitHub pull request files API for the resolved PR number.
+- Rule: An explicit PR number supplied by the user is an acceptable deterministic input for resolving the authoritative PR changed-file set.
+- Rule: Do not assume the GitHub CLI is installed, and do not require `gh` as the only compliant path for PR file retrieval.
+- Rule: Do not reconstruct PR scope by scraping local Copilot session files, `workspaceStorage`, `chat-session-resources`, or ad hoc cached JSON artifacts from the local machine.
+- Rule: If explicit user-supplied PR context and environment PR context both exist and conflict, committed review must fail closed instead of silently choosing one.
+- Rule: The only allowed exception is an explicit user override that says the supplied PR should override the active or viewed PR context.
+
 ## File-type-specific review coverage
 
 ### REVIEW-SCOPE-001: Always review user-visible content quality
@@ -181,6 +193,10 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: The generic code review contract continues to govern overall review flow, evidence handling, classification, and output shape.
 - Rule: The docs-writer verification footer and docs-only prompt output contract do not apply to `/code-review-local-changes` or `/code-review-committed-changes`.
 - Rule: Do not extend `DOCS-*` rules to non-reference docs such as `README.md`, `docs/*.md`, or other markdown files unless a future contract explicitly does so.
+- Rule: For reference docs in committed or local review scope, `DOCS-DEPR-*` remains authoritative for next-major deprecations even when implementation evidence shows a legacy non-vNext field still exists on a transitional code path.
+- Rule: Do not raise a docs-parity Issue solely because a legacy field is still accepted on a non-vNext path when the docs contract and docs guidance require that field to stay out of current reference docs and place migration guidance in an upgrade guide.
+- Rule: Any docs Issue raised for files under `website/docs/**/*.html.markdown` must cite at least one exact supporting `DOCS-*` rule ID.
+- Rule: If no exact `DOCS-*` rule supports a proposed docs claim, do not raise it as an Issue in generic review; demote it to an Observation or omit it.
 
 ### REVIEW-SCOPE-005: Go implementation and acceptance-test files defer to scoped guidance
 - Rule: When the review scope includes `internal/**/*.go` or `internal/**/*_test.go`, load and apply the applicable file-scoped instructions and skills.
@@ -272,6 +288,7 @@ If evidence is missing for a claim that would change severity or requested actio
   - the currently open or viewed pull request context, when available
   - an explicit PR number provided by the user or prompt invocation text
 - Rule: Do not guess or invent a PR number from the branch name, diff text, commit messages, or other ambiguous signals.
+- Rule: If explicit user-supplied PR context conflicts with environment PR context and there is no explicit user override, do not run the linter.
 - Rule: If committed review cannot determine a valid PR number, report the linter section as `Not run` with a concise summary that instructs the user to create a draft PR and run the review again.
 - Rule: When the PR number was not provided explicitly in the committed review invocation, that summary should include an example of how to pass one, such as `/code-review-committed-changes PR 12345`.
 

--- a/.github/instructions/docs-compliance-contract.instructions.md
+++ b/.github/instructions/docs-compliance-contract.instructions.md
@@ -289,11 +289,14 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 ## Examples
 
 ### DOCS-EX-000: Examples must be functional
-- **Rule**: Examples MUST be functional; a user should be able to copy/paste and run `terraform plan` without errors.
+- **Rule**: Examples MUST be functional for their intended scenario.
+- **Rule**: Resource examples must be functional and self-contained enough that a user can copy/paste them and run `terraform plan` without errors.
+- **Rule**: Data source examples must be functional for an existing-object lookup scenario and do not need to declare the looked-up object in the same example.
 - **Provenance**: Published upstream standard.
 - **Evidence**:
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Examples`
   - That guidance says examples MUST be functional and should not error when a user runs `terraform plan`
+  - Proposed clarification in `hashicorp/terraform-provider-azurerm` PR `#32299` separates resource examples from data source lookup examples and explains that data source examples may assume the looked-up object already exists
 
 ### DOCS-EX-001: Example Terraform config fences must be `hcl`
 - **Scope**: fenced Terraform configuration blocks under headings that start with `Example` (e.g. `## Example Usage`, `## Example ...`).
@@ -308,17 +311,19 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 - **Scope**: fenced CLI blocks under headings that start with `Example`.
 - **Rule**: CLI examples MUST use `shell` (single command) or `shell-session` (prompt/output transcript).
 
-### DOCS-EX-003: Examples must be self-contained
-- **Rule**: Every Terraform reference used in an Example configuration (`resource`, `data`, `module`, expressions like `azurerm_*.*`, `data.*.*`, `module.*`) MUST be declared somewhere on the same doc page.
+### DOCS-EX-003: Resource examples must be self-contained
+- **Scope**: resource docs under `website/docs/r/**`.
+- **Rule**: Every Terraform reference used in a resource Example configuration (`resource`, `data`, `module`, expressions like `azurerm_*.*`, `data.*.*`, `module.*`) MUST be declared somewhere on the same doc page.
 - **Allowed pattern**: define shared resources in `## Example Usage`, reference them from other examples on the same page.
 - **Remediation rule**: if an Example is not self-contained, fix it by adding the missing `resource`/`data`/`module` declarations to the page (typically in `## Example Usage`), not by deleting the Example section/block.
 - **Provenance**: Local safeguard.
 - **Evidence**:
   - Added to stop audits from resolving broken examples by deleting Example content or leaving undeclared references behind
   - Reflected in this repository's docs review workflow for copy/pasteable examples
+  - Scoped to resource docs because the upstream clarification in `hashicorp/terraform-provider-azurerm` PR `#32299` distinguishes resource examples from data source lookup examples
 
 ### DOCS-EX-020: Example self-containedness must be transitive
-- **Scope**: Example Terraform configuration blocks (`## Example*`).
+- **Scope**: resource Example Terraform configuration blocks (`## Example*`) in `website/docs/r/**`.
 - **Rule**: When you add missing `resource`/`data`/`module` declarations to satisfy `DOCS-EX-003`, you MUST ensure the resulting Example is fully runnable:
   - Newly added declarations MUST include all schema-required arguments/blocks for those objects (see `DOCS-EX-011`).
   - Any Terraform references introduced by the newly added declarations MUST also be declared on the same doc page.
@@ -331,7 +336,7 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
   - Enforced for deterministic docs audits in this repository
 
 ### DOCS-EX-021: Preserve reference semantics in examples
-- **Scope**: Example Terraform configuration blocks (`## Example*`).
+- **Scope**: resource Example Terraform configuration blocks (`## Example*`) in `website/docs/r/**`.
 - **Rule**: Do not change an argument value from a Terraform reference to a literal (or from a literal to a reference) as a convenience workaround unless schema/implementation evidence proves the replacement is correct and intended.
   - Examples of Terraform references: `azurerm_*.example.*`, `data.*.*`, `module.*`.
   - Examples of problematic "convenience" rewrites: replacing a reference with a plausible-looking hostname/domain string, or removing a reference entirely.
@@ -343,7 +348,7 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
   - Works with `DOCS-EVID-001` to keep example rewrites evidence-based
 
 ### DOCS-EX-019: Do not replace Terraform references with invented literals
-- **Scope**: Example Terraform configuration blocks (`## Example*`).
+- **Scope**: resource Example Terraform configuration blocks (`## Example*`) in `website/docs/r/**`.
 - **Rule**: When fixing Example self-containedness or undeclared references, you MUST NOT replace Terraform references (for example `azurerm_*.example.*`, `data.*.*`, `module.*`) with invented literal string values (for example `"example.foo.azure.com"`) as a shortcut.
 - **Required remediation**: declare the missing referenced `resource`/`data`/`module` blocks on the same doc page (see `DOCS-EX-003`).
 - **Exception**: you may replace a reference with a literal only when schema/implementation evidence proves the literal value form and constraints deterministically and the Example is explicitly teaching a literal value scenario (see `DOCS-EX-010`/`DOCS-EX-016`). Otherwise record an Observation per `DOCS-EVID-001`.
@@ -431,6 +436,17 @@ Additional auditor behavior (deterministic suffix; nit-level):
 ### DOCS-EX-014: Avoid multiple examples when possible
 - **Rule**: Avoid multiple examples unless a specific configuration is particularly difficult to configure.
 - **Rule**: If many complex examples are needed, prefer using the repository `examples/` folder instead of expanding the docs page.
+
+### DOCS-EX-022: Data source examples should demonstrate existing-object lookups
+- **Scope**: data source docs under `website/docs/d/**`.
+- **Rule**: Data source examples MUST demonstrate the intended lookup scenario for an existing object.
+- **Rule**: Data source examples may assume the looked-up object already exists and do not need to declare the backing resource in the same example.
+- **Rule**: Data source examples should include only the arguments needed to identify the looked-up object.
+- **Rule**: Do not add resource scaffolding solely to create the lookup target in a data source example.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Examples`
+  - Proposed clarification in `hashicorp/terraform-provider-azurerm` PR `#32299` adds an explicit resource-example versus data-source-example split and says data source examples may assume the looked-up object already exists
 
 ### DOCS-EX-015: Deterministic example name value derivation (nit-level)
 - **Scope**: Example Terraform configuration blocks (`## Example*`).

--- a/.github/instructions/documentation-guidelines.instructions.md
+++ b/.github/instructions/documentation-guidelines.instructions.md
@@ -635,15 +635,39 @@ A `configuration` block supports the following:
 
 ## 💡 Example Configuration Guidelines
 
+### General shared rules
+
+Rules:
+- Each resource/data source page should include an example HCL configuration block that shows the end user how to use the resource/data source correctly.
+- Generally the Terraform instance name should simply be `example`.
+- Avoid multiple examples unless a specific configuration is difficult to demonstrate briefly.
+- Do not include `terraform` or `provider` blocks in docs examples.
+- All example values must satisfy schema validation and naming restrictions proven by workspace evidence.
+
+### Resource examples
+
+Rules:
+- Resource examples must be functional and self-contained.
+- If a user copies a resource example and runs `terraform plan`, it should not fail because of undeclared backing infrastructure.
+- Resource examples do not need to include every argument; the basic acceptance-test shape is usually enough, including any required dependencies.
+- Resource name-like values should start with `example-` where feasible.
+
+### Data source examples
+
+Rules:
+- Data source examples should demonstrate an existing-object lookup scenario.
+- Data source examples may assume the looked-up object already exists and do not need to declare the backing resource in the same example.
+- Data source examples should include only the arguments needed to identify the looked-up object.
+- Do not add resource scaffolding solely to create the lookup target for a data source example.
+- Data source identifier-like values should start with `existing-` where feasible.
+
 ### Example naming conventions (provider style)
 
 Rules:
-- Resources: user-supplied name-like argument values (for example `name = "..."`) should start with the prefix `example-` where feasible.
-- Data sources: required identifier-like argument values should start with the prefix `existing-` where feasible.
 - Derive example values from the Terraform **block type being named**, not from the doc topic.
-- Prefer deriving the suffix from the full Terraform resource type so examples are predictable.
-  - Default: kebab-case (underscores replaced with hyphens), for example `azurerm_resource_group` -> `example-resource-group`.
-  - ValidateFunc-safe fallback: if the schema `ValidateFunc` evidence indicates hyphens are not allowed, do not use kebab-case. Use a lowercase no-separator form instead (for example `azurerm_cdn_frontdoor_firewall_policy` -> `examplecdnfrontdoorfirewallpolicy`).
+- Prefer deriving the suffix from the full Terraform resource or data source type so examples are predictable.
+  - Default: kebab-case (underscores replaced with hyphens), for example `azurerm_resource_group` -> `example-resource-group` and `data.azurerm_subnet` -> `existing-subnet`.
+  - ValidateFunc-safe fallback: if the schema `ValidateFunc` evidence indicates hyphens are not allowed, do not use kebab-case. Use a lowercase no-separator form instead (for example `azurerm_storage_account` -> `examplestorageaccount` when that is the simplest valid value).
 - Honor naming constraints from the schema field `ValidateFunc` when present; abbreviate only as much as required to satisfy validation.
 
 Naming constraints (mandatory; use schema evidence):
@@ -652,7 +676,7 @@ Naming constraints (mandatory; use schema evidence):
 ### Example `depends_on` guidance (deterministic)
 
 Rules:
-- Existing docs: do not remove or weaken `depends_on` entries in examples purely to make a snippet “self-contained”. If `depends_on` references resources not declared on the page, fix self-containedness by adding the missing referenced resources (prefer the primary `## Example Usage` block).
+- Existing resource docs: do not remove or weaken `depends_on` entries in examples purely to make a snippet “self-contained”. If `depends_on` references resources not declared on the page, fix self-containedness by adding the missing referenced resources (prefer the primary `## Example Usage` block).
 - Net-new docs: do not introduce `depends_on` unless you have concrete schema/implementation evidence that ordering is required (or the example is explicitly teaching an ordering constraint).
 - If a note says `depends_on` must reference multiple resources (for example both a route and a security policy), preserve all required references.
 - If you cannot reliably determine whether a page is net-new vs existing, default to preserving `depends_on` intent.

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -63,20 +63,50 @@ Use `run_in_terminal` with `mode: "sync"`, a concrete `goal`, and a short `timeo
 Execute these required commands directly when this step begins; do not pause for confirmation.
 The commands in steps 1 and 4 must be executed again for each invocation of this prompt, even if they were executed earlier in the conversation.
 
-Run these commands in order and do not repeat them:
+Run this command first and do not repeat it:
 
 ```text
 git branch --show-current
+```
+
+Determine committed review scope in this order:
+
+- If authoritative pull request context is available, use the pull request changed-file set and diff as the committed review scope.
+- Authoritative pull request context means one of the following explicit sources:
+  - the active pull request context, when available
+  - the currently open or viewed pull request context, when available
+- When pull request context is available, obtain the authoritative PR changed-file set from GitHub-backed pull request metadata.
+- Acceptable authoritative PR file sources are:
+  - environment-provided pull request metadata that includes the PR changed-file set
+  - the GitHub pull request files API for the resolved PR number
+- If the user supplies an explicit PR number in the invocation text, that PR number is an acceptable deterministic input for resolving the authoritative PR changed-file set.
+- Do not assume the GitHub CLI is installed.
+- Do not require `gh` as the only way to resolve PR files.
+- Do not reconstruct PR scope by scraping local Copilot session artifacts, `workspaceStorage`, `chat-session-resources`, or ad hoc `content.json` files from the local machine.
+- Do not build PR scope through generated local shell scripts that deserialize PR metadata from user-profile caches.
+- If explicit user-supplied PR context and environment PR context both exist, resolve them before continuing:
+  - If they match, use that PR.
+  - If they conflict, hard-stop and output exactly this one line and nothing else:
+    - `☠️ Argh! Cannot sail the code-review-committed-changes sea, yer PR bearings be crossed. Environment PR be <environment_pr>, but ye supplied <supplied_pr>. Set a proper course and set sail with true bearings, or declare the supplied PR be takin’ command o’er the current course. ☠️`
+  - Only if the user explicitly states that the supplied PR should override the active PR context may the supplied PR number win.
+- Only if no authoritative pull request context exists, or when the user explicitly asks for a branch-wide committed review, run these commands in order and do not repeat them:
+
+```text
 git --no-pager diff --stat --no-prefix origin/main...HEAD
 git --no-pager diff --no-prefix --unified=3 origin/main...HEAD
 ```
 
 Rules:
-- Review the committed diff against `origin/main...HEAD`.
-- If the committed diff is empty, hard-stop and output exactly:
+- When authoritative pull request context exists, treat the pull request changed-file set and diff as the committed review scope.
+- When an explicit PR number is available, the review may use that PR number to resolve the authoritative changed-file set from GitHub without relying on local branch-diff inference.
+- Do not silently choose between conflicting explicit and environment PR targets.
+- Conflict between explicit and environment PR context must fail closed unless the user explicitly requests an override.
+- Do not expand committed-review findings to unrelated branch-only commits when authoritative pull request context exists.
+- Fall back to `origin/main...HEAD` only when no authoritative pull request context exists or when the user explicitly asks for a branch-wide committed review.
+- If the authoritative committed review scope is empty, hard-stop and output exactly:
   - `☠️ Argh! Shiver me source files! This branch be cleaner than a swabbed deck! Push some code, Ye Lily-livered scallywag! ☠️`
-- If the diff is large, inspect the changed files individually rather than rerunning the branch-wide commands.
-- If additional commit-by-commit context is genuinely needed after reviewing the diff, inspect the relevant commit(s) individually instead of making commit history a mandatory first step.
+- If the committed review scope is large, inspect the changed files individually rather than rerunning broader scope commands.
+- If additional commit-by-commit context is genuinely needed after reviewing the committed review scope, inspect the relevant commit(s) individually instead of making commit history a mandatory first step.
 
 ### 2) Classify files accurately
 - Parse the diff stat carefully so added, modified, and deleted files are counted correctly.
@@ -89,6 +119,11 @@ Rules:
 - Read `.github/pull_request_template.md` when present.
 - Read any file-scoped instructions or skills that directly govern the changed files.
 - If the review scope includes `website/docs/**/*.html.markdown`, also read `.github/instructions/docs-compliance-contract.instructions.md` and `.github/instructions/documentation-guidelines.instructions.md`, and apply `DOCS-*` rules only to those docs files.
+- When `website/docs/**/*.html.markdown` files are in scope, audit those docs files using the docs contract instead of generic schema-parity assumptions.
+- For docs files in committed review scope, treat `DOCS-DEPR-*` as authoritative for next-major deprecations: legacy non-vNext fields may be intentionally removed from live reference docs and moved to versioned upgrade guides.
+- Do not raise an Issue solely because a legacy field still exists on a non-vNext implementation path when the docs contract and docs guidance classify that field as legacy-only and require it to stay out of current reference docs.
+- For docs files in committed review scope, every docs Issue must cite at least one exact `DOCS-*` rule ID that supports the claim.
+- If no exact `DOCS-*` rule supports a proposed docs Issue, demote it to an Observation or omit it.
 - If provider contributor guidance exists in the current workspace or is explicitly fetched as evidence, apply it only where relevant.
 - Use the precedence rules from the shared review contract.
 
@@ -111,6 +146,7 @@ Rules:
     - the active pull request context, when available
     - the currently open or viewed pull request context, when available
     - an explicit PR number supplied by the user or prompt invocation text
+  - If explicit and environment PR sources conflict, do not run the linter until the PR target is resolved by matching values or an explicit user override
   - If a valid PR number is available, run `azurerm-linter --pr=<number> -output json` with shell-native stderr suppression
   - Do not guess or invent a PR number from the branch name, diff text, commit messages, or other ambiguous signals
   - If the stderr-suppressed run does not yield valid stdout JSON or otherwise cannot be classified deterministically, rerun once without stderr suppression to inspect diagnostics
@@ -155,6 +191,9 @@ Rules:
 - Review the full committed change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
+- When `website/docs/**/*.html.markdown` files are in scope, explicitly apply the docs contract's deprecation and upgrade-guide rules before raising docs Issues about removed legacy fields.
+- When `website/docs/**/*.html.markdown` files are in scope, any docs Issue in the review body must include the exact supporting `DOCS-*` rule ID or IDs.
+- Do not emit generic docs-parity Issues for `website/docs/**/*.html.markdown` files without exact `DOCS-*` rule support and evidence.
 - When `internal/**/*_test.go` files are in scope, explicitly inspect embedded Terraform configuration strings and apply the `REVIEW-TEST-*` rules for formatting drift instead of assuming `azurerm-linter` will catch those issues.
 - Keep the review concise but complete.
 
@@ -230,6 +269,7 @@ Use this template:
 
 ### 🔴 **ISSUES** (only actual problems)
 - [Evidence-backed defects, regressions, or policy violations]
+- [For `website/docs/**/*.html.markdown` Issues, include the exact supporting `DOCS-*` rule ID or IDs]
 - [Include azurerm-linter findings from the filtered run]
 
 ## ✅ **RECOMMENDATIONS**

--- a/.github/prompts/code-review-docs.prompt.md
+++ b/.github/prompts/code-review-docs.prompt.md
@@ -143,7 +143,7 @@ Vendored constants allowance (mandatory):
 - If the schema/validation logic references SDK constants/enums (e.g. cipher suite constants), use `vendor/**` as supporting evidence for the allowed values.
 
 **Mandatory: deterministic example naming + ValidateFunc evidence (no invented names):**
-- If you must introduce new Terraform blocks into an example to satisfy self-containedness (`DOCS-EX-003`), any name-like string values you add or rename MUST follow `DOCS-EX-015` (derive from the Terraform type suffix; do not make up values like `example-route`).
+- If you must introduce new Terraform blocks into a resource example to satisfy self-containedness (`DOCS-EX-003`), any name-like string values you add or rename MUST follow `DOCS-EX-015` (derive from the Terraform type suffix; do not make up values like `example-route`).
 - If the value is constrained by `ValidateFunc`/validation logic, you MUST derive a compliant deterministic value from workspace evidence.
   - Primary: `internal/**` validation logic.
   - Supporting (when referenced): `vendor/**` SDK constants/enums.
@@ -152,7 +152,7 @@ Vendored constants allowance (mandatory):
 **Mandatory: apply `DOCS-EX-015` only when a rename is required (contract-accurate):**
 - `DOCS-EX-015` is a deterministic *derivation rule* for replacement values when you must propose/apply a rename.
 - Do NOT treat `DOCS-EX-015` as a blanket requirement that every Example `name = "..."` literal must equal the type-derived value.
-- When you do need to rename a name-like value (for example to satisfy `DOCS-EX-007`, or to replace an invalid value per `DOCS-EX-016`, or when adding/updating scaffolding blocks for self-containedness), derive the new value per `DOCS-EX-015` and ensure it is ValidateFunc-safe per `DOCS-EX-016`.
+- When you do need to rename a name-like value (for example to satisfy `DOCS-EX-007`, or to replace an invalid value per `DOCS-EX-016`, or when adding/updating resource-example scaffolding blocks for self-containedness), derive the new value per `DOCS-EX-015` and ensure it is ValidateFunc-safe per `DOCS-EX-016`.
 
 Generalized deterministic-name preference (nit-level; evidence-gated):
 - For any Terraform `resource`/`data` block in `Example*` sections, when a `name = "..."` **string literal** is present:
@@ -210,7 +210,7 @@ Internal multi-pass audit (mandatory):
     - Trigger (mandatory; prevents misses): in resource docs, if any argument bullet contains more than 2 sentences OR mixes definition text with validation-style constraints (length/charset/regex/start/end rules) OR contains both a long constraints clause and the ForceNew sentence, you MUST treat it as a `DOCS-ARG-011` failure and split the constraints into an inline note under the bullet.
     - Data source rule (mandatory): in data source docs, if a field bullet contains extended caveats or a field-level note block, you MUST treat it as a contract failure and require the text to be reduced to a short explanation of what the field is.
     - Note format (mandatory): when a resource field note is required, the inline note MUST use `(->|~>|!>) **Note:**` per `DOCS-NOTE-003`.
-- **Examples pass**: enforce `DOCS-EX-*` (fences, self-containedness, required `depends_on` preservation, ValidateFunc-safe values, no secrets).
+- **Examples pass**: enforce `DOCS-EX-*` (fences, resource self-containedness, data source lookup behavior, required `depends_on` preservation, ValidateFunc-safe values, no secrets).
 - **Import/Timeouts/Wording pass**: enforce `DOCS-IMP-*` (resources), `DOCS-TIMEOUT-*` (if present), and `DOCS-WORD-*`.
 
 If you cannot confidently verify a section due to missing workspace evidence, do not guess; record an Observation and cite `DOCS-EVID-001`.
@@ -321,8 +321,8 @@ Skill footer rule (mandatory; prevents duplicate sections):
 - **Import Text**: Pass/Fail (resources only, resource-specific sentence per `DOCS-IMP-002`)
 - **Import Example**: Pass/Fail (resources only, ID shape matches importer/parser)
 - **Link Locales**: Pass/Fail (no locale segments like `/en-us/` in URLs)
-- **Examples**: Pass/Fail (functional/self-contained, no hard-coded secrets; naming conventions are low-priority nit issues with fix steps, but do not make the page `Invalid` by themselves)
-- **Example Invariants**: Pass/Fail (preserve example-adjacent notes per `DOCS-EX-018`, preserve existing `depends_on` per `DOCS-EX-004`, do not replace references with invented literals per `DOCS-EX-019`, ensure transitive self-containedness per `DOCS-EX-020`, preserve reference semantics per `DOCS-EX-021`)
+- **Examples**: Pass/Fail (resource docs: examples are functional and self-contained; data source docs: examples demonstrate existing-object lookup behavior without unnecessary backing-resource scaffolding; no hard-coded secrets)
+- **Example Invariants**: Pass/Fail (resource docs: preserve example-adjacent notes per `DOCS-EX-018`, preserve existing `depends_on` per `DOCS-EX-004`, do not replace references with invented literals per `DOCS-EX-019`, ensure transitive self-containedness per `DOCS-EX-020`, preserve reference semantics per `DOCS-EX-021`; data source docs: follow `DOCS-EX-022` lookup-example rules)
 - **Example `name` Values**: Pass/Fail (nit-level; Example `name` values follow `DOCS-EX-007` where feasible and satisfy `DOCS-EX-016` constraints; when a rename is required, the replacement value is derived deterministically per `DOCS-EX-015`)
 
 ## 🟢 **STRENGTHS**

--- a/.github/skills/docs-writer/SKILL.md
+++ b/.github/skills/docs-writer/SKILL.md
@@ -84,9 +84,10 @@ Use this to avoid missing common compliance breakpoints. The authoritative detai
 - ForceNew + wording hygiene: `DOCS-WORD-*` (including enum phrasing + Oxford comma) and `DOCS-ARG-003/006/009`
 - Azure object-name wording: keep canonical Azure proper-name capitalization such as `Resource Group` in field prose per `DOCS-WORD-007`
 - Notes required/marker correctness + de-dup: `DOCS-NOTE-*`
-- Examples (no deletions, self-contained, depends_on rules, ValidateFunc-safe values): `DOCS-EX-*` + `DOCS-EVID-001`
+- Examples (no deletions, resource self-containedness, data source lookup behavior, depends_on rules, ValidateFunc-safe values): `DOCS-EX-*` + `DOCS-EVID-001`
 - Example invariants: `DOCS-EX-004`, `DOCS-EX-018`, `DOCS-EX-019`
-- Example self-containedness closure: `DOCS-EX-003`, `DOCS-EX-011`, `DOCS-EX-020`
+- Resource example self-containedness closure: `DOCS-EX-003`, `DOCS-EX-011`, `DOCS-EX-020`
+- Data source lookup examples: `DOCS-EX-022`
 - Example reference semantics: `DOCS-EX-021`
 - Example `name` values (including scaffolding): `DOCS-EX-015`, `DOCS-EX-016`
 - Example `name` values (type-derived): `DOCS-EX-015`, `DOCS-EX-016`
@@ -121,7 +122,8 @@ When auditing or writing the Import section:
 
 ### Examples remediation (mandatory; no deletions)
 When fixing Example sections:
-- If an Example is not self-contained, fix it by adding the missing `resource`/`data`/`module` declarations to the page (prefer adding shared objects to `## Example Usage`).
+- If a resource Example is not self-contained, fix it by adding the missing `resource`/`data`/`module` declarations to the page (prefer adding shared objects to `## Example Usage`).
+- If a data source Example is intended to look up an existing object, do not add resource scaffolding solely to create the lookup target.
 - Do not delete an `Example*` section or remove a fenced Terraform configuration block as a remediation (see `DOCS-EX-012`).
 - If an existing example contains `depends_on = [...]`, preserve it verbatim and add any missing referenced declarations rather than weakening/removing `depends_on` entries (see `DOCS-EX-004`).
 - Preserve any example-adjacent notes that describe sequencing/validation requirements; if the example changes, update the note to remain accurate and evidence-based rather than deleting it (see `DOCS-EX-018`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an adjudicated committed-review regression case that covers PR-authoritative scope selection, so branch-only commits are not treated as PR findings when explicit pull request context exists.
+- Added an adjudicated committed-review regression case that covers `DOCS-DEPR-*` handling for mixed Go-plus-reference-doc PRs, so legacy non-vNext fields are not incorrectly required in live docs when migration belongs in the upgrade guide.
+- Added an adjudicated docs-review regression case that covers the resource-versus-data-source example split, so data source examples are not incorrectly forced to declare backing resources when they are demonstrating existing-object lookups.
+- Added an adjudicated committed-review regression case that covers conflicting PR context, so mismatched environment and user-supplied PR numbers fail closed unless the user explicitly requests an override.
+
 ### Changed
+
+- Tightened the committed-review prompt and shared review contract so committed review now prefers authoritative pull request scope when PR context exists, falling back to `origin/main...HEAD` only when no PR context is available or the user explicitly asks for a branch-wide committed review.
+- Tightened committed-review docs handling so PR-scoped mixed reviews must use GitHub PR tools for authoritative PR scope and must honor `DOCS-DEPR-*` next-major deprecation policy for `website/docs/**/*.html.markdown` files instead of treating legacy non-vNext fields as required live-doc parity.
+- Tightened committed-review docs handling further so docs Issues for `website/docs/**/*.html.markdown` files now require exact supporting `DOCS-*` rule IDs; unsupported generic docs-parity claims must be demoted or omitted.
+- Updated the docs contract, docs-review prompt, docs-writer skill, and user-facing docs to follow the clarified upstream example standard: resource examples must be self-contained, while data source examples may assume existing objects and should not add unnecessary backing-resource scaffolding.
+- Clarified committed-review PR scope retrieval so explicit PR numbers may resolve the authoritative changed-file set through GitHub metadata or the GitHub pull request files API without assuming `gh` is installed.
+- Tightened committed-review PR resolution so conflicting environment and user-supplied PR numbers now hard-stop by default instead of silently choosing a scope.
+- Updated the conflicting-PR-context hard-stop text in committed review to use the same pirate-style voice as the other prompt-owned hard-stop messages.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ AI Chat: "Create documentation following provider standards for azurerm_cdn_fron
 > 2) apply the patch-ready fixes
 > 3) rerun the audit and expect no repeated Issues
 >
-> `/code-review-docs` also enforces deterministic doc-quality checks such as `hcl` fences in examples, page-self-contained examples (no undefined references), import example ID shape validation, and human-readable timeout defaults.
+> `/code-review-docs` also enforces deterministic doc-quality checks such as `hcl` fences in examples, self-contained resource examples, existing-object lookup data source examples, import example ID shape validation, and human-readable timeout defaults.
 
 
 ## 🎬 See It In Action

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -364,7 +364,7 @@ Docs components (quick links):
 
 - `/code-review-local-changes`: reviews local workspace changes and uses local-diff linting.
 - `/code-review-committed-changes`: reviews committed branch changes against `origin/main` and prefers PR-scoped linting. When PR context is not already available, users can pass a PR number explicitly, for example `/code-review-committed-changes PR 12345`.
-- `/code-review-docs`: deterministic docs review for `website/docs/**` pages (enforces `hcl` code fences in Terraform examples, page-self-contained examples with no undefined references, import example ID shape validation, and human-readable timeout defaults).
+- `/code-review-docs`: deterministic docs review for `website/docs/**` pages (enforces `hcl` code fences in Terraform examples, self-contained resource examples, existing-object lookup data source examples, import example ID shape validation, and human-readable timeout defaults).
 - Rule citations such as `REVIEW-SCOPE-005` and `DOCS-EX-003` are explained in `docs/CODE_REVIEW_RULES.md`.
 
 ### Docs governance (contract, prompt, skill)

--- a/docs/CODE_REVIEW_RULES.md
+++ b/docs/CODE_REVIEW_RULES.md
@@ -131,7 +131,7 @@ These IDs come from `.github/instructions/docs-compliance-contract.instructions.
 | `DOCS-FMT-*` | Formatting | Backticks, intro lines, and code-fence conventions |
 | `DOCS-IMP-*` | Import docs | Import wording and example correctness |
 | `DOCS-SHAPE-*` | Schema shape parity | Whether docs reflect blocks, maps, lists, and nested structures correctly |
-| `DOCS-EX-*` | Example code | Example correctness, self-containedness, naming, and Terraform syntax |
+| `DOCS-EX-*` | Example code | Example correctness, resource self-containedness, data source lookup behavior, naming, and Terraform syntax |
 | `DOCS-NOTE-*` | Notes | Required note blocks, note severity, formatting, and de-duplication |
 | `DOCS-ARG-*` | Arguments Reference | Field coverage, ordering, defaults, and validation wording |
 | `DOCS-ATTR-*` | Attributes Reference | Computed field coverage and ordering |

--- a/installer/README.md
+++ b/installer/README.md
@@ -425,7 +425,7 @@ Simply use slash commands to invoke the prompts directly:
 |---------------|-------------|-------------|
 | `/code-review-local-changes` | `code-review-local-changes.prompt.md` | Review your uncommitted changes |
 | `/code-review-committed-changes` | `code-review-committed-changes.prompt.md` | Review committed changes |
-| `/code-review-docs` | `code-review-docs.prompt.md` | Review a `website/docs/**` page for docs standards + schema parity (includes deterministic checks like `hcl` example fences, self-contained examples, import ID shape, and timeout readability) |
+| `/code-review-docs` | `code-review-docs.prompt.md` | Review a `website/docs/**` page for docs standards + schema parity (includes deterministic checks like `hcl` example fences, self-contained resource examples, existing-object lookup data source examples, import ID shape, and timeout readability) |
 
 **Example Usage:**
 ```
@@ -440,7 +440,7 @@ Simply use slash commands to invoke the prompts directly:
 |-------------|---------|-------|
 | `code-review-local-changes.prompt.md` | **Review uncommitted changes** with Terraform provider best practices | Use before committing to get expert feedback on your local changes |
 | `code-review-committed-changes.prompt.md` | **Review committed changes** for pull request feedback | Use to review git commits with detailed technical analysis |
-| `code-review-docs.prompt.md` | **Review a docs page** for required sections and schema parity | Open a file under `website/docs/**` and run to get patch-ready fixes (examples must use `hcl`, be self-contained, include correct import IDs, and document readable timeouts) |
+| `code-review-docs.prompt.md` | **Review a docs page** for required sections and schema parity | Open a file under `website/docs/**` and run to get patch-ready fixes (examples must use `hcl`, resource examples must be self-contained, data source examples must reflect existing-object lookups, include correct import IDs, and document readable timeouts) |
 
 ## 🎛️ Command Reference
 

--- a/tools/regression/cases/review-committed-docs-deprecation-policy.json
+++ b/tools/regression/cases/review-committed-docs-deprecation-policy.json
@@ -1,0 +1,61 @@
+{
+  "id": "review-committed-docs-deprecation-policy",
+  "title": "Committed review honors docs deprecation policy in mixed PR scope",
+  "task": "code-review-committed-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized committed-review scenario where a mixed Go-plus-reference-doc PR removes a legacy non-vNext field from live docs while the provider still accepts that field on a transitional non-5.0 path. The correct review must apply `DOCS-DEPR-*` and keep migration guidance in the upgrade guide rather than raising a docs-parity issue.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-committed-docs-deprecation-policy/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/cdn/cdn_frontdoor_custom_domain_resource.go",
+      "website/docs/r/cdn_frontdoor_custom_domain.html.markdown",
+      "website/docs/guides/5.0-upgrade-guide.html.markdown"
+    ],
+    "notes": "The modeled PR updates implementation and docs together. The live resource doc intentionally removes the legacy `minimum_tls_version` field, while the versioned upgrade guide carries the migration note."
+  },
+  "expectedRules": [
+    "REVIEW-SCOPE-004A",
+    "DOCS-DEPR-001",
+    "DOCS-DEPR-002",
+    "DOCS-EVID-001"
+  ],
+  "mustCatch": [
+    {
+      "key": "docs-deprecation-policy-applied",
+      "severity": "high",
+      "description": "The committed review should apply the docs contract's next-major deprecation rules and recognize that the legacy non-vNext field should stay out of current reference docs."
+    },
+    {
+      "key": "exact-docs-rule-citation",
+      "severity": "medium",
+      "description": "The committed review should cite the exact supporting docs rule IDs when justifying why the legacy field stays out of the live reference docs."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "legacy-field-doc-parity-issue",
+      "description": "The review must not raise an Issue claiming the live reference docs need to restore the legacy `minimum_tls_version` field when migration belongs in the 5.0 upgrade guide."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "AZURERM LINTER",
+      "MUST FIX"
+    ],
+    "mustIncludeMarkers": [
+      "DOCS-DEPR-001",
+      "DOCS-DEPR-002"
+    ]
+  },
+  "notes": "Pair this case with the sample review Markdown output and scored result to benchmark mixed committed-review docs deprecation policy handling."
+}

--- a/tools/regression/cases/review-committed-pr-authoritative-scope.json
+++ b/tools/regression/cases/review-committed-pr-authoritative-scope.json
@@ -1,0 +1,58 @@
+{
+  "id": "review-committed-pr-authoritative-scope",
+  "title": "Committed review uses authoritative PR scope instead of branch-only commits",
+  "task": "code-review-committed-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized committed-review scenario where explicit PR context exists, but the local branch also contains unrelated branch-only commits. The correct review must treat the PR changed-file set as authoritative and must not report findings from branch-only files.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-committed-pr-authoritative-scope/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go"
+    ],
+    "notes": "The authoritative PR scope contains one provider Go file. The local branch also contains an unrelated docs-only commit that is intentionally outside PR scope and must not leak into committed-review findings."
+  },
+  "expectedRules": [
+    "REVIEW-FILE-004",
+    "REVIEW-LINT-*",
+    "REVIEW-SCOPE-005"
+  ],
+  "mustCatch": [
+    {
+      "key": "pr-scope-authoritative",
+      "severity": "high",
+      "description": "The committed review should treat explicit PR metadata as the authoritative review scope instead of reviewing the whole branch diff."
+    },
+    {
+      "key": "scope-reporting-consistency",
+      "severity": "medium",
+      "description": "The review should describe the committed review as PR-scoped and keep the files-changed and analysis sections consistent with that scope."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "branch-only-doc-finding",
+      "description": "The review must not raise findings against branch-only files such as `docs/TROUBLESHOOTING.md` when that file is outside the authoritative pull request scope."
+    },
+    {
+      "key": "branch-wide-diff-framing",
+      "description": "The review must not describe the committed review scope as a generic `origin/main...HEAD` branch diff when explicit PR context is available."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "AZURERM LINTER",
+      "MUST FIX"
+    ]
+  },
+  "notes": "Pair this case with the sample review Markdown output and scored result to benchmark PR-authoritative committed-review scope selection."
+}

--- a/tools/regression/cases/review-committed-pr-context-conflict.json
+++ b/tools/regression/cases/review-committed-pr-context-conflict.json
@@ -1,0 +1,48 @@
+{
+  "id": "review-committed-pr-context-conflict",
+  "title": "Committed review fails closed on conflicting PR context",
+  "task": "code-review-committed-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A sanitized committed-review scenario where active PR context identifies one PR, but the user supplies a different PR number by mistake. The correct review must fail closed instead of silently choosing one scope.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-committed-pr-context-conflict/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go"
+    ],
+    "notes": "The active or viewed PR context resolves to PR 30997, while the invocation text mistakenly supplies PR 30998. No review or linter run should continue until the conflict is resolved or explicitly overridden."
+  },
+  "expectedRules": [
+    "REVIEW-FILE-004",
+    "REVIEW-LINT-002E"
+  ],
+  "mustCatch": [
+    {
+      "key": "pr-context-conflict-hard-stop",
+      "severity": "high",
+      "description": "The committed review should stop immediately when explicit and environment PR targets conflict and no explicit user override exists."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "silent-pr-selection",
+      "description": "The review must not silently choose either the environment PR or the user-supplied PR when they conflict."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "not-run"
+  },
+  "outputChecks": {
+    "mustIncludeMarkers": [
+      "☠️ Argh! Cannot run code-review-committed-changes:",
+      "Environment PR be 30997",
+      "but ye supplied 30998",
+      "takin’ command o’er the current course"
+    ]
+  },
+  "notes": "Pair this case with the sample review output and scored result to benchmark committed-review PR conflict fail-closed behavior."
+}

--- a/tools/regression/cases/review-docs-datasource-example-lookup.json
+++ b/tools/regression/cases/review-docs-datasource-example-lookup.json
@@ -1,0 +1,51 @@
+{
+  "id": "review-docs-datasource-example-lookup",
+  "title": "Docs review accepts existing-object lookup examples for data sources",
+  "task": "code-review-docs",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized docs-review scenario where a data source page uses a minimal existing-object lookup example. The correct review should apply the resource-versus-data-source example split and must not require backing-resource scaffolding on the page.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-docs-datasource-example-lookup/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/d/example_subnet.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a data source docs review after the upstream example-standard clarification."
+  },
+  "expectedRules": [
+    "DOCS-EX-000",
+    "DOCS-EX-022",
+    "DOCS-EX-010"
+  ],
+  "mustCatch": [
+    {
+      "key": "datasource-lookup-standard-applied",
+      "severity": "high",
+      "file": "website/docs/d/example_subnet.html.markdown",
+      "description": "The review should apply the data source existing-object lookup standard and accept the example without demanding backing-resource scaffolding."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "resource-scaffolding-required",
+      "description": "The review must not require adding the looked-up resource to the page just to make the data source example look self-contained."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "DETAILED TECHNICAL REVIEW",
+      "ISSUES"
+    ],
+    "mustIncludeMarkers": [
+      "DOCS-EX-022",
+      "existing-object lookup"
+    ]
+  },
+  "notes": "Pair this case with the sample docs-review markdown output to benchmark the clarified data source example standard."
+}

--- a/tools/regression/examples/review-committed-docs-deprecation-policy.result.json
+++ b/tools/regression/examples/review-committed-docs-deprecation-policy.result.json
@@ -1,0 +1,44 @@
+{
+  "caseId": "review-committed-docs-deprecation-policy",
+  "runId": "sample-committed-review-docs-depr-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "code-review-committed-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "docs-deprecation-policy-applied",
+      "exact-docs-rule-citation"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the committed-review docs deprecation policy regression case, including exact DOCS rule citation handling."
+}

--- a/tools/regression/examples/review-committed-docs-deprecation-policy.review.md
+++ b/tools/regression/examples/review-committed-docs-deprecation-policy.review.md
@@ -1,0 +1,59 @@
+# 📋 **Code Review**: committed-review docs deprecation policy handling
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 3 files (0 new, 0 deleted, 3 modified)
+- **Line Changes**: 14 insertions, 7 deletions
+- **Branch**: fixture/committed-review-docs-depr
+- **Scope**: reviews a mixed PR with provider implementation, live reference docs, and a versioned upgrade guide
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `internal/services/cdn/cdn_frontdoor_custom_domain_resource.go`
+- `website/docs/r/cdn_frontdoor_custom_domain.html.markdown`
+- `website/docs/guides/5.0-upgrade-guide.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The modeled PR keeps the provider-compatible transitional path while moving legacy-field migration guidance out of the live reference doc and into the 5.0 upgrade guide. The benchmarked requirement is that committed review honors the docs contract's next-major deprecation policy instead of demanding legacy-field parity in the live docs.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: committed-review path applied with docs contract and documentation guidance loaded for the reference docs in scope
+- **Scope Rules**: `REVIEW-SCOPE-004A`, `DOCS-DEPR-001`, `DOCS-DEPR-002`, and `DOCS-EVID-001` were directly relevant because the PR includes live reference docs and a versioned upgrade guide alongside implementation changes
+- **Docs Contract**: loaded and applied for the `website/docs/**/*.html.markdown` files in scope
+- **Notes**: the review treats the legacy `minimum_tls_version` field as non-vNext and accepts its removal from the live reference docs while keeping migration guidance in the upgrade guide, consistent with `DOCS-DEPR-001` and `DOCS-DEPR-002`
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: PR-scoped diff for the committed review context
+- **Issue Count**: 0
+- **Summary**: linter completed successfully for the in-scope provider Go change with no findings
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review applies `DOCS-DEPR-001` and `DOCS-DEPR-002` instead of treating the live reference doc as requiring legacy-field parity with the transitional implementation path.
+
+### 🟡 **OBSERVATIONS**
+- The migration note belongs in `website/docs/guides/5.0-upgrade-guide.html.markdown`, not in the live resource reference doc.
+
+### 🔴 **ISSUES**
+- None
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Keep `DOCS-DEPR-001` and `DOCS-DEPR-002` authoritative in mixed committed reviews whenever `website/docs/**/*.html.markdown` files are part of the PR scope.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve this regression case so committed review does not regress back to generic docs-parity findings for legacy non-vNext fields.
+
+## 🏆 **OVERALL ASSESSMENT**
+The committed-review flow is acceptable when it treats legacy non-vNext fields as intentionally absent from live reference docs and keeps migration guidance in the versioned upgrade guide.

--- a/tools/regression/examples/review-committed-pr-authoritative-scope.result.json
+++ b/tools/regression/examples/review-committed-pr-authoritative-scope.result.json
@@ -1,0 +1,44 @@
+{
+  "caseId": "review-committed-pr-authoritative-scope",
+  "runId": "sample-committed-review-pr-scope-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "code-review-committed-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "pr-scope-authoritative",
+      "scope-reporting-consistency"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the committed-review PR-authoritative scope regression case."
+}

--- a/tools/regression/examples/review-committed-pr-authoritative-scope.review.md
+++ b/tools/regression/examples/review-committed-pr-authoritative-scope.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: committed-review authoritative PR scope selection
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 0 deleted, 1 modified)
+- **Line Changes**: 6 insertions, 1 deletion
+- **Branch**: fixture/committed-review-pr-scope
+- **Type**: committed pull request review
+- **Scope**: reviews only the explicit PR-scoped provider Go change and excludes unrelated branch-only commits
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `internal/services/example/example_resource.go`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The modeled pull request contains one provider Go file. The benchmarked requirement is that the committed review honors the authoritative PR scope and does not pull unrelated branch-only commits into the review body.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: committed-review path applied with authoritative PR metadata
+- **Scope Rules**: `REVIEW-FILE-004`, `REVIEW-LINT-*`, and `REVIEW-SCOPE-005` were directly relevant because explicit PR context exists and the review must not leak branch-only commits into committed-review findings
+- **Docs Contract**: not applicable
+- **Notes**: the review stays within the authoritative PR changed-file set and excludes the modeled branch-only docs commit from scope
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: PR-scoped diff for the committed review context
+- **Issue Count**: 0
+- **Summary**: linter completed successfully for the authoritative PR-scoped diff with no findings
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review keeps the committed-review scope aligned to the explicit PR metadata instead of expanding to unrelated branch-only files.
+
+### 🟡 **OBSERVATIONS**
+- The review correctly excludes the modeled `docs/TROUBLESHOOTING.md` branch-only commit from both the files-changed section and the findings.
+
+### 🔴 **ISSUES**
+- None
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Keep committed-review scope selection anchored to authoritative PR metadata whenever active or viewed PR context exists.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve this regression case so future prompt or contract changes do not reintroduce branch-wide committed review framing when PR scope is known.
+
+## 🏆 **OVERALL ASSESSMENT**
+The committed-review flow is acceptable when it treats the pull request changed-file set as authoritative and keeps unrelated branch-only commits out of the review body.

--- a/tools/regression/examples/review-committed-pr-context-conflict.result.json
+++ b/tools/regression/examples/review-committed-pr-context-conflict.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-committed-pr-context-conflict",
+  "runId": "sample-committed-review-pr-conflict-001",
+  "timestampUtc": "2026-05-02T00:00:00Z",
+  "task": "code-review-committed-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "pr-context-conflict-hard-stop"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "not-run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the committed-review conflicting PR context regression case."
+}

--- a/tools/regression/examples/review-committed-pr-context-conflict.review.md
+++ b/tools/regression/examples/review-committed-pr-context-conflict.review.md
@@ -1,0 +1,1 @@
+☠️ Argh! Cannot run code-review-committed-changes: Yer PR bearings be crossed. Environment PR be 30997, but ye supplied 30998. Set a proper course—re-run with true bearings, or declare the supplied PR be takin’ command o’er the current course. ☠️

--- a/tools/regression/examples/review-docs-datasource-example-lookup.result.json
+++ b/tools/regression/examples/review-docs-datasource-example-lookup.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "review-docs-datasource-example-lookup",
+  "runId": "sample-docs-datasource-example-001",
+  "timestampUtc": "2026-05-03T00:00:00Z",
+  "task": "code-review-docs",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "datasource-lookup-standard-applied"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the docs-review data source lookup example regression case."
+}

--- a/tools/regression/examples/review-docs-datasource-example-lookup.review.md
+++ b/tools/regression/examples/review-docs-datasource-example-lookup.review.md
@@ -1,0 +1,57 @@
+# 📋 **Code Review**: docs data source lookup example standard
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 1 modified, 0 deleted)
+- **Scale**: 5 insertions, 1 deletion
+- **Branch**: fixture/docs-datasource-example vs origin/main
+- **Scope**: updates a data source docs example to use a minimal existing-object lookup configuration
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `website/docs/d/example_subnet.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The docs update changes the example strategy for a data source page so it demonstrates an existing-object lookup instead of a self-contained resource-style scaffold.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: docs compliance contract applied
+- **Repo Guidance**: documentation guidance loaded
+- **Scope Rules**: docs-only review path applied
+- **Docs Contract**: `DOCS-EX-000`, `DOCS-EX-022`, and `DOCS-EX-010` were directly relevant
+- **Notes**: the review treats the example as an existing-object lookup for a data source rather than requiring resource-style scaffolding
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: 0
+- **Summary**: docs-only scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The example follows the clarified data source pattern by using only the identifying arguments required to look up an existing object.
+
+### 🟡 **OBSERVATIONS**
+- The review correctly avoids forcing resource scaffolding onto a data source example that is teaching an existing-object lookup scenario.
+
+### 🔴 **ISSUES**
+- None
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Keep `DOCS-EX-022` authoritative for data source pages when reviewing example strategy.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve this fixture so docs review does not regress back to resource-style self-containedness requirements for data source examples.
+
+## 🏆 **OVERALL ASSESSMENT**
+The docs update is aligned with the clarified data source example standard and should not be blocked for lacking backing-resource scaffolding.

--- a/tools/regression/fixtures/review-committed-docs-deprecation-policy/README.md
+++ b/tools/regression/fixtures/review-committed-docs-deprecation-policy/README.md
@@ -1,0 +1,43 @@
+# Sanitized Fixture: Committed Review Docs Deprecation Policy
+
+This fixture is derived from a real mixed committed-review docs-policy dispute, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A committed review runs with explicit PR context for a mixed change that touches one provider Go file, one live reference doc, and one versioned upgrade guide.
+
+The implementation still accepts a legacy field on the non-5.0 path, but the live reference doc intentionally removes that field because it is legacy-only under the next-major deprecation model.
+
+The upgrade guide carries the migration guidance instead.
+
+## Simplified PR Shape
+
+```text
+PR Changed Files:
+- internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+- website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+- website/docs/guides/5.0-upgrade-guide.html.markdown
+
+Legacy field still accepted on transitional path:
+- minimum_tls_version
+```
+
+## Expected Review Behavior
+
+A correct committed review should:
+
+- Load and apply the docs contract and docs guidance for the `website/docs/**/*.html.markdown` files in scope
+- Treat `DOCS-DEPR-001` and `DOCS-DEPR-002` as authoritative for next-major deprecations
+- Accept removal of the legacy non-vNext field from the live reference doc
+- Treat the upgrade guide as the correct place for migration guidance
+- Cite the exact supporting docs rule IDs when explaining that behavior
+- Avoid raising a docs-parity issue that tries to restore the legacy field to the live reference doc
+
+## Expected Must-Catch Outcomes
+
+- `docs-deprecation-policy-applied`
+- `exact-docs-rule-citation`
+
+## Expected Must-Not-Flag Outcomes
+
+- `legacy-field-doc-parity-issue`

--- a/tools/regression/fixtures/review-committed-pr-authoritative-scope/README.md
+++ b/tools/regression/fixtures/review-committed-pr-authoritative-scope/README.md
@@ -1,0 +1,43 @@
+# Sanitized Fixture: Committed Review PR-Authoritative Scope
+
+This fixture is derived from a real committed-review scope-selection failure mode, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A committed review runs with explicit pull request context and a bounded PR diff.
+
+The authoritative PR scope contains one provider Go file modeled as `internal/services/example/example_resource.go`.
+
+The local branch also contains a separate docs-only commit modeled as `docs/TROUBLESHOOTING.md`, but that commit is not part of the active pull request.
+
+The benchmarked behavior is whether the committed review keeps the review body scoped to the PR diff instead of leaking the broader branch diff into files changed, findings, or review framing.
+
+## Simplified PR Shape
+
+```text
+PR Number: 4821
+PR Changed Files:
+- internal/services/example/example_resource.go
+
+Branch-only commits outside the PR:
+- docs/TROUBLESHOOTING.md
+```
+
+## Expected Review Behavior
+
+A correct committed review should:
+
+- Treat the explicit PR changed-file set as the authoritative committed-review scope
+- Keep `docs/TROUBLESHOOTING.md` and any other branch-only commits out of the files-changed section and out of findings
+- Describe the committed review as PR-scoped rather than as a generic branch diff against `origin/main...HEAD`
+- Continue to run `azurerm-linter` with PR scope for the in-scope provider Go file
+
+## Expected Must-Catch Outcomes
+
+- `pr-scope-authoritative`
+- `scope-reporting-consistency`
+
+## Expected Must-Not-Flag Outcomes
+
+- `branch-only-doc-finding`
+- `branch-wide-diff-framing`

--- a/tools/regression/fixtures/review-committed-pr-context-conflict/README.md
+++ b/tools/regression/fixtures/review-committed-pr-context-conflict/README.md
@@ -1,0 +1,28 @@
+# Sanitized Fixture: Committed Review PR Context Conflict
+
+This fixture is derived from a real committed-review scope-selection failure mode, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A committed review runs with both environment PR context and an explicit PR number supplied in the invocation text.
+
+The environment context resolves to PR `30997`, but the invocation text says `PR 30998`.
+
+There is no explicit user instruction that the supplied PR should override the active or viewed PR context.
+
+## Expected Review Behavior
+
+A correct committed review should:
+
+- Detect that the two PR targets conflict
+- Fail closed instead of silently choosing one PR target
+- Stop before running the normal review flow or `azurerm-linter`
+- Tell the user, in the prompt's pirate-style hard-stop voice, how to rerun with either the correct PR number or an explicit override
+
+## Expected Must-Catch Outcomes
+
+- `pr-context-conflict-hard-stop`
+
+## Expected Must-Not-Flag Outcomes
+
+- `silent-pr-selection`

--- a/tools/regression/fixtures/review-docs-datasource-example-lookup/README.md
+++ b/tools/regression/fixtures/review-docs-datasource-example-lookup/README.md
@@ -1,0 +1,40 @@
+# Sanitized Fixture: Docs Review For Data Source Lookup Examples
+
+This fixture is derived from a real docs-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A data source page modeled as `website/docs/d/example_subnet.html.markdown` is updated to show a minimal lookup example for an existing object.
+
+The modeled page uses identifying arguments only and does not declare the backing subnet, virtual network, or resource group on the same page.
+
+## Simplified Docs Shape
+
+```markdown
+## Example Usage
+
+```hcl
+data "azurerm_subnet" "example" {
+  name                 = "existing-subnet"
+  virtual_network_name = "existing-virtual-network"
+  resource_group_name  = "existing-resource-group"
+}
+```
+```
+
+## Expected Review Behavior
+
+A correct docs review should:
+
+- Load and apply the docs contract
+- Treat `DOCS-EX-022` as authoritative for data source lookup examples
+- Accept the example as a valid existing-object lookup pattern
+- Avoid requiring backing-resource scaffolding just to make the example look like a resource example
+
+## Expected Must-Catch Outcomes
+
+- `datasource-lookup-standard-applied`
+
+## Expected Must-Not-Flag Outcomes
+
+- `resource-scaffolding-required`


### PR DESCRIPTION
# Summary

Tightens committed-review scope resolution and updates the local docs example rules so resource examples remain self-contained while data source examples can model existing-object lookups without unnecessary backing-resource scaffolding.

## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

This PR fixes several AI-toolkit behavior issues in the local review and docs guidance surfaces.

On the committed-review side, it tightens PR-scope handling so committed review prefers authoritative PR context, supports explicit PR numbers without assuming `gh` is installed, and fails closed when environment PR context conflicts with a user-supplied PR unless the user explicitly requests an override. It also tightens mixed committed-review docs behavior so docs findings for `website/docs/**/*.html.markdown` must be grounded in exact `DOCS-*` rule IDs rather than generic docs-parity reasoning.

On the docs side, it aligns the local AI guidance with the clarified resource-versus-data-source example distinction: resource examples should be self-contained, while data source examples may assume an existing-object lookup scenario and should not add unnecessary backing-resource scaffolding. This behavior is enforced locally now through the contract, prompt, skill, and regression coverage so the assistance tools use the distinction immediately even before the upstream contributor-doc clarification is merged.

This PR also adds regression coverage for:
- PR-authoritative committed-review scope
- conflicting committed-review PR context
- committed-review docs deprecation-policy handling
- docs-review data source lookup example handling

## Type of Change

- [x] Bug fix
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Enhancement
- [ ] Breaking change

## Scope

- [ ] Installer
- [ ] Bash
- [ ] PowerShell
- [x] AI prompts (`.github/prompts/`)
- [x] AI instructions (`.github/instructions/`)
- [x] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

N/A

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

Ran the local maintainer validation flow and supporting targeted checks:

- `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1`
- `pwsh -NoProfile -File ./tools/check-upstream-contributor-drift.ps1`
- `pwsh -NoProfile -File ./tools/validate-contracts.ps1`
- `pwsh -NoProfile -File ./tools/regression/validate-regression-artifacts.ps1`
- `pwsh -NoProfile -File ./tools/regression/run-regression-suite.ps1 -Task code-review-committed-changes -CaseStatus adjudicated`
- `pwsh -NoProfile -File ./tools/regression/run-regression-suite.ps1 -Task code-review-docs -CaseStatus adjudicated`
- `npx -y markdownlint-cli2 ".github/**/*.md" "docs/**/*.md" "CHANGELOG.md" --config .github/.markdownlint.json`

Validation passed, including:
- contract validation
- markdown lint
- regression artifact validation
- committed-review adjudicated regression coverage
- docs-review adjudicated regression coverage
- upstream drift check with changed sources `0`, catalog issues `0`, and rule issues `0`

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

AI assisted with drafting and refining the prompt, contract, skill, docs, changelog, and regression-harness updates, plus validation command orchestration and PR description drafting.

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [x] Applied appropriate labels (examples: `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`)