### PR TITLE
[ENHANCEMENT:] Extend AI toolkit coverage for list resources, Ephemeral Resources, provider-defined Functions, and vendored review scope

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,6 +138,7 @@ When you give specific commands, I'll act directly:
 - [ ] Examine ALL `model_*.go` files for the resource
 - [ ] Verify service-specific patterns (SKU, identity types)
 - [ ] Document required/optional/computed fields
+- [ ] Plan Resource Identity and the corresponding List Resource for new resources unless there is a concrete upstream-supported exception
 - [ ] Make NO assumptions without API structure verification
 
 ## 🎯 **CLEAN CODE EXPERTISE** (HashiCorp PR Standards)

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -202,6 +202,17 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: When the review scope includes `internal/**/*.go` or `internal/**/*_test.go`, load and apply the applicable file-scoped instructions and skills.
 - Rule: Use those sources as the primary checklist for provider implementation and acceptance-test concerns rather than relying on stale prompt summaries.
 
+### REVIEW-SCOPE-005A: New resources must include required companion artifacts
+- Rule: When the review scope adds a brand-new resource under `internal/**/*.go`, review whether the required companion artifacts are present or explicitly justified.
+- Rule: For new resources, treat missing Resource Identity support, missing list resources, missing list-resource query tests, and missing list-resource docs as reviewable issues unless the change explicitly uses the maintainer-reviewed upstream exception path.
+- Rule: For the documentation companion, expect the corresponding list-resource doc page under `website/docs/list-resources/` when the new resource requires a list resource.
+- Rule: Do not treat upstream exception labels such as `allow-without-list` or `list-not-supported` as implicit; the review should only accept the omission when the exception is explicitly justified in the change context.
+
+### REVIEW-SCOPE-005B: Ephemeral resources and provider-defined functions must include their companions
+- Rule: When the review scope adds a new `*_ephemeral.go` implementation, review whether the required companion artifacts are present: service registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests under `*_ephemeral_test.go`.
+- Rule: When the review scope adds a new provider-defined function under `internal/provider/function/`, review whether the required companion artifacts are present: docs under `website/docs/functions/` and Terraform 1.8-gated unit tests under `internal/provider/function/*_test.go`.
+- Rule: Treat missing companion docs or tests for new ephemeral resources and provider-defined functions as reviewable issues.
+
 ### REVIEW-SCOPE-006: Manifest and bundle changes must match shipped content expectations
 - Rule: When file manifests, release-bundle lists, or installer packaging inputs change, review whether the changed entries remain consistent with the repository structure and the expected shipped assets.
 - Rule: Treat missing or mismatched prompt, instruction, skill, or installer entries as reviewable issues when the manifest is intended to distribute them.

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -172,7 +172,9 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: Vendor files must still be identified when they appear in the selected diff scope, but they should be excluded from actionable findings unless a current workspace instruction explicitly says otherwise.
 - Rule: Do not raise Issues that tell contributors to edit vendored files directly.
 - Rule: When a correctness concern appears to originate from vendored content, review the first actionable non-vendored source that controls or introduces that vendored change instead, such as dependency/version updates, generation inputs, or service client wiring.
-- Reviewer behavior: disclose vendored files as skipped non-actionable files rather than silently omitting them.
+- Reviewer behavior: disclose the count of vendored files skipped as non-actionable scope rather than silently omitting them or enumerating each vendored path in the review body.
+- Reviewer behavior: when the selected diff scope is entirely vendored files, say so explicitly in the review output so the reader understands the actionable review surface is limited.
+- Reviewer behavior: when vendored files make up the majority of the selected diff scope, say so explicitly in the review output so sparse actionable findings are not ambiguous.
 
 ## File-type-specific review coverage
 

--- a/.github/instructions/code-review-compliance-contract.instructions.md
+++ b/.github/instructions/code-review-compliance-contract.instructions.md
@@ -167,6 +167,13 @@ If evidence is missing for a claim that would change severity or requested actio
 - Rule: If explicit user-supplied PR context and environment PR context both exist and conflict, committed review must fail closed instead of silently choosing one.
 - Rule: The only allowed exception is an explicit user override that says the supplied PR should override the active or viewed PR context.
 
+### REVIEW-FILE-005: Vendored third-party files are non-actionable review scope
+- Rule: Files under `vendor/**` are non-actionable for normal code review because contributors are not expected to hand-edit or directly remediate vendored third-party content in this workflow.
+- Rule: Vendor files must still be identified when they appear in the selected diff scope, but they should be excluded from actionable findings unless a current workspace instruction explicitly says otherwise.
+- Rule: Do not raise Issues that tell contributors to edit vendored files directly.
+- Rule: When a correctness concern appears to originate from vendored content, review the first actionable non-vendored source that controls or introduces that vendored change instead, such as dependency/version updates, generation inputs, or service client wiring.
+- Reviewer behavior: disclose vendored files as skipped non-actionable files rather than silently omitting them.
+
 ## File-type-specific review coverage
 
 ### REVIEW-SCOPE-001: Always review user-visible content quality

--- a/.github/instructions/docs-compliance-contract.instructions.md
+++ b/.github/instructions/docs-compliance-contract.instructions.md
@@ -128,7 +128,7 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 - **Minimum** (as enforced today): `subcategory`, `layout`, `page_title`, `description`.
 
 ### DOCS-FM-007: Frontmatter must appear at the beginning of the file
-- **Rule**: Resource and data source reference docs MUST include YAML frontmatter at the beginning of the documentation file.
+- **Rule**: Resource, data source, list-resource, ephemeral-resource, and function reference docs MUST include YAML frontmatter at the beginning of the documentation file.
 
 ### DOCS-FM-003: Resource `page_title` canonical format
 - **Scope**: resource docs under `website/docs/r/**`.
@@ -139,19 +139,35 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 - **Rule**: You must include `Data Source:` in the YAML `page_title`.
 - **Rule**: Use the canonical format: `page_title: "Azure Resource Manager: Data Source: azurerm_<name>"`.
 
+### DOCS-FM-008: List resource `page_title` canonical format
+- **Scope**: list-resource docs under `website/docs/list-resources/**`.
+- **Rule**: List-resource docs MUST use the canonical YAML `page_title` format: `page_title: "Azure Resource Manager: azurerm_<name>"`.
+
+### DOCS-FM-009: Ephemeral resource `page_title` canonical format
+- **Scope**: ephemeral-resource docs under `website/docs/ephemeral-resources/**`.
+- **Rule**: Ephemeral-resource docs MUST use the canonical YAML `page_title` format: `page_title: "Azure Resource Manager: azurerm_<name>"`.
+
+### DOCS-FM-010: Function `page_title` canonical format
+- **Scope**: function docs under `website/docs/functions/**`.
+- **Rule**: Function docs MUST use the canonical YAML `page_title` format: `page_title: "Azure Resource Manager: <name>"`.
+
 ### DOCS-FM-004: Frontmatter `description` must match the doc type summary style
 - **Rule**: The YAML `description` MUST be a short summary sentence matching the doc type.
 - **Rule**: Resource docs MUST use the canonical resource summary style defined by `DOCS-WORD-003` (for example `Manages ...`).
 - **Rule**: Data source docs MUST use the canonical data source summary style defined by `DOCS-WORD-003` (for example `Gets information about an existing ...`).
+- **Rule**: List-resource docs MUST use the canonical list-resource summary style defined by `DOCS-WORD-003` (for example `Lists ... resources.`).
+- **Rule**: Ephemeral-resource docs MUST use the canonical ephemeral-resource summary style defined by `DOCS-WORD-003` (for example `Use this to access information about an existing ...`).
+- **Rule**: Function docs MUST use the canonical function summary style defined by `DOCS-WORD-003` (for example `Takes ...` or another implementation-backed function behavior sentence).
 
 ### DOCS-FM-005: `subcategory` must match the service website category
 - **Rule**: The YAML `subcategory` value MUST match the website category used for that service in the target provider repo.
 - **Rule**: When the target repo exposes an allowed-category list or existing service docs, use that evidence instead of guessing.
 - **Rule**: If multiple valid website categories exist for the same service, match the existing documentation for that service.
+- **Rule**: Function docs may use an empty-string `subcategory` when that matches the existing function docs in the target provider repo.
 - **Guardrail**: if the correct category cannot be proven from workspace evidence or the target repo standards, do not guess (see `DOCS-EVID-001`).
 
 ### DOCS-FM-006: `layout` must be `azurerm`
-- **Rule**: The YAML `layout` value for resource and data source reference docs MUST be `azurerm`.
+- **Rule**: The YAML `layout` value for resource, data source, list-resource, ephemeral-resource, and function reference docs MUST be `azurerm`.
 
 ---
 
@@ -160,15 +176,28 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 ### DOCS-STRUCT-006: Reference doc path and filename must match the Terraform name
 - **Rule**: Resource documentation for `azurerm_<name>` MUST live at `website/docs/r/<name>.html.markdown`.
 - **Rule**: Data source documentation for `azurerm_<name>` MUST live at `website/docs/d/<name>.html.markdown`.
+- **Rule**: List-resource documentation for `azurerm_<name>` MUST live at `website/docs/list-resources/<name>.html.markdown`.
+- **Rule**: Ephemeral-resource documentation for `azurerm_<name>` MUST live at `website/docs/ephemeral-resources/<name>.html.markdown`.
+- **Rule**: Function documentation for `<name>` MUST live at `website/docs/functions/<name>.html.markdown`.
 - **Rule**: The documentation filename MUST match the Terraform type suffix exactly.
 
 ### DOCS-STRUCT-001: Required sections by doc type
 - **Resource docs** (`website/docs/r/**`) MUST include: `Example Usage`, `Arguments Reference`, `Attributes Reference`, `Import`.
 - **Data source docs** (`website/docs/d/**`) MUST include: `Example Usage`, `Arguments Reference`, `Attributes Reference`.
 - **Data source docs** MUST NOT include: `Import`.
+- **List-resource docs** (`website/docs/list-resources/**`) MUST include: `Example Usage`, `Argument Reference`.
+- **List-resource docs** MUST NOT include: `Import`.
+- **Ephemeral-resource docs** (`website/docs/ephemeral-resources/**`) MUST include: `Example Usage`, `Argument Reference`, `Attributes Reference`.
+- **Ephemeral-resource docs** MUST NOT include: `Import`.
+- **Function docs** (`website/docs/functions/**`) MUST include: `Example Usage`, `Signature`, `Arguments`.
+- **Function docs** MUST NOT include: `Import` as a top-level reference-doc section.
 
 ### DOCS-STRUCT-002: Section order
-- **Rule**: Section order must follow repo standards (for example: Examples before Arguments, then Attributes, then Timeouts (if present), then Import (resources)).
+- **Rule**: Section order must follow repo standards by doc type.
+- **Rule**: Resource and data source docs use: Examples before Arguments, then Attributes, then Timeouts (if present), then Import (resources).
+- **Rule**: List-resource docs use: `Example Usage` before `Argument Reference`, followed by any optional follow-on sections that are evidence-backed for the list resource.
+- **Rule**: Ephemeral-resource docs use: required runtime-support note, summary sentence, `Example Usage`, `Argument Reference`, then `Attributes Reference`.
+- **Rule**: Function docs use: required runtime-support note, summary sentence, `Example Usage`, then any additional `Example ...` sections, then `Signature`, then `Arguments`.
 
 ### DOCS-STRUCT-003: Timeouts section presence
 - **Rule**: Include a `Timeouts` section only when the schema defines timeouts for the object.
@@ -176,11 +205,25 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 ### DOCS-STRUCT-004: Document title heading by doc type
 - **Resources** (`website/docs/r/**`): the top-level heading must be `# azurerm_<name>`.
 - **Data sources** (`website/docs/d/**`): the top-level heading must be `# Data Source: azurerm_<name>`.
+- **List resources** (`website/docs/list-resources/**`): the top-level heading must be `# List resource: azurerm_<name>`.
+- **Ephemeral resources** (`website/docs/ephemeral-resources/**`): the top-level heading must be `# Ephemeral: azurerm_<name>`.
+- **Functions** (`website/docs/functions/**`): the top-level heading must be `# Function: <name>`.
 
 ### DOCS-STRUCT-005: Summary sentence must appear directly below the title
-- **Rule**: Immediately below the top-level heading, the page MUST include a short summary sentence.
+- **Rule**: Immediately below the top-level heading, or immediately after any required doc-type runtime-support note, the page MUST include a short summary sentence.
 - **Rule**: Resource docs MUST use the canonical resource summary style defined by `DOCS-WORD-003` (for example `Manages ...`).
 - **Rule**: Data source docs MUST use the canonical data source summary style defined by `DOCS-WORD-003` (for example `Gets information about ...`).
+- **Rule**: List-resource docs MUST use the canonical list-resource summary style defined by `DOCS-WORD-003` (for example `Lists ... resources.`).
+- **Rule**: Ephemeral-resource docs MUST use the canonical ephemeral-resource summary style defined by `DOCS-WORD-003` (for example `Use this to access information about an existing ...`).
+- **Rule**: Function docs MUST use the canonical function summary style defined by `DOCS-WORD-003` (for example `Takes ...` or another implementation-backed function behavior sentence).
+
+### DOCS-STRUCT-007: Ephemeral-resource runtime support note
+- **Scope**: ephemeral-resource docs under `website/docs/ephemeral-resources/**`.
+- **Rule**: Ephemeral-resource docs MUST include the exact runtime-support note `~> **Note:** Ephemeral Resources are supported in Terraform 1.10 and later.` immediately below the title and before the summary sentence.
+
+### DOCS-STRUCT-008: Function runtime support note
+- **Scope**: function docs under `website/docs/functions/**`.
+- **Rule**: Function docs MUST include the exact runtime-support note `~> **Note:** Provider-defined functions are supported in Terraform 1.8 and later, and are available from version 4.0 of the provider.` immediately below the title and before the summary sentence.
 
 ---
 
@@ -189,6 +232,9 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 ### DOCS-FMT-001: Canonical section intro lines
 - Under `## Arguments Reference`: `The following arguments are supported:`
 - Under `## Attributes Reference`: `In addition to the Arguments listed above - the following Attributes are exported:`
+- Under `## Argument Reference` for list-resource docs: `This list resource supports the following arguments:`
+- Under `## Argument Reference` for ephemeral-resource docs: `The following arguments are supported:`
+- Under `## Attributes Reference` for ephemeral-resource docs: `The following attributes are exported:`
 
 ### DOCS-FMT-002: Backticks for arguments and values
 - **Rule**: Always use backticks around argument/attribute names (for example `resource_group_name`).
@@ -292,6 +338,9 @@ If you cannot locate workspace evidence for a claim that affects validity, do no
 - **Rule**: Examples MUST be functional for their intended scenario.
 - **Rule**: Resource examples must be functional and self-contained enough that a user can copy/paste them and run `terraform plan` without errors.
 - **Rule**: Data source examples must be functional for an existing-object lookup scenario and do not need to declare the looked-up object in the same example.
+- **Rule**: List-resource examples must be functional for a list query scenario and use Terraform `list` blocks rather than `resource` or `data` blocks for the primary example.
+- **Rule**: Ephemeral-resource examples must be functional for an ephemeral read scenario and use Terraform `ephemeral` blocks rather than `resource` or `data` blocks for the primary documented object.
+- **Rule**: Function examples must be functional for a provider-defined function scenario and call the documented function through `provider::azurerm::<name>(...)`.
 - **Provenance**: Published upstream standard.
 - **Evidence**:
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Examples`
@@ -404,7 +453,9 @@ Additional auditor behavior (deterministic suffix; nit-level):
 - If that validity cannot be proven from workspace evidence, do not guess; record an Observation per `DOCS-EVID-001`.
 
 ### DOCS-EX-008: Examples must not include `terraform` or `provider` blocks
-- **Rule**: Example Terraform configuration blocks must not include a `terraform { ... }` block or a `provider { ... }` block.
+- **Scope**: resource docs under `website/docs/r/**`, data source docs under `website/docs/d/**`, list-resource docs under `website/docs/list-resources/**`, and ephemeral-resource docs under `website/docs/ephemeral-resources/**`.
+- **Rule**: Example Terraform configuration blocks for those doc types must not include a `terraform { ... }` block or a `provider { ... }` block.
+- **Rule**: Function docs under `website/docs/functions/**` may include a `provider "azurerm"` block when needed to make the provider-defined function example runnable.
 - **Provenance**: Published upstream standard.
 - **Evidence**:
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Examples`
@@ -430,12 +481,13 @@ Additional auditor behavior (deterministic suffix; nit-level):
   - Keeps `Example*` sections aligned with the repository's copy/pasteable-example expectation
 
 ### DOCS-EX-013: Example instance name convention (style)
-- **Rule**: Generally, the resource/data source instance name in examples should be `example`.
+- **Rule**: Generally, the resource/data source/list-resource/ephemeral-resource instance name in examples should be `example`.
 - **Severity**: deviations are typically style-level and should not, by themselves, make a page invalid.
 
 ### DOCS-EX-014: Avoid multiple examples when possible
 - **Rule**: Avoid multiple examples unless a specific configuration is particularly difficult to configure.
 - **Rule**: If many complex examples are needed, prefer using the repository `examples/` folder instead of expanding the docs page.
+- **Rule**: List-resource docs may use multiple examples when they are showing distinct query scopes such as subscription-wide and narrowed query configurations.
 
 ### DOCS-EX-022: Data source examples should demonstrate existing-object lookups
 - **Scope**: data source docs under `website/docs/d/**`.
@@ -447,6 +499,36 @@ Additional auditor behavior (deterministic suffix; nit-level):
 - **Evidence**:
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Examples`
   - Proposed clarification in `hashicorp/terraform-provider-azurerm` PR `#32299` adds an explicit resource-example versus data-source-example split and says data source examples may assume the looked-up object already exists
+
+### DOCS-EX-023: List-resource examples must demonstrate list queries
+- **Scope**: list-resource docs under `website/docs/list-resources/**`.
+- **Rule**: The primary example blocks in list-resource docs MUST use Terraform `list "azurerm_<name>" "example"` syntax for the documented list resource.
+- **Rule**: List-resource examples should demonstrate the intended query scopes of the list resource, such as the default subscription-wide query and any supported narrowed query configuration.
+- **Rule**: Do not model the primary example as a `resource` or `data` block when the page is documenting a list resource.
+- **Provenance**: Published upstream standard.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` under `Add documentation for this List Resource`
+  - The upstream example there uses `list "azurerm_network_profile" "example"` blocks and shows multiple query-scope examples for the list resource
+
+### DOCS-EX-024: Ephemeral-resource examples must demonstrate ephemeral reads
+- **Scope**: ephemeral-resource docs under `website/docs/ephemeral-resources/**`.
+- **Rule**: The primary example blocks in ephemeral-resource docs MUST use Terraform `ephemeral "azurerm_<name>" "example"` syntax for the documented ephemeral resource.
+- **Rule**: Ephemeral-resource examples may include resource and data source blocks needed to source the ephemeral query inputs, but the primary documented object must remain an `ephemeral` block.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - The tracked upstream contributor docs do not currently expose a dedicated contributor topic for ephemeral-resource reference pages
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/ephemeral-resources/key_vault_secret.html.markdown`
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/ephemeral-resources/key_vault_certificate.html.markdown`
+
+### DOCS-EX-025: Function examples must call provider-defined functions
+- **Scope**: function docs under `website/docs/functions/**`.
+- **Rule**: Function examples MUST call the documented function using `provider::azurerm::<name>(...)` syntax.
+- **Rule**: Function docs may include additional example sections such as import-oriented examples when the function is specifically useful there.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - The tracked upstream contributor docs do not currently expose a dedicated contributor topic for provider-defined function reference pages
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/functions/parse_resource_id.html.markdown`
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/functions/normalise_resource_id.html.markdown`
 
 ### DOCS-EX-015: Deterministic example name value derivation (nit-level)
 - **Scope**: Example Terraform configuration blocks (`## Example*`).
@@ -523,15 +605,18 @@ Additional auditor behavior (deterministic suffix; nit-level):
 - **Example combined note pattern** (adjust wording to match the extracted constraint evidence):
   - `~> **Note:** The `X` block is required when `Y` is set to `A` and must not be specified when `Y` is not set to `A`.`
 
-### DOCS-NOTE-009: Data source field notes are prohibited
-- **Scope**: data source docs under `website/docs/d/**`.
-- **Rule**: Data source documentation for arguments, attributes, and nested fields MUST stay concise and limited to explaining what the field is.
-- **Rule**: Data source docs MUST NOT use field-level note blocks for additional caveats, setup guidance, conditional requirements, or extended explanations.
-- **Auditor behavior**: any field-level `-> **Note:**`, `~> **Note:**`, or `!> **Note:**` in a data source doc is an Issue.
+### DOCS-NOTE-009: Data source, list-resource, ephemeral-resource, and function field notes are prohibited
+- **Scope**: data source docs under `website/docs/d/**`, list-resource docs under `website/docs/list-resources/**`, ephemeral-resource docs under `website/docs/ephemeral-resources/**`, and function docs under `website/docs/functions/**`.
+- **Rule**: Data source, list-resource, ephemeral-resource, and function documentation for arguments, attributes, and nested fields MUST stay concise and limited to explaining what the field is.
+- **Rule**: Those doc types MUST NOT use field-level note blocks for additional caveats, setup guidance, conditional requirements, or extended explanations.
+- **Auditor behavior**: any field-level `-> **Note:**`, `~> **Note:**`, or `!> **Note:**` in a data source, list-resource, ephemeral-resource, or function doc is an Issue.
 - **Provenance**: Local safeguard.
 - **Evidence**:
   - Companion guidance in `.github/instructions/documentation-guidelines.instructions.md` prefers short, field-definitional data source bullets
-  - Added to keep `/code-review-docs` and `/docs-writer` deterministic and prevent drift toward over-explained data source fields
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` shows concise query-argument bullets for list-resource docs
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/ephemeral-resources/*.html.markdown` show concise ephemeral argument bullets plus only the top-level runtime-support note
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/functions/*.html.markdown` show concise argument lists plus only the top-level runtime-support note
+  - Added to keep `/code-review-docs` and `/docs-writer` deterministic and prevent drift toward over-explained non-resource docs
 
 ---
 
@@ -551,6 +636,27 @@ Additional auditor behavior (deterministic suffix; nit-level):
 - **Evidence**:
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-documentation-standards.md` under `Arguments` -> `Ordering`
   - That guidance defines ID-segment ordering, `location`, required arguments, then optional arguments with `tags` last
+
+### DOCS-ARG-012: List-resource query arguments should be ordered alphabetically
+- **Scope**: list-resource docs under `website/docs/list-resources/**`.
+- **Rule**: Query arguments in list-resource docs should be ordered alphabetically.
+- **Rule**: If the list-resource config schema marks an argument as required, keep required arguments first and then order within required and optional groups alphabetically.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` shows `resource_group_name` before `subscription_id` in the list-resource `Argument Reference`
+  - List-resource query config documents filters rather than resource identity fields, so the resource/data-source ID ordering pattern does not apply directly
+
+### DOCS-ARG-013: Function argument lists must follow function signature order
+- **Scope**: function docs under `website/docs/functions/**`.
+- **Rule**: The `## Arguments` section for function docs MUST list parameters in the same order as the implementation signature.
+- **Rule**: Function arguments should be documented as ordered list items rather than resource-style argument bullets.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - The tracked upstream contributor docs do not currently expose a dedicated contributor topic for provider-defined function reference pages
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/parse_resource_id.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/normalise_resource_id.go`
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/functions/parse_resource_id.html.markdown`
+  - Upstream provider docs under `hashicorp/terraform-provider-azurerm/website/docs/functions/normalise_resource_id.html.markdown`
 
 ### DOCS-ARG-003: ForceNew behavior must be documented
 - **Rule**: For `ForceNew: true` arguments, include the standard ForceNew sentence (see DOCS-WORD-001).
@@ -596,6 +702,9 @@ Example (rewrite long bullet to bullet + note):
 ### DOCS-ARG-006: ForceNew sentence scope (resources vs data sources)
 - **Rule**: Resource docs must use the ForceNew sentence for `ForceNew: true` fields.
 - **Rule**: Data source docs must not use ForceNew wording (data sources do not create resources).
+- **Rule**: List-resource docs must not use ForceNew wording (list resources do not create resources).
+- **Rule**: Ephemeral-resource docs must not use ForceNew wording (ephemeral resources do not create managed resources).
+- **Rule**: Function docs must not use ForceNew wording (functions do not create managed resources).
 
 ### DOCS-ARG-007: Required arguments must be documented
 - **Rule**: All schema required arguments/blocks must be documented in Arguments Reference.
@@ -637,7 +746,13 @@ Example (rewrite long bullet to bullet + note):
 ### DOCS-WORD-003: Resource vs data source summary sentence
 - **Rule**: Resource docs should start with an action verb (prefer `Manages ...`).
 - **Rule**: Data source docs should start with a retrieval verb (prefer `Gets information about ...`).
+- **Rule**: List-resource docs should start with a list verb (prefer `Lists ... resources.`).
+- **Rule**: Ephemeral-resource docs should start with `Use this to access information about an existing ...`.
+- **Rule**: Function docs should start with an implementation-backed behavior sentence (prefer `Takes ...` for input-transforming functions).
 - **Rule**: Data source summary sentences must not use resource-only wording (for example `Manages`, `Creates`, or ForceNew wording).
+- **Rule**: List-resource summary sentences must not use resource-only or data-source-only wording (for example `Manages`, `Creates`, or `Gets information about ...`).
+- **Rule**: Ephemeral-resource summary sentences must not use managed-resource wording such as `Manages` or `Creates`.
+- **Rule**: Function summary sentences must not use resource/data source wording such as `Manages`, `Creates`, or `Gets information about an existing ...`.
 
 ### DOCS-WORD-004: `*_enabled` field phrasing
 - **Rule**: In resource docs, for boolean fields ending in `_enabled`, prefer: `Whether <thing> is enabled.`

--- a/.github/instructions/documentation-guidelines.instructions.md
+++ b/.github/instructions/documentation-guidelines.instructions.md
@@ -7,7 +7,7 @@ description: This document outlines the standards and guidelines for writing doc
 
 <a id="documentation-guidelines"></a>
 
-This document outlines the standards and guidelines for writing documentation for Terraform resources and data sources in the AzureRM provider.
+This document outlines the standards and guidelines for writing documentation for Terraform resources, data sources, list resources, ephemeral resources, and provider-defined functions in the AzureRM provider.
 
 <a id="quick-navigation"></a>
 
@@ -17,7 +17,7 @@ Core: <a href="#canonical-sources">Canonical sources</a> | <a href="#optional-ai
 
 AI checks: <a href="#ai-docs-style-enforcement">Style enforcement</a> | <a href="#ai-docs-forcenew-subset">ForceNew subset switching</a> | <a href="#ai-docs-enabled-fields">`*_enabled` wording</a> | <a href="#ai-docs-block-placement">Block placement</a> | <a href="#ai-docs-secrets">Secrets</a> | <a href="#ai-docs-audit">Schema parity</a> | <a href="#ai-docs-quick-audit">Quick audit</a> | <a href="#ai-docs-post-edit">Post-edit</a>
 
-Reference: <a href="#📚-key-differences-resources-vs-data-sources">Resources vs data sources</a> | <a href="#🏗️-documentation-structure">Doc structure</a> | <a href="#📄-resource-documentation-template">Resource template</a> | <a href="#📊-data-source-documentation-template">Data source template</a> | <a href="#✍️-writing-guidelines">Writing guidelines</a> | <a href="#💡-example-configuration-guidelines">Examples</a> | <a href="#📁-import-documentation">Import</a> | <a href="#⏱️-timeout-documentation">Timeouts</a> | <a href="#☁️-azure-specific-documentation-patterns">Azure patterns</a> | <a href="#📋-attributes-reference-differences">Attributes</a> | <a href="#📝-field-documentation-rules">Field rules</a>
+Reference: <a href="#📚-key-differences-resources-vs-data-sources">Resources vs data sources</a> | <a href="#🧾-list-resource-documentation-guidance">List resources</a> | <a href="#⚡-ephemeral-resource-documentation-guidance">Ephemeral resources</a> | <a href="#🔧-function-documentation-guidance">Functions</a> | <a href="#🏗️-documentation-structure">Doc structure</a> | <a href="#📄-resource-documentation-template">Resource template</a> | <a href="#📊-data-source-documentation-template">Data source template</a> | <a href="#✍️-writing-guidelines">Writing guidelines</a> | <a href="#💡-example-configuration-guidelines">Examples</a> | <a href="#📁-import-documentation">Import</a> | <a href="#⏱️-timeout-documentation">Timeouts</a> | <a href="#☁️-azure-specific-documentation-patterns">Azure patterns</a> | <a href="#📋-attributes-reference-differences">Attributes</a> | <a href="#📝-field-documentation-rules">Field rules</a>
 
 <a id="canonical-sources"></a>
 
@@ -71,12 +71,60 @@ Use this file for companion guidance:
 - illustrative templates and snippets
 
 Practical authoring reminders:
-- Preserve the resource vs data source distinction in tone and examples.
+- Preserve the resource vs data source vs list-resource vs ephemeral-resource vs function distinction in tone and examples.
 - Repeat the short summary sentence immediately below the top-level heading; for the exact requirement, see `DOCS-STRUCT-005` and `DOCS-WORD-003` in the contract.
 - In resource docs, keep argument descriptions short, then move caveats or conditions into notes.
 - In data source docs, keep field descriptions short and limited to explaining what the field is; do not use field-level note blocks.
+- In list-resource docs, keep query-argument descriptions short and limited to explaining what the field is; do not use field-level note blocks.
+- In ephemeral-resource docs, keep query arguments and exported attributes short and field-definitional; use only the top-level Terraform-version support note, not field-level note blocks.
+- In function docs, keep the `Arguments` section short and parameter-focused; use only the top-level runtime-support note, not field-level note blocks.
 - Prefer shared example dependencies in the primary `## Example Usage` block.
+- For list-resource pages, prefer query examples that use Terraform `list` blocks and show the supported query scopes instead of resource or data examples.
+- For ephemeral-resource pages, prefer primary examples that use Terraform `ephemeral` blocks and source any needed IDs from nearby resource/data examples.
+- For function pages, prefer examples that call `provider::azurerm::<name>(...)` directly and add provider/output/import scaffolding only when needed to make the example runnable.
 - When a rule needs exact wording or ordering, look up the contract instead of relying on memory.
+
+## 🧾 List Resource Documentation Guidance
+
+List-resource documentation is written manually under `website/docs/list-resources/`.
+
+Companion guidance:
+- Use the title shape `# List resource: azurerm_<name>`.
+- Use a short summary sentence that starts with `Lists ... resources.`.
+- Use `## Example Usage` followed by `## Argument Reference` for the default structure.
+- Use the intro line `This list resource supports the following arguments:`.
+- Model primary examples with Terraform `list "azurerm_<name>" "example"` blocks.
+- Query arguments such as `resource_group_name` and `subscription_id` should be concise and field-definitional, similar to data source query inputs.
+- Do not add an `Import` section for list-resource docs.
+- List-resource docs are manual and should not rely on the standard website scaffold flow.
+
+## ⚡ Ephemeral Resource Documentation Guidance
+
+Ephemeral-resource documentation is written manually under `website/docs/ephemeral-resources/`.
+
+Companion guidance:
+- Use the title shape `# Ephemeral: azurerm_<name>`.
+- Add the exact Terraform-version support note for Ephemeral Resources immediately below the title.
+- Use a short summary sentence that starts with `Use this to access information about an existing ...`.
+- Use `## Example Usage`, `## Argument Reference`, and `## Attributes Reference` as the default structure.
+- Model primary examples with Terraform `ephemeral "azurerm_<name>" "example"` blocks.
+- Use the intro line `The following attributes are exported:` for the attributes section.
+- Do not add an `Import` section for ephemeral-resource docs.
+- Ephemeral-resource docs are manual and should not rely on the standard website scaffold flow.
+
+## 🔧 Function Documentation Guidance
+
+Function documentation is written manually under `website/docs/functions/`.
+
+Companion guidance:
+- Use the title shape `# Function: <name>`.
+- Add the exact provider-defined function runtime-support note immediately below the title.
+- Use a short summary sentence that describes the function behavior, typically starting with `Takes ...` when the function transforms an input value.
+- Use `## Example Usage`, any additional `## Example ...` sections, then `## Signature`, then `## Arguments`.
+- Use `provider::azurerm::<name>(...)` syntax in the function examples.
+- A `provider "azurerm"` block is acceptable in function examples when it makes the example runnable.
+- Do not add a top-level `Import` section for function docs, though import-oriented example sections are acceptable when they are the point of the function.
+- Function docs are manual and should not rely on the standard website scaffold flow.
 
 ### Mandatory HashiCorp docs style enforcement
 

--- a/.github/instructions/implementation-compliance-contract.instructions.md
+++ b/.github/instructions/implementation-compliance-contract.instructions.md
@@ -105,6 +105,58 @@ If evidence is missing for a behavior-changing claim, do not guess.
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/best-practices.md` under `Typed vs. Untyped Resources`
   - Upstream contributor guidance there says new Data Sources and Resources should be added as typed implementations
 
+### IMPL-WF-002: New resources must include resource identity and list-resource planning
+- Rule: For new resources, plan and implement Resource Identity support as a prerequisite for the list resource.
+- Rule: For new resources, plan and implement a corresponding list resource by default.
+- Rule: If a new resource genuinely cannot support listing because no list API exists or the upstream provider workflow allows an exception, do not silently omit the list resource; explain the reason and use the maintainer-reviewed exception path instead.
+- Rule: Treat the upstream `allow-without-list` and `list-not-supported` labels as exception handling, not as the default workflow.
+- **Provenance**: Published upstream standard.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-new-resource.md` Step 5 and Step 6 says Resource Identity and List Resource implementations are mandatory for all new resources
+  - Upstream contributor guidance there says pull requests adding new resources without these will not pass CI checks unless a maintainer applies the `allow-without-list` or `list-not-supported` label
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` says list resource implementations are mandatory for all new resources and are verified by the `enforce-list-resources` CI check
+
+### IMPL-WF-002A: Existing resources retrofitting list support should add the full companion set together
+- Rule: When adding list support to an existing resource, plan Resource Identity, the `*_resource_list.go` implementation, service registration, list-query acceptance coverage, and list-resource docs as one workflow.
+- Rule: Do not treat list registration, list tests, or list-resource docs as optional follow-up work when the change is explicitly adding list support to an existing resource.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` describes the full list-resource workflow: identity prerequisite, implementation, tests, and docs
+  - Upstream provider PR `hashicorp/terraform-provider-azurerm#32192` (`List and identity implementation - azurerm_web_pubsub_custom_certificate`) is a concrete example of retrofitting an existing resource with Resource Identity, list implementation, list tests, and list-resource docs together
+
+### IMPL-WF-003: New resources must include the required documentation companions
+- Rule: For new resources, plan and implement the primary resource documentation and the corresponding list-resource documentation when a list resource is required.
+- Rule: Place list-resource docs under `website/docs/list-resources/` and treat them as part of the default new-resource workflow, not as an optional follow-up.
+- Rule: If a new resource is using the maintainer-reviewed exception path that omits the list resource, explicitly document that exception in the PR rather than silently skipping the list-resource docs.
+- **Provenance**: Published upstream standard.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-new-resource.md` Step 10 says new resources must add documentation for the resource
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` Step 7 says list resources require manual documentation under `website/docs/list-resources/`
+  - The same upstream workflow now makes list resources mandatory for all new resources unless a maintainer applies the documented exception path
+
+### IMPL-WF-004: Ephemeral resources must follow the framework ephemeral pattern
+- Rule: Implement provider ephemeral resources under the owning service package as `*_ephemeral.go` using the `sdk.EphemeralResource` pattern.
+- Rule: Ephemeral resources should use `Metadata`, `Configure`, `Schema`, and `Open` rather than CRUD lifecycle methods.
+- Rule: Register new ephemeral resources through the service `Registration.EphemeralResources()` hook.
+- Rule: Treat `website/docs/ephemeral-resources/` docs and `*_ephemeral_test.go` coverage as the required companions for a new ephemeral resource.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/sdk/ephemeral_resource.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/services/keyvault/key_vault_secret_ephemeral.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/services/keyvault/registration.go`
+  - Upstream provider docs in `hashicorp/terraform-provider-azurerm/website/docs/ephemeral-resources/key_vault_secret.html.markdown`
+
+### IMPL-WF-005: Provider-defined functions must follow the internal provider-function pattern
+- Rule: Implement provider-defined functions under `internal/provider/function/` using the `terraform-plugin-framework/function.Function` pattern.
+- Rule: Provider-defined functions should implement `Metadata`, `Definition`, and `Run`, and should expose their name, arguments, and return shape through `Definition`.
+- Rule: Treat `website/docs/functions/` docs and `internal/provider/function/*_test.go` coverage as the required companions for a new provider-defined function.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/parse_resource_id.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/normalise_resource_id.go`
+  - Upstream provider docs in `hashicorp/terraform-provider-azurerm/website/docs/functions/parse_resource_id.html.markdown`
+  - Upstream provider docs in `hashicorp/terraform-provider-azurerm/website/docs/functions/normalise_resource_id.html.markdown`
+
 ## Schema and mapping
 
 ### IMPL-SCHEMA-001: Schema requirements must match real behavior

--- a/.github/instructions/implementation-guide.instructions.md
+++ b/.github/instructions/implementation-guide.instructions.md
@@ -794,8 +794,13 @@ d.SetId(id.ID())
 
 - New service packages require `internal/services/<service>/client/client.go`, `registration.go`, provider service registration, client registration, and a `make generate` pass before feature work starts.
 - New provider feature flags must be wired through `internal/features`, `internal/provider`, `internal/provider/framework`, their respective tests, and the target resource behavior.
+- List resources are mandatory for all new resources unless the upstream maintainer exception path is explicitly used because no list API exists.
 - List resources are specialized framework resources, not ordinary resources. Implement resource identity first, extract a reusable flatten helper from the parent resource read path, wrap the base resource with `sdk.FrameworkListWrappedResource`, register it in `registration.go`, and add Terraform 1.14 list query tests plus list-resource docs.
+- If a new resource cannot support a list resource, do not silently proceed without one; document the reason and use the maintainer-reviewed `allow-without-list` or `list-not-supported` label path.
 - If a list resource iterator needs extra API reads during flattening, recreate a context with the original deadline because the iterator runs after the original list context has been cancelled.
+- When retrofitting list support onto an existing resource, ship the identity, list implementation, service registration, list-query tests, and list-resource docs together rather than treating the docs or registration as optional follow-up cleanup.
+- Ephemeral resources are framework read patterns, not managed resources. Implement them as `*_ephemeral.go` using `sdk.EphemeralResource`, wire `Metadata`, `Configure`, `Schema`, and `Open`, register them through `EphemeralResources()`, add docs under `website/docs/ephemeral-resources/`, and add Terraform 1.10-gated `*_ephemeral_test.go` coverage.
+- Provider-defined functions live under `internal/provider/function/`. Implement `Metadata`, `Definition`, and `Run`, keep the docs under `website/docs/functions/` aligned to the function signature and behavior, and add Terraform 1.8-gated unit tests under `internal/provider/function/*_test.go`.
 
 Official upstream references:
 
@@ -834,10 +839,12 @@ New Resource Request
 │
 └─ Implementation Order
    ├─ 1. Define model structs (Typed) or schema (Untyped)
-   ├─ 2. Implement CRUD operations
-   ├─ 3. Add validation and error handling
-   ├─ 4. Create acceptance tests
-   └─ 5. Write documentation
+    ├─ 2. Implement Resource Identity
+    ├─ 3. Implement CRUD operations
+    ├─ 4. Implement the corresponding List Resource
+    ├─ 5. Add validation and error handling
+    ├─ 6. Create acceptance tests, including list query tests
+    └─ 7. Write resource and list-resource documentation
 ```
 
 #### Cross-Implementation Consistency Validation

--- a/.github/instructions/testing-compliance-contract.instructions.md
+++ b/.github/instructions/testing-compliance-contract.instructions.md
@@ -108,6 +108,32 @@ If evidence is missing for a behavior-changing testing claim, do not guess.
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/reference-acceptance-testing.md` under `Which Tests are Required?`
   - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-new-resource.md` Step 6 and Step 7 examples
 
+### TEST-WF-003: New resources with list resources should include list query coverage
+- Rule: When adding a new resource that includes a list resource, add list-resource acceptance coverage using Terraform 1.14 query tests.
+- Rule: The list-resource test should provision multiple resources, exercise the base list query, and cover at least one narrowed query path when the list configuration supports it.
+- Rule: Only omit list-resource acceptance coverage when the list resource itself is legitimately omitted under the maintainer-reviewed exception path.
+- **Provenance**: Published upstream standard.
+- **Evidence**:
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/guide-list-resource.md` under `Add Acceptance Tests for this List Resource`
+  - Upstream contributor guidance there shows Terraform 1.14 query-based tests as the expected validation path for list resources added alongside new resources
+
+### TEST-WF-004: Ephemeral resource tests should use the framework ephemeral test pattern
+- Rule: Acceptance tests for provider ephemeral resources should use the service-local `*_ephemeral_test.go` pattern with `acceptance.BuildTestData(t, "ephemeral.azurerm_<name>", ...)`.
+- Rule: Ephemeral-resource acceptance tests should gate on Terraform 1.10 support and use the framework provider factories required by the upstream ephemeral pattern.
+- Rule: When the test needs to assert the ephemeral result payload, prefer the `echo` provider pattern with config-state checks rather than inventing a custom assertion mechanism.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/services/keyvault/key_vault_secret_ephemeral_test.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/services/keyvault/key_vault_certificate_ephemeral_test.go`
+
+### TEST-WF-005: Provider-defined functions should use focused framework unit tests
+- Rule: Provider-defined function tests should live under `internal/provider/function/*_test.go` and use `resource.UnitTest` with framework provider factories.
+- Rule: Provider-defined function tests should gate on Terraform 1.8 support and prove outputs from `provider::azurerm::<name>(...)` calls rather than inventing a resource-style lifecycle harness.
+- **Provenance**: Inferred maintainer convention.
+- **Evidence**:
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/parse_resource_id_test.go`
+  - Upstream provider implementation in `hashicorp/terraform-provider-azurerm/internal/provider/function/normalise_resource_id_test.go`
+
 ## Execution safety
 
 ### TEST-RUN-001: Treat acceptance tests as real Azure activity

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -111,7 +111,7 @@ Rules:
 ### 2) Classify files accurately
 - Parse the diff stat carefully so added, modified, and deleted files are counted correctly.
 - Do not silently skip files that belong to the committed review scope.
-- Identify files under `vendor/**` and mark them as skipped non-actionable files per `REVIEW-FILE-005` rather than treating them as ordinary review targets.
+- Identify files under `vendor/**`, exclude them from actionable review targets, and report only the skipped vendored-file count per `REVIEW-FILE-005`.
 
 ### 3) Load applicable workspace standards
 - Discover repo-level contributor guidance in the current workspace before reading it.
@@ -192,7 +192,8 @@ Rules:
 - Review the full committed change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
-- Treat vendored files under `vendor/**` as skipped non-actionable files: disclose them, but do not raise Issues that require directly editing vendored content.
+- Treat vendored files under `vendor/**` as skipped non-actionable files: report only the skipped vendored-file count, and do not raise Issues that require directly editing vendored content.
+- When the selected committed diff is vendored-only or vendored-heavy, say so explicitly in the summary or notes so sparse actionable findings are easy to interpret.
 - When `website/docs/**/*.html.markdown` files are in scope, explicitly apply the docs contract's deprecation and upgrade-guide rules before raising docs Issues about removed legacy fields.
 - When `website/docs/**/*.html.markdown` files are in scope, any docs Issue in the review body must include the exact supporting `DOCS-*` rule ID or IDs.
 - Do not emit generic docs-parity Issues for `website/docs/**/*.html.markdown` files without exact `DOCS-*` rule support and evidence.
@@ -240,8 +241,7 @@ Use this template:
 **Deleted Files:**
 - `path/to/file`
 
-**Skipped Vendored Files:**
-- `vendor/path/to/file`
+**Skipped Vendored Files:** [count]
 
 ## 🎯 **PRIMARY CHANGES ANALYSIS**
 [Brief explanation of the branch changes and their purpose.]
@@ -256,7 +256,7 @@ Use this template:
 - **Repo Guidance**: [contributor docs / instructions / skills actually used]
 - **Scope Rules**: [which `REVIEW-SCOPE-*` rules were relevant]
 - **Docs Contract**: [whether `DOCS-*` rules were loaded for `website/docs/**/*.html.markdown` files in scope]
-- **Notes**: [scope-specific guidance that affected severity or classification, including any vendored files skipped as non-actionable]
+- **Notes**: [scope-specific guidance that affected severity or classification, including whether the change-set is vendored-only or vendored-heavy]
 
 ### 🧰 **AZURERM LINTER**
 - **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -194,6 +194,9 @@ Rules:
 - When `website/docs/**/*.html.markdown` files are in scope, explicitly apply the docs contract's deprecation and upgrade-guide rules before raising docs Issues about removed legacy fields.
 - When `website/docs/**/*.html.markdown` files are in scope, any docs Issue in the review body must include the exact supporting `DOCS-*` rule ID or IDs.
 - Do not emit generic docs-parity Issues for `website/docs/**/*.html.markdown` files without exact `DOCS-*` rule support and evidence.
+- When `internal/**/*.go` scope adds a brand-new resource, explicitly inspect whether the required companion artifacts from the implementation and testing guidance are present: Resource Identity, list resource, list-resource query tests, and list-resource docs.
+- When the change adds a new `*_ephemeral.go` implementation, explicitly inspect whether the required companion artifacts are present: `EphemeralResources()` registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests under `*_ephemeral_test.go`.
+- When the change adds a new provider-defined function under `internal/provider/function/`, explicitly inspect whether the required companion artifacts are present: docs under `website/docs/functions/` and Terraform 1.8-gated tests under `internal/provider/function/*_test.go`.
 - When `internal/**/*_test.go` files are in scope, explicitly inspect embedded Terraform configuration strings and apply the `REVIEW-TEST-*` rules for formatting drift instead of assuming `azurerm-linter` will catch those issues.
 - Keep the review concise but complete.
 

--- a/.github/prompts/code-review-committed-changes.prompt.md
+++ b/.github/prompts/code-review-committed-changes.prompt.md
@@ -111,6 +111,7 @@ Rules:
 ### 2) Classify files accurately
 - Parse the diff stat carefully so added, modified, and deleted files are counted correctly.
 - Do not silently skip files that belong to the committed review scope.
+- Identify files under `vendor/**` and mark them as skipped non-actionable files per `REVIEW-FILE-005` rather than treating them as ordinary review targets.
 
 ### 3) Load applicable workspace standards
 - Discover repo-level contributor guidance in the current workspace before reading it.
@@ -191,6 +192,7 @@ Rules:
 - Review the full committed change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
+- Treat vendored files under `vendor/**` as skipped non-actionable files: disclose them, but do not raise Issues that require directly editing vendored content.
 - When `website/docs/**/*.html.markdown` files are in scope, explicitly apply the docs contract's deprecation and upgrade-guide rules before raising docs Issues about removed legacy fields.
 - When `website/docs/**/*.html.markdown` files are in scope, any docs Issue in the review body must include the exact supporting `DOCS-*` rule ID or IDs.
 - Do not emit generic docs-parity Issues for `website/docs/**/*.html.markdown` files without exact `DOCS-*` rule support and evidence.
@@ -238,6 +240,9 @@ Use this template:
 **Deleted Files:**
 - `path/to/file`
 
+**Skipped Vendored Files:**
+- `vendor/path/to/file`
+
 ## 🎯 **PRIMARY CHANGES ANALYSIS**
 [Brief explanation of the branch changes and their purpose.]
 
@@ -251,7 +256,7 @@ Use this template:
 - **Repo Guidance**: [contributor docs / instructions / skills actually used]
 - **Scope Rules**: [which `REVIEW-SCOPE-*` rules were relevant]
 - **Docs Contract**: [whether `DOCS-*` rules were loaded for `website/docs/**/*.html.markdown` files in scope]
-- **Notes**: [scope-specific guidance that affected severity or classification]
+- **Notes**: [scope-specific guidance that affected severity or classification, including any vendored files skipped as non-actionable]
 
 ### 🧰 **AZURERM LINTER**
 - **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]

--- a/.github/prompts/code-review-docs.prompt.md
+++ b/.github/prompts/code-review-docs.prompt.md
@@ -108,14 +108,23 @@ Rules (mandatory):
 ### 1) Identify the Terraform object from the doc path
 - Resource docs: `website/docs/r/<name>.html.markdown` → `azurerm_<name>`
 - Data source docs: `website/docs/d/<name>.html.markdown` → `azurerm_<name>`
+- List-resource docs: `website/docs/list-resources/<name>.html.markdown` → `azurerm_<name>`
+- Ephemeral-resource docs: `website/docs/ephemeral-resources/<name>.html.markdown` → `azurerm_<name>`
+- Function docs: `website/docs/functions/<name>.html.markdown` → `<name>`
 
 Also record the **doc type** from the path:
 - `website/docs/r/**` => **Resource** documentation rules
 - `website/docs/d/**` => **Data Source** documentation rules
+- `website/docs/list-resources/**` => **List Resource** documentation rules
+- `website/docs/ephemeral-resources/**` => **Ephemeral Resource** documentation rules
+- `website/docs/functions/**` => **Function** documentation rules
 
 ### 2) Locate the schema in `internal/**`
 - Search under `internal/**` for the Terraform name (e.g. `azurerm_<name>`).
 - Open the relevant registration/implementation files until you find the Terraform schema definition.
+- For list-resource docs, locate both the base resource implementation and the corresponding `*_resource_list.go` implementation so you can verify the list query config schema and the list-resource-specific example behavior.
+- For ephemeral-resource docs, locate the corresponding `*_ephemeral.go` implementation and the service `registration.go` entry so you can verify the ephemeral schema and the registration pattern.
+- For function docs, locate the corresponding implementation under `internal/provider/function/<name>.go` and its test file under `internal/provider/function/`.
 - Record the schema file path(s) used.
 
 If you cannot find the schema, say so explicitly and continue with a docs-only standards review.
@@ -128,11 +137,24 @@ From the schema, extract:
 - ForceNew fields (`ForceNew: true`)
 - constraints that affect docs (e.g. `ConflictsWith`, `ExactlyOneOf`, `AtLeastOneOf`, validations), if clearly visible
 
+List-resource specialization (mandatory):
+- For list-resource docs, treat the list resource config schema as the authoritative source for `Argument Reference`.
+- For list-resource docs, validate the `list "azurerm_<name>" ...` examples against the list resource config schema and any list-resource-specific behavior proven by the `*_resource_list.go` implementation.
+
+Ephemeral-resource specialization (mandatory):
+- For ephemeral-resource docs, treat the `*_ephemeral.go` schema as the authoritative source for `Argument Reference` and `Attributes Reference`.
+- For ephemeral-resource docs, validate the `ephemeral "azurerm_<name>" ...` examples against the ephemeral resource schema and any implementation-backed behavior proven by `Open(...)`.
+
+Function specialization (mandatory):
+- For function docs, treat the implementation under `internal/provider/function/<name>.go` as the authoritative source for the function name, summary, signature, arguments, and return shape.
+- For function docs, validate `provider::azurerm::<name>(...)` usage against the function `Definition(...)` and `Run(...)` implementations rather than ordinary resource schema rules.
+
 **Mandatory: validate all example-used fields against schema evidence (not just `name`)**
 - Enumerate every argument assignment used in any Terraform configuration block under headings starting with `Example` (for example: `name = ...`, `sku_name = ...`, `ttl = ...`, nested blocks, and meta-arguments like `depends_on`).
 - Mandatory scope expansion (prevents skipped auxiliary blocks):
-  - This validation applies to **every** Terraform `resource` and `data` block that appears in any `Example*` section, not only the primary object being documented.
-  - For each such block type (for example `azurerm_resource_group`, `azurerm_dns_zone`, etc.), you MUST locate its schema under `internal/**` and validate the example-used fields against that schema/implementation evidence.
+  - This validation applies to **every** Terraform `resource`, `data`, and `ephemeral` block that appears in any `Example*` section, not only the primary object being documented.
+  - For each such block type (for example `azurerm_resource_group`, `azurerm_dns_zone`, or `azurerm_key_vault_secret` in an `ephemeral` block), you MUST locate its schema under `internal/**` and validate the example-used fields against that schema/implementation evidence.
+  - For function docs, also validate every `provider::azurerm::<name>(...)` call in `Example*` sections against the implementation under `internal/provider/function/<name>.go`.
 - For each referenced field, locate and record the relevant schema/implementation evidence that constrains it, including (when present):
   - `ValidateFunc` (regex/length/charset/enums)
   - `ConflictsWith`, `ExactlyOneOf`, `AtLeastOneOf`, `RequiredWith`
@@ -185,6 +207,9 @@ Evidence requirements:
 Doc requirements (contract-driven):
 - In resource docs, any constraint that affects valid config must be documented as notes per `DOCS-NOTE-*`.
 - In data source docs, enforce the contract rule that field documentation stays concise and limited to explaining what the field is, with no field-level note blocks.
+- In list-resource docs, enforce the contract rule that query-argument documentation stays concise and limited to explaining what the field is, with no field-level note blocks.
+- In ephemeral-resource docs, enforce the contract rule that query arguments and exported attributes stay concise and limited to what the field is, with only the top-level runtime-support note.
+- In function docs, enforce the contract rule that the `Arguments` section stays concise and parameter-focused, with only the top-level runtime-support note.
 - If evidence cannot be proven, do not guess; record an Observation per `DOCS-EVID-001`.
 
 ### 4) Audit the documentation (contract-driven)
@@ -201,7 +226,9 @@ Internal multi-pass audit (mandatory):
 - **Index pass (internal only)**: build a mental index of major headings and block subsections.
 - **Structure pass**: enforce `DOCS-FM-*` and `DOCS-STRUCT-*` (frontmatter, required sections, section order).
     - Mandatory exact-intro checks (contract-driven; prevents tiny drift):
-      - Under `## Attributes Reference`, the intro line MUST be exactly: `In addition to the Arguments listed above - the following Attributes are exported:` (hyphen form, not a comma).
+    - Under `## Attributes Reference` for resource and data source docs, the intro line MUST be exactly: `In addition to the Arguments listed above - the following Attributes are exported:` (hyphen form, not a comma).
+      - Under `## Argument Reference` for list-resource docs, the intro line MUST be exactly: `This list resource supports the following arguments:`.
+    - Under `## Attributes Reference` for ephemeral-resource docs, the intro line MUST be exactly: `The following attributes are exported:`.
 - **Arguments/Attributes pass**:
     - Top-level ordering and coverage (`DOCS-ARG-*`, `DOCS-ATTR-*`)
     - Block shape + subsection placement/order (`DOCS-SHAPE-001/002/003/004/005`)
@@ -209,8 +236,11 @@ Internal multi-pass audit (mandatory):
     - Bullet conciseness + note splitting (`DOCS-ARG-011`, `DOCS-NOTE-*`)
     - Trigger (mandatory; prevents misses): in resource docs, if any argument bullet contains more than 2 sentences OR mixes definition text with validation-style constraints (length/charset/regex/start/end rules) OR contains both a long constraints clause and the ForceNew sentence, you MUST treat it as a `DOCS-ARG-011` failure and split the constraints into an inline note under the bullet.
     - Data source rule (mandatory): in data source docs, if a field bullet contains extended caveats or a field-level note block, you MUST treat it as a contract failure and require the text to be reduced to a short explanation of what the field is.
+    - List-resource rule (mandatory): in list-resource docs, if a query-argument bullet contains extended caveats or a field-level note block, you MUST treat it as a contract failure and require the text to be reduced to a short explanation of what the field is.
+    - Ephemeral-resource rule (mandatory): in ephemeral-resource docs, if an argument or attribute bullet contains extended caveats or a field-level note block, you MUST treat it as a contract failure and require the text to be reduced to a short explanation of what the field is.
+    - Function rule (mandatory): in function docs, if an argument item contains extended caveats or a field-level note block, you MUST treat it as a contract failure and require the text to be reduced to a short explanation of what the parameter is.
     - Note format (mandatory): when a resource field note is required, the inline note MUST use `(->|~>|!>) **Note:**` per `DOCS-NOTE-003`.
-- **Examples pass**: enforce `DOCS-EX-*` (fences, resource self-containedness, data source lookup behavior, required `depends_on` preservation, ValidateFunc-safe values, no secrets).
+    - **Examples pass**: enforce `DOCS-EX-*` (fences, resource self-containedness, data source lookup behavior, list-resource query examples, ephemeral-resource examples, function call examples, required `depends_on` preservation, ValidateFunc-safe values, no secrets).
 - **Import/Timeouts/Wording pass**: enforce `DOCS-IMP-*` (resources), `DOCS-TIMEOUT-*` (if present), and `DOCS-WORD-*`.
 
 If you cannot confidently verify a section due to missing workspace evidence, do not guess; record an Observation and cite `DOCS-EVID-001`.
@@ -292,7 +322,7 @@ Skill footer rule (mandatory; prevents duplicate sections):
 ## 📌 **COMPLIANCE RESULT**
 - **Status**: Valid / Invalid
 - **Doc File**: ${docs_file_path}
-- **Doc Type**: Resource / Data Source
+- **Doc Type**: Resource / Data Source / List Resource / Ephemeral Resource / Function
 
 ## 🧾 **SCHEMA SNAPSHOT**
 - **Schema File(s)**: ${schema_file_paths}
@@ -308,21 +338,21 @@ Skill footer rule (mandatory; prevents duplicate sections):
 ## 📊 **DOC STANDARDS CHECK**
 - **Frontmatter**: Pass/Fail + missing keys (if any)
 - **Section Order**: Pass/Fail + missing sections (if any)
-- **Argument Ordering**: Pass/Fail (ID segments first per contract ordering, `location` next when present, remaining required alphabetical, then optional alphabetical, `tags` last)
-- **Argument Bullet Conciseness**: Pass/Fail (resource docs: long bullets split into inline notes per `DOCS-ARG-011`; data source docs: bullets stay short and field-definitional)
+- **Argument Ordering**: Pass/Fail (resource/data source/ephemeral docs: ID segments first per contract ordering, `location` next when present, remaining required alphabetical, then optional alphabetical, `tags` last; list-resource docs: query arguments alphabetical; function docs: arguments follow signature order)
+- **Argument Bullet Conciseness**: Pass/Fail (resource docs: long bullets split into inline notes per `DOCS-ARG-011`; data source, list-resource, ephemeral-resource, and function docs: entries stay short and field-definitional)
 - **Nested Block Field Ordering**: Pass/Fail (nested args: required alpha then optional alpha, `tags` last via `DOCS-SHAPE-006`; nested attrs: `id` first then alpha via `DOCS-ATTR-005`)
 - **Schema Shape**: Pass/Fail (docs describe blocks vs inline fields consistently with schema)
 - **Attributes Coverage**: Pass/Fail (`id` first, computed attrs present, remaining alphabetical; no other exceptions)
 - **ForceNew Wording**: Pass/Fail (resources only, missing “Changing this forces…” sentence)
-- **Conditional Notes**: Pass/Fail (resource docs: cross-field/conditional requirements from schema constraints and `CustomizeDiff` are documented using `~> **Note:**`; data source docs: field-level note blocks are absent and field text stays concise)
+- **Conditional Notes**: Pass/Fail (resource docs: cross-field/conditional requirements from schema constraints and `CustomizeDiff` are documented using `~> **Note:**`; data source, list-resource, ephemeral-resource, and function docs: field-level note blocks are absent and field text stays concise)
 - **Note Notation**: Pass/Fail (->/~>/!> exact format + marker meaning matches note content)
 - **Note Accuracy**: Pass/Fail (note content matches schema/diff-time/implicit behavior; no contradictory or incomplete constraints)
 - **Timeouts Readability**: Pass/Fail (convert defaults >60 minutes to hours)
-- **Import Text**: Pass/Fail (resources only, resource-specific sentence per `DOCS-IMP-002`)
+- **Import Text**: Pass/Fail (resources only, resource-specific sentence per `DOCS-IMP-002`; list-resource, ephemeral-resource, and function docs should omit a top-level Import section)
 - **Import Example**: Pass/Fail (resources only, ID shape matches importer/parser)
 - **Link Locales**: Pass/Fail (no locale segments like `/en-us/` in URLs)
-- **Examples**: Pass/Fail (resource docs: examples are functional and self-contained; data source docs: examples demonstrate existing-object lookup behavior without unnecessary backing-resource scaffolding; no hard-coded secrets)
-- **Example Invariants**: Pass/Fail (resource docs: preserve example-adjacent notes per `DOCS-EX-018`, preserve existing `depends_on` per `DOCS-EX-004`, do not replace references with invented literals per `DOCS-EX-019`, ensure transitive self-containedness per `DOCS-EX-020`, preserve reference semantics per `DOCS-EX-021`; data source docs: follow `DOCS-EX-022` lookup-example rules)
+- **Examples**: Pass/Fail (resource docs: examples are functional and self-contained; data source docs: examples demonstrate existing-object lookup behavior without unnecessary backing-resource scaffolding; list-resource docs: examples demonstrate Terraform `list` query usage; ephemeral-resource docs: examples demonstrate Terraform `ephemeral` usage; function docs: examples demonstrate `provider::azurerm::<name>(...)` usage; no hard-coded secrets)
+- **Example Invariants**: Pass/Fail (resource docs: preserve example-adjacent notes per `DOCS-EX-018`, preserve existing `depends_on` per `DOCS-EX-004`, do not replace references with invented literals per `DOCS-EX-019`, ensure transitive self-containedness per `DOCS-EX-020`, preserve reference semantics per `DOCS-EX-021`; data source docs: follow `DOCS-EX-022` lookup-example rules; list-resource docs: follow `DOCS-EX-023` list-query rules; ephemeral-resource docs: follow `DOCS-EX-024`; function docs: follow `DOCS-EX-025`)
 - **Example `name` Values**: Pass/Fail (nit-level; Example `name` values follow `DOCS-EX-007` where feasible and satisfy `DOCS-EX-016` constraints; when a rename is required, the replacement value is derived deterministically per `DOCS-EX-015`)
 
 ## 🟢 **STRENGTHS**

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -152,6 +152,9 @@ Rules:
 - Review the full in-scope change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
+- When `internal/**/*.go` scope adds a brand-new resource, explicitly inspect whether the required companion artifacts from the implementation and testing guidance are present: Resource Identity, list resource, list-resource query tests, and list-resource docs.
+- When the change adds a new `*_ephemeral.go` implementation, explicitly inspect whether the required companion artifacts are present: `EphemeralResources()` registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests under `*_ephemeral_test.go`.
+- When the change adds a new provider-defined function under `internal/provider/function/`, explicitly inspect whether the required companion artifacts are present: docs under `website/docs/functions/` and Terraform 1.8-gated tests under `internal/provider/function/*_test.go`.
 - When `internal/**/*_test.go` files are in scope, explicitly inspect embedded Terraform configuration strings and apply the `REVIEW-TEST-*` rules for formatting drift instead of assuming `azurerm-linter` will catch those issues.
 - Keep the review concise but complete.
 

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -85,6 +85,7 @@ Rules:
 - Parse `git status --porcelain=v1` to distinguish modified, added, deleted, and untracked files.
 - Parse `git diff --stat` carefully so deleted files are not counted as modified files.
 - Do not omit any file that belongs to the selected review scope.
+- Identify files under `vendor/**` and mark them as skipped non-actionable files per `REVIEW-FILE-005` rather than treating them as ordinary review targets.
 
 ### 3) Load applicable workspace standards
 - Discover repo-level contributor guidance in the current workspace before reading it.
@@ -152,6 +153,7 @@ Rules:
 - Review the full in-scope change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
+- Treat vendored files under `vendor/**` as skipped non-actionable files: disclose them, but do not raise Issues that require directly editing vendored content.
 - When `internal/**/*.go` scope adds a brand-new resource, explicitly inspect whether the required companion artifacts from the implementation and testing guidance are present: Resource Identity, list resource, list-resource query tests, and list-resource docs.
 - When the change adds a new `*_ephemeral.go` implementation, explicitly inspect whether the required companion artifacts are present: `EphemeralResources()` registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests under `*_ephemeral_test.go`.
 - When the change adds a new provider-defined function under `internal/provider/function/`, explicitly inspect whether the required companion artifacts are present: docs under `website/docs/functions/` and Terraform 1.8-gated tests under `internal/provider/function/*_test.go`.
@@ -200,6 +202,9 @@ Use this template:
 **Deleted Files:**
 - `path/to/file`
 
+**Skipped Vendored Files:**
+- `vendor/path/to/file`
+
 ## 🎯 **PRIMARY CHANGES ANALYSIS**
 [Brief explanation of the implementation or content changes in scope.]
 
@@ -213,7 +218,7 @@ Use this template:
 - **Repo Guidance**: [contributor docs / instructions / skills actually used]
 - **Scope Rules**: [which `REVIEW-SCOPE-*` rules were relevant]
 - **Docs Contract**: [whether `DOCS-*` rules were loaded for `website/docs/**/*.html.markdown` files in scope]
-- **Notes**: [scope-specific guidance that affected severity or classification]
+- **Notes**: [scope-specific guidance that affected severity or classification, including any vendored files skipped as non-actionable]
 
 ### 🧰 **AZURERM LINTER**
 - **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]

--- a/.github/prompts/code-review-local-changes.prompt.md
+++ b/.github/prompts/code-review-local-changes.prompt.md
@@ -85,7 +85,7 @@ Rules:
 - Parse `git status --porcelain=v1` to distinguish modified, added, deleted, and untracked files.
 - Parse `git diff --stat` carefully so deleted files are not counted as modified files.
 - Do not omit any file that belongs to the selected review scope.
-- Identify files under `vendor/**` and mark them as skipped non-actionable files per `REVIEW-FILE-005` rather than treating them as ordinary review targets.
+- Identify files under `vendor/**`, exclude them from actionable review targets, and report only the skipped vendored-file count per `REVIEW-FILE-005`.
 
 ### 3) Load applicable workspace standards
 - Discover repo-level contributor guidance in the current workspace before reading it.
@@ -153,7 +153,8 @@ Rules:
 - Review the full in-scope change-set.
 - Findings must follow the shared review contract, including `REVIEW-EVID-*`, `REVIEW-CLASS-*`, and `REVIEW-LINT-*` behavior.
 - Apply the file-type coverage rules from `REVIEW-SCOPE-*` so installer/script, AI customization, manifest, and user-visible content checks are not skipped.
-- Treat vendored files under `vendor/**` as skipped non-actionable files: disclose them, but do not raise Issues that require directly editing vendored content.
+- Treat vendored files under `vendor/**` as skipped non-actionable files: report only the skipped vendored-file count, and do not raise Issues that require directly editing vendored content.
+- When the selected local diff is vendored-only or vendored-heavy, say so explicitly in the summary or notes so sparse actionable findings are easy to interpret.
 - When `internal/**/*.go` scope adds a brand-new resource, explicitly inspect whether the required companion artifacts from the implementation and testing guidance are present: Resource Identity, list resource, list-resource query tests, and list-resource docs.
 - When the change adds a new `*_ephemeral.go` implementation, explicitly inspect whether the required companion artifacts are present: `EphemeralResources()` registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests under `*_ephemeral_test.go`.
 - When the change adds a new provider-defined function under `internal/provider/function/`, explicitly inspect whether the required companion artifacts are present: docs under `website/docs/functions/` and Terraform 1.8-gated tests under `internal/provider/function/*_test.go`.
@@ -202,8 +203,7 @@ Use this template:
 **Deleted Files:**
 - `path/to/file`
 
-**Skipped Vendored Files:**
-- `vendor/path/to/file`
+**Skipped Vendored Files:** [count]
 
 ## 🎯 **PRIMARY CHANGES ANALYSIS**
 [Brief explanation of the implementation or content changes in scope.]
@@ -218,7 +218,7 @@ Use this template:
 - **Repo Guidance**: [contributor docs / instructions / skills actually used]
 - **Scope Rules**: [which `REVIEW-SCOPE-*` rules were relevant]
 - **Docs Contract**: [whether `DOCS-*` rules were loaded for `website/docs/**/*.html.markdown` files in scope]
-- **Notes**: [scope-specific guidance that affected severity or classification, including any vendored files skipped as non-actionable]
+- **Notes**: [scope-specific guidance that affected severity or classification, including whether the change-set is vendored-only or vendored-heavy]
 
 ### 🧰 **AZURERM LINTER**
 - **Version**: [JSON `version`, `n/a`, or `unknown` when the tool could not be interrogated reliably]

--- a/.github/skills/acceptance-testing/SKILL.md
+++ b/.github/skills/acceptance-testing/SKILL.md
@@ -79,6 +79,20 @@ Before running tests:
    - At a minimum, plan for `basic`, `requiresImport`, `complete`, `update`, and import validation when import is supported.
    - Only omit one of those when the resource behavior or provider pattern makes it genuinely not applicable.
 
+- New-resource list coverage:
+   - When a new resource includes a list resource, also plan a dedicated `*_resource_list_test.go` file.
+   - Use Terraform 1.14 query tests for the list resource and provision multiple resources so the list query path is meaningfully exercised.
+   - Only omit list-resource acceptance coverage when the resource is using a maintainer-reviewed upstream exception path such as `allow-without-list` or `list-not-supported`.
+
+- Ephemeral-resource coverage:
+   - Use the service-local `*_ephemeral_test.go` pattern with `acceptance.BuildTestData(t, "ephemeral.azurerm_<name>", ...)`.
+   - Gate the test on Terraform 1.10 support and use the framework provider factories required by the upstream ephemeral-resource test pattern.
+   - When validating ephemeral output payloads, prefer the `echo` provider plus config-state checks rather than inventing a one-off assertion pattern.
+
+- Provider-defined function coverage:
+   - Use focused unit tests under `internal/provider/function/*_test.go`.
+   - Gate the tests on Terraform 1.8 support, use framework provider factories, and assert outputs from `provider::azurerm::<name>(...)` calls.
+
 - Basic tests should validate existence:
    - Primary check should be `check.That(data.ResourceName).ExistsInAzure(r)`.
 

--- a/.github/skills/docs-writer/SKILL.md
+++ b/.github/skills/docs-writer/SKILL.md
@@ -42,6 +42,9 @@ Use this skill when working on Terraform AzureRM provider documentation pages un
 
 - `website/docs/r/*.html.markdown` (resources)
 - `website/docs/d/*.html.markdown` (data sources)
+- `website/docs/list-resources/*.html.markdown` (list resources)
+- `website/docs/ephemeral-resources/*.html.markdown` (ephemeral resources)
+- `website/docs/functions/*.html.markdown` (provider-defined functions)
 
 Your goal is to produce docs that match provider conventions and stay consistent with the actual Terraform schema.
 
@@ -52,6 +55,9 @@ When this skill is invoked, you must still:
 - verify schema parity and enforce ordering
 - enforce the standard generic ForceNew sentence
 - add missing required notes where the contract permits them (for example resource field notes and example-adjacent notes), and enforce the data source no-field-notes rule
+- enforce the list-resource doc-type rules when the page lives under `website/docs/list-resources/`, including the list-resource title/summary shape, `Argument Reference` heading, list query examples, and no-import behavior
+- enforce the ephemeral-resource doc-type rules when the page lives under `website/docs/ephemeral-resources/`, including the `Ephemeral:` title, Terraform 1.10 support note, `Argument Reference` heading, `ephemeral` examples, and no-import behavior
+- enforce the function doc-type rules when the page lives under `website/docs/functions/`, including the `Function:` title, Terraform 1.8/provider 4.0 support note, `Signature` and `Arguments` sections, and `provider::azurerm::<name>(...)` examples
 
 Do not require the user to explicitly ask for these checks.
 
@@ -78,13 +84,21 @@ Auditor independence:
 Use this to avoid missing common compliance breakpoints. The authoritative details live in `.github/instructions/docs-compliance-contract.instructions.md`.
 
 - Structure + frontmatter: `DOCS-FM-*`, `DOCS-STRUCT-*`
+- List-resource doc type rules: list-resource title/summary/sections/intro lines via `DOCS-FM-*`, `DOCS-STRUCT-*`, and `DOCS-FMT-*`
+- Ephemeral-resource doc type rules: ephemeral title/summary/support-note/sections via `DOCS-FM-*`, `DOCS-STRUCT-*`, and `DOCS-FMT-*`
+- Function doc type rules: function title/summary/support-note/sections via `DOCS-FM-*`, `DOCS-STRUCT-*`, and `DOCS-FMT-*`
 - Arguments parity + ordering + shape: `DOCS-ARG-*`, `DOCS-SHAPE-*` (including bullet split via `DOCS-ARG-011`)
 - Bullet split trigger (mandatory; prevents misses): in resource docs, if an argument bullet mixes the definition with validation-style constraints (length/charset/regex/start/end rules) or includes the ForceNew sentence plus constraints, split constraints into an inline note per `DOCS-ARG-011` + `DOCS-NOTE-003`; in data source docs, keep the bullet short and field-definitional instead of adding a field-level note.
+- List-resource query arguments follow the same concise, field-definitional rule as data source query fields; do not add field-level note blocks.
+- Ephemeral-resource and function argument docs follow the same concise, field-definitional rule as data source query fields; do not add field-level note blocks below individual fields.
 - Nested block field ordering: `DOCS-SHAPE-006`, `DOCS-ATTR-005`
 - ForceNew + wording hygiene: `DOCS-WORD-*` (including enum phrasing + Oxford comma) and `DOCS-ARG-003/006/009`
 - Azure object-name wording: keep canonical Azure proper-name capitalization such as `Resource Group` in field prose per `DOCS-WORD-007`
 - Notes required/marker correctness + de-dup: `DOCS-NOTE-*`
 - Examples (no deletions, resource self-containedness, data source lookup behavior, depends_on rules, ValidateFunc-safe values): `DOCS-EX-*` + `DOCS-EVID-001`
+- List-resource query examples: `DOCS-EX-023`
+- Ephemeral-resource examples: `DOCS-EX-024`
+- Function examples: `DOCS-EX-025`
 - Example invariants: `DOCS-EX-004`, `DOCS-EX-018`, `DOCS-EX-019`
 - Resource example self-containedness closure: `DOCS-EX-003`, `DOCS-EX-011`, `DOCS-EX-020`
 - Data source lookup examples: `DOCS-EX-022`
@@ -136,6 +150,7 @@ Mandatory policy:
 - **Default behavior:** when updating/fixing an existing docs page, edit the existing file in place. Do NOT run scaffolding.
 - **Use scaffolding only when creating a brand-new docs page from scratch**, meaning the target docs file does not already exist under `website/docs/r/**` or `website/docs/d/**`.
 - Also allow scaffolding when (and only when) the user explicitly asks for a scaffold/dry-run baseline to compare (see Testing mode).
+- **List-resource, ephemeral-resource, and function docs are manual:** do not treat the standard website scaffold tool as the default path for `website/docs/list-resources/**`, `website/docs/ephemeral-resources/**`, or `website/docs/functions/**` pages.
 
 Guardrails:
 - Never use scaffolding as part of an audit-only workflow. Audits should be static, evidence-based reviews.

--- a/.github/skills/resource-implementation/SKILL.md
+++ b/.github/skills/resource-implementation/SKILL.md
@@ -78,6 +78,9 @@ Rules:
 ## Default approach
 
 - Prefer the **typed resource** implementation style (internal SDK framework) for new resources.
+- For new resources, plan Resource Identity first and a corresponding list resource immediately after it unless there is a concrete upstream-supported exception.
+- For ephemeral resources, use the service-local `*_ephemeral.go` pattern with `sdk.EphemeralResource`, `Open(...)`, and registration through `EphemeralResources()`.
+- For provider-defined functions, use the `internal/provider/function/` pattern with `Metadata`, `Definition`, and `Run`.
 - Make changes consistent with existing resources in the same service.
 
 ## Workflow (recommended)
@@ -89,6 +92,26 @@ Rules:
 - Confirm API model structure before mapping fields:
    - Do not guess types or required properties.
    - When needed, inspect the Azure SDK model structs or the provider’s generated clients.
+
+- New-resource workflow expectations:
+   - Treat Resource Identity as mandatory for new resources.
+   - Treat the list resource as mandatory for new resources by default.
+   - Treat the primary resource docs and the list-resource docs as mandatory companions for new resources.
+   - If no list API exists, do not silently omit the list resource; call out the exception path and the need for maintainer-reviewed `allow-without-list` or `list-not-supported` labeling.
+
+- Existing-resource list-retrofit expectations:
+   - When the task is to add list support to an existing resource, plan Resource Identity, the `*_resource_list.go` implementation, service registration, list-query tests, and list-resource docs together.
+   - Do not treat registration, tests, or list-resource docs as optional follow-up work once the list-support retrofit is in scope.
+
+- Ephemeral-resource workflow expectations:
+   - Implement the object as `*_ephemeral.go` under the owning service package.
+   - Register it through the service `EphemeralResources()` slice.
+   - Plan the companion docs under `website/docs/ephemeral-resources/` and acceptance coverage in `*_ephemeral_test.go`.
+
+- Provider-defined function workflow expectations:
+   - Implement the function under `internal/provider/function/<name>.go`.
+   - Expose its contract through `Definition(...)` and keep docs/tests aligned to that contract.
+   - Plan the companion docs under `website/docs/functions/` and unit coverage under `internal/provider/function/*_test.go`.
 
 - Schema design:
    - Required vs Optional must reflect real API requirements and provider conventions.
@@ -107,7 +130,12 @@ Rules:
 
 - Tests:
    - Add or adjust tests when implementation behavior changes materially.
+   - For new resources that add a list resource, plan a dedicated `*_resource_list_test.go` query-test path in addition to the resource lifecycle tests.
    - For acceptance-test-specific guidance, use the testing compliance contract and the `acceptance-testing` skill instead of treating this skill as the source of detailed acctest patterns.
+
+- Documentation companions:
+   - For new resources, plan the primary resource docs plus the corresponding list-resource docs under `website/docs/list-resources/`.
+   - Do not treat list-resource docs as optional when the list resource itself is required.
 
 ## Output expectation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an adjudicated resource-implementation regression case that covers the new-resource list-resource requirement, so new resource guidance does not omit mandatory Resource Identity, list-resource planning, and the maintainer-reviewed exception path.
+- Added an adjudicated local-review regression case that covers missing new-resource companion artifacts, so code review catches missing list-resource docs and other required companion files for new resources.
+- Added adjudicated docs-review and docs-writer regression cases for list-resource pages, so the docs workflow now enforces list-resource page structure and list query examples directly instead of treating those pages like ordinary resource docs.
+- Added adjudicated docs-review and implementation-guidance regression cases for Ephemeral Resources and provider-defined Functions, so the toolkit now treats those workflows as first-class doc and implementation types instead of letting them fall through resource-only guidance.
+- Added an adjudicated implementation-guidance regression case based on a real upstream list-support retrofit PR, so the toolkit now also tests the “existing resource gains list support” workflow instead of only the brand-new resource path.
+
 ### Changed
+
+- Updated the implementation contract, implementation skill, acceptance-testing skill, implementation guide, and user-facing examples to reflect the new upstream workflow that all new resources must plan Resource Identity and a corresponding list resource unless the maintainer exception path is explicitly used.
+- Updated the implementation contract and the local/committed code-review prompts so new-resource reviews also validate the required documentation companion for the list resource under `website/docs/list-resources/`.
+- Updated the docs contract, docs-writer skill, docs-review prompt, and user-facing docs so `website/docs/list-resources/*.html.markdown` pages are treated as a first-class docs type with their own title, summary, section, and example rules.
+- Updated the docs contract, docs-writer skill, docs-review prompt, implementation/testing contracts, and generic code-review prompts so `website/docs/ephemeral-resources/*.html.markdown`, `website/docs/functions/*.html.markdown`, `*_ephemeral.go`, and `internal/provider/function/*.go` all have explicit toolkit standards.
+- Updated the implementation guidance so retrofitting list support onto an existing resource explicitly requires the same companion set: identity, registration, list-query tests, and list-resource docs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the docs contract, docs-writer skill, docs-review prompt, and user-facing docs so `website/docs/list-resources/*.html.markdown` pages are treated as a first-class docs type with their own title, summary, section, and example rules.
 - Updated the docs contract, docs-writer skill, docs-review prompt, implementation/testing contracts, and generic code-review prompts so `website/docs/ephemeral-resources/*.html.markdown`, `website/docs/functions/*.html.markdown`, `*_ephemeral.go`, and `internal/provider/function/*.go` all have explicit toolkit standards.
 - Updated the implementation guidance so retrofitting list support onto an existing resource explicitly requires the same companion set: identity, registration, list-query tests, and list-resource docs.
+- Updated the local and committed review workflow so files under `vendor/**` are disclosed but treated as skipped non-actionable review scope instead of generating findings that ask contributors to edit vendored third-party content directly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added adjudicated docs-review and docs-writer regression cases for list-resource pages, so the docs workflow now enforces list-resource page structure and list query examples directly instead of treating those pages like ordinary resource docs.
 - Added adjudicated docs-review and implementation-guidance regression cases for Ephemeral Resources and provider-defined Functions, so the toolkit now treats those workflows as first-class doc and implementation types instead of letting them fall through resource-only guidance.
 - Added an adjudicated implementation-guidance regression case based on a real upstream list-support retrofit PR, so the toolkit now also tests the “existing resource gains list support” workflow instead of only the brand-new resource path.
+- Added an adjudicated committed-review regression case for vendored-heavy diffs, so generic review now benchmarks count-only vendor reporting plus the explicit vendored-heavy scope callout instead of letting vendored-file handling drift.
 
 ### Changed
 
@@ -22,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the docs contract, docs-writer skill, docs-review prompt, and user-facing docs so `website/docs/list-resources/*.html.markdown` pages are treated as a first-class docs type with their own title, summary, section, and example rules.
 - Updated the docs contract, docs-writer skill, docs-review prompt, implementation/testing contracts, and generic code-review prompts so `website/docs/ephemeral-resources/*.html.markdown`, `website/docs/functions/*.html.markdown`, `*_ephemeral.go`, and `internal/provider/function/*.go` all have explicit toolkit standards.
 - Updated the implementation guidance so retrofitting list support onto an existing resource explicitly requires the same companion set: identity, registration, list-query tests, and list-resource docs.
-- Updated the local and committed review workflow so files under `vendor/**` are disclosed but treated as skipped non-actionable review scope instead of generating findings that ask contributors to edit vendored third-party content directly.
+- Updated the local and committed review workflow so files under `vendor/**` are reported as a skipped vendored-file count, not a path-by-path list, and vendored-only or vendored-heavy change-sets are called out explicitly while still being treated as non-actionable review scope instead of generating findings that ask contributors to edit vendored third-party content directly.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ AI Chat: "Create documentation following provider standards for azurerm_cdn_fron
 > 2) apply the patch-ready fixes
 > 3) rerun the audit and expect no repeated Issues
 >
-> `/code-review-docs` also enforces deterministic doc-quality checks such as `hcl` fences in examples, self-contained resource examples, existing-object lookup data source examples, import example ID shape validation, and human-readable timeout defaults.
+> `/code-review-docs` also enforces deterministic doc-quality checks such as `hcl` fences in examples, self-contained resource examples, existing-object lookup data source examples, list-resource query examples, ephemeral-resource example shape, provider-defined function example shape, import example ID shape validation, and human-readable timeout defaults.
 
 
 ## 🎬 See It In Action

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ AI Chat: "Create a new Azure CDN Front Door Profile resource using typed impleme
 /code-review-committed-changes
 ```
 
+Both generic review prompts now report the count of vendored files under `vendor/**` when they are in scope, but treat them as skipped non-actionable files rather than asking contributors to edit vendored third-party content directly.
+
 If Copilot does not already have PR context for your branch, pass the PR number explicitly:
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -364,7 +364,7 @@ Docs components (quick links):
 
 - `/code-review-local-changes`: reviews local workspace changes and uses local-diff linting.
 - `/code-review-committed-changes`: reviews committed branch changes against `origin/main` and prefers PR-scoped linting. When PR context is not already available, users can pass a PR number explicitly, for example `/code-review-committed-changes PR 12345`.
-- `/code-review-docs`: deterministic docs review for `website/docs/**` pages (enforces `hcl` code fences in Terraform examples, self-contained resource examples, existing-object lookup data source examples, import example ID shape validation, and human-readable timeout defaults).
+- `/code-review-docs`: deterministic docs review for `website/docs/**` pages (enforces `hcl` code fences in Terraform examples, self-contained resource examples, existing-object lookup data source examples, list-resource query examples, ephemeral-resource doc shape, function doc shape, import example ID shape validation, and human-readable timeout defaults).
 - Rule citations such as `REVIEW-SCOPE-005` and `DOCS-EX-003` are explained in `docs/CODE_REVIEW_RULES.md`.
 
 ### Docs governance (contract, prompt, skill)

--- a/docs/CODE_REVIEW_RULES.md
+++ b/docs/CODE_REVIEW_RULES.md
@@ -109,6 +109,17 @@ This means the review applied Go/provider-specific guidance because the change t
 
 It is the rule that tells the auditor to load the scoped Go instructions and skills instead of relying only on the generic review contract.
 
+### `REVIEW-FILE-005`
+
+This means the review recognized vendored third-party files under `vendor/**` as non-actionable scope.
+
+In practice, the review should:
+
+- disclose the count of vendored files skipped in the diff rather than listing each vendored path
+- avoid raising Issues that tell a contributor to edit vendored files directly
+- focus findings on the first actionable non-vendored source, such as dependency bumps, generation inputs, or service wiring
+- say explicitly when a change-set is vendored-only or vendored-heavy so sparse actionable findings are easy to interpret
+
 ### `REVIEW-LINT-*`
 
 These rules explain how `azurerm-linter` should be handled. If you see a `REVIEW-LINT-*` citation, it usually means the review is explaining one of these:

--- a/docs/CODE_REVIEW_RULES.md
+++ b/docs/CODE_REVIEW_RULES.md
@@ -127,11 +127,11 @@ These IDs come from `.github/instructions/docs-compliance-contract.instructions.
 | `DOCS-EVID-*` | Evidence guardrails | The docs audit refused to guess values, imports, or constraints without code evidence |
 | `DOCS-OBS-*` | Observation-only guidance | Non-blocking docs or schema-design suggestions |
 | `DOCS-FM-*` | Frontmatter | YAML frontmatter requirements such as `page_title`, `layout`, and `subcategory` |
-| `DOCS-STRUCT-*` | Document structure | Required sections and section ordering |
+| `DOCS-STRUCT-*` | Document structure | Required sections, section ordering, and doc-type structure for resource, data source, list-resource, ephemeral-resource, and function pages |
 | `DOCS-FMT-*` | Formatting | Backticks, intro lines, and code-fence conventions |
 | `DOCS-IMP-*` | Import docs | Import wording and example correctness |
 | `DOCS-SHAPE-*` | Schema shape parity | Whether docs reflect blocks, maps, lists, and nested structures correctly |
-| `DOCS-EX-*` | Example code | Example correctness, resource self-containedness, data source lookup behavior, naming, and Terraform syntax |
+| `DOCS-EX-*` | Example code | Example correctness, resource self-containedness, data source lookup behavior, list-resource query behavior, ephemeral-resource usage, function-call usage, naming, and Terraform syntax |
 | `DOCS-NOTE-*` | Notes | Required note blocks, note severity, formatting, and de-duplication |
 | `DOCS-ARG-*` | Arguments Reference | Field coverage, ordering, defaults, and validation wording |
 | `DOCS-ATTR-*` | Attributes Reference | Computed field coverage and ordering |
@@ -148,7 +148,7 @@ These IDs come from `.github/instructions/implementation-compliance-contract.ins
 | Prefix | Meaning | What it usually tells the user |
 | ------ | ------- | ------------------------------ |
 | `IMPL-EVID-*` | Evidence and verification | The implementation guidance had to be grounded in provider code, SDK/client models, or nearby implementations instead of guessing |
-| `IMPL-WF-*` | Workflow | Which high-level implementation approach should be preferred, such as typed resources for new work |
+| `IMPL-WF-*` | Workflow | Which high-level implementation approach should be preferred, such as typed resources for new work, framework ephemeral resources, and provider-defined functions |
 | `IMPL-SCHEMA-*` | Schema and mapping | How schema shape, field ordering, and field requirements should align with real provider behavior |
 | `IMPL-PATCH-*` | PATCH and residual state | How Azure PATCH behavior should be handled so omitted fields do not leave stale state behind |
 | `IMPL-ERR-*` | Error handling | How provider-standard error wording and wrapping should be applied |
@@ -162,7 +162,7 @@ These IDs come from `.github/instructions/testing-compliance-contract.instructio
 | Prefix | Meaning | What it usually tells the user |
 | ------ | ------- | ------------------------------ |
 | `TEST-EVID-*` | Evidence and verification | The testing guidance had to follow existing provider test patterns instead of inventing new structures |
-| `TEST-WF-*` | Workflow | How much test coverage should be added and how focused the scenario should be |
+| `TEST-WF-*` | Workflow | How much test coverage should be added and how focused the scenario should be, including list-resource, ephemeral-resource, and provider-function patterns |
 | `TEST-RUN-*` | Execution safety | Acceptance tests create real Azure resources and should be run narrowly and intentionally |
 | `TEST-PATTERN-*` | Acceptance test patterns | How `ExistsInAzure`, `ImportStep()`, and `requiresImport`-style coverage should be used |
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -50,10 +50,11 @@ You: Create a new resource for Azure CDN Front Door Profile.
 
 **What Copilot Does**:
 1. ✅ Creates the resource file in the correct directory
-2. ✅ Implements all CRUD operations
-3. ✅ Adds proper schema with validations
-4. ✅ Includes error handling with formatted errors
-5. ✅ Adds metadata for state tracking
+2. ✅ Plans Resource Identity and the corresponding list resource
+3. ✅ Implements all CRUD operations
+4. ✅ Adds proper schema with validations
+5. ✅ Includes error handling with formatted errors
+6. ✅ Adds metadata for state tracking
 
 **Step 2**: Review and refine
 
@@ -140,7 +141,7 @@ func resourceCdnFrontDoorProfileUpdate(d *pluginsdk.ResourceData, meta interface
 
 ```
 You: Generate acceptance tests for azurerm_cdn_frontdoor_profile
-     including basic, complete, and update scenarios
+    including basic, complete, update, and list query scenarios
 ```
 
 **What Copilot Generates**:
@@ -167,6 +168,10 @@ func TestAccCdnFrontDoorProfile_complete(t *testing.T) {
 
 func TestAccCdnFrontDoorProfile_update(t *testing.T) {
     // Update scenarios
+}
+
+func TestAccCdnFrontDoorProfile_list_basic(t *testing.T) {
+    // Terraform 1.14 query tests for the list resource
 }
 ```
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -425,7 +425,7 @@ Simply use slash commands to invoke the prompts directly:
 |---------------|-------------|-------------|
 | `/code-review-local-changes` | `code-review-local-changes.prompt.md` | Review your uncommitted changes |
 | `/code-review-committed-changes` | `code-review-committed-changes.prompt.md` | Review committed changes |
-| `/code-review-docs` | `code-review-docs.prompt.md` | Review a `website/docs/**` page for docs standards + schema parity (includes deterministic checks like `hcl` example fences, self-contained resource examples, existing-object lookup data source examples, import ID shape, and timeout readability) |
+| `/code-review-docs` | `code-review-docs.prompt.md` | Review a `website/docs/**` page for docs standards + schema parity (includes deterministic checks like `hcl` example fences, self-contained resource examples, existing-object lookup data source examples, list-resource query examples, ephemeral-resource docs shape, function docs shape, import ID shape, and timeout readability) |
 
 **Example Usage:**
 ```
@@ -440,7 +440,7 @@ Simply use slash commands to invoke the prompts directly:
 |-------------|---------|-------|
 | `code-review-local-changes.prompt.md` | **Review uncommitted changes** with Terraform provider best practices | Use before committing to get expert feedback on your local changes |
 | `code-review-committed-changes.prompt.md` | **Review committed changes** for pull request feedback | Use to review git commits with detailed technical analysis |
-| `code-review-docs.prompt.md` | **Review a docs page** for required sections and schema parity | Open a file under `website/docs/**` and run to get patch-ready fixes (examples must use `hcl`, resource examples must be self-contained, data source examples must reflect existing-object lookups, include correct import IDs, and document readable timeouts) |
+| `code-review-docs.prompt.md` | **Review a docs page** for required sections and schema parity | Open a file under `website/docs/**` and run to get patch-ready fixes (examples must use `hcl`, resource examples must be self-contained, data source examples must reflect existing-object lookups, list-resource pages must use list query examples and the correct list-resource doc shape, ephemeral-resource pages must use the `Ephemeral:` workflow, function pages must use the `Function:` workflow, include correct import IDs, and document readable timeouts) |
 
 ## 🎛️ Command Reference
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -423,8 +423,8 @@ Simply use slash commands to invoke the prompts directly:
 
 | Slash Command | Prompt File | Description |
 |---------------|-------------|-------------|
-| `/code-review-local-changes` | `code-review-local-changes.prompt.md` | Review your uncommitted changes |
-| `/code-review-committed-changes` | `code-review-committed-changes.prompt.md` | Review committed changes |
+| `/code-review-local-changes` | `code-review-local-changes.prompt.md` | Review your uncommitted changes, while reporting the count of skipped non-actionable vendored files under `vendor/**` |
+| `/code-review-committed-changes` | `code-review-committed-changes.prompt.md` | Review committed changes, while reporting the count of skipped non-actionable vendored files under `vendor/**` |
 | `/code-review-docs` | `code-review-docs.prompt.md` | Review a `website/docs/**` page for docs standards + schema parity (includes deterministic checks like `hcl` example fences, self-contained resource examples, existing-object lookup data source examples, list-resource query examples, ephemeral-resource docs shape, function docs shape, import ID shape, and timeout readability) |
 
 **Example Usage:**
@@ -438,8 +438,8 @@ Simply use slash commands to invoke the prompts directly:
 
 | Prompt File | Purpose | Usage |
 |-------------|---------|-------|
-| `code-review-local-changes.prompt.md` | **Review uncommitted changes** with Terraform provider best practices | Use before committing to get expert feedback on your local changes |
-| `code-review-committed-changes.prompt.md` | **Review committed changes** for pull request feedback | Use to review git commits with detailed technical analysis |
+| `code-review-local-changes.prompt.md` | **Review uncommitted changes** with Terraform provider best practices | Use before committing to get expert feedback on your local changes; vendored files under `vendor/**` are counted and treated as non-actionable review scope |
+| `code-review-committed-changes.prompt.md` | **Review committed changes** for pull request feedback | Use to review git commits with detailed technical analysis; vendored files under `vendor/**` are counted and treated as non-actionable review scope |
 | `code-review-docs.prompt.md` | **Review a docs page** for required sections and schema parity | Open a file under `website/docs/**` and run to get patch-ready fixes (examples must use `hcl`, resource examples must be self-contained, data source examples must reflect existing-object lookups, list-resource pages must use list query examples and the correct list-resource doc shape, ephemeral-resource pages must use the `Ephemeral:` workflow, function pages must use the `Function:` workflow, include correct import IDs, and document readable timeouts) |
 
 ## 🎛️ Command Reference

--- a/tools/config/upstream-contributor.json
+++ b/tools/config/upstream-contributor.json
@@ -144,7 +144,7 @@
       "domain": "implementation-and-testing",
       "title": "Guide: New Resource",
       "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/guide-new-resource.md",
-      "baselineSha256": "d2911e87107ab0ba5fcf3e6f5c424eab575f68050ec5ccdd16d8c878160245b8",
+      "baselineSha256": "2de79de35ec45b66fb70a7ee3f2c3cfad584e4f8818bd134160f65566969f1e9",
       "reviewNotes": [
         "Useful when upstream changes the staged workflow for new resources, including acceptance-test, docs, and PR expectations."
       ]
@@ -194,7 +194,7 @@
       "domain": "implementation-and-framework-list",
       "title": "Guide: List Resource",
       "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/guide-list-resource.md",
-      "baselineSha256": "22b9dea8777e1deee75c82f4be01a18d595a6aa048b07aa9199d2673c27a6dee",
+      "baselineSha256": "38068aec9b25abb1d579b669653bb444ea5b48555fc3d865c24d7aff0e191e8f",
       "reviewNotes": [
         "Primary upstream source for framework list resources, identity prerequisites, flatten reuse, TF 1.14 query tests, and list-resource docs."
       ]
@@ -264,7 +264,7 @@
       "domain": "schema-design",
       "title": "Guide: Resource Identity",
       "rawUrl": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/main/contributing/topics/guide-resource-identity.md",
-      "baselineSha256": "b322422a6f68661766c4ad867429fec20d686fdc5992fbfd7aaf67477e68f787",
+      "baselineSha256": "25734f6fc429691896ba0446a02844b5b7b9cbd314b3a98957a77946919ac228",
       "reviewNotes": [
         "Primary upstream source for resource identity schema, SetResourceIdentityData usage, generated tests, and current generator limitations."
       ]

--- a/tools/regression/cases/review-committed-vendored-scope.json
+++ b/tools/regression/cases/review-committed-vendored-scope.json
@@ -1,0 +1,58 @@
+{
+  "id": "review-committed-vendored-scope",
+  "title": "Committed review treats vendored-heavy diffs as limited actionable scope",
+  "task": "code-review-committed-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A committed-review scenario where a pull request is dominated by vendored SDK churn plus a small non-vendored control-surface change. The correct review should report only the skipped vendored-file count, explicitly call out the vendored-heavy scope, and avoid telling contributors to edit vendored files directly.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-committed-vendored-scope/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "go.mod",
+      "go.sum",
+      "internal/services/example/client/client.go",
+      "vendor/github.com/hashicorp/go-azure-sdk/resource-manager/example/2026-01-01/widgets/client.go",
+      "vendor/github.com/hashicorp/go-azure-sdk/resource-manager/example/2026-01-01/widgets/model_widget.go",
+      "vendor/modules.txt"
+    ],
+    "notes": "Sanitized fixture models a committed-review PR where the actionable surface is limited because most changed files are vendored SDK updates."
+  },
+  "expectedRules": [
+    "REVIEW-FILE-005",
+    "REVIEW-SCOPE-005",
+    "REVIEW-LINT-*"
+  ],
+  "mustCatch": [
+    {
+      "key": "vendored-heavy-scope-callout",
+      "severity": "medium",
+      "description": "The review should explicitly call out that the committed diff is vendored-heavy and report only the skipped vendored-file count."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "edit-vendored-files-directly",
+      "description": "The review must not raise findings that tell the contributor to modify files under vendor/** directly."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "DETAILED TECHNICAL REVIEW",
+      "AZURERM LINTER"
+    ],
+    "mustIncludeMarkers": [
+      "Skipped Vendored Files:",
+      "vendored-heavy"
+    ]
+  },
+  "notes": "Use this case to benchmark count-only vendored-file reporting and the explicit vendored-heavy scope callout in committed review output."
+}

--- a/tools/regression/cases/review-docs-ephemeral-resource-shape.json
+++ b/tools/regression/cases/review-docs-ephemeral-resource-shape.json
@@ -1,0 +1,52 @@
+{
+  "id": "review-docs-ephemeral-resource-shape",
+  "title": "Docs review enforces ephemeral-resource page structure and examples",
+  "task": "code-review-docs",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized docs-review scenario where an ephemeral-resource page drifts toward ordinary resource-doc structure. The correct review should apply the ephemeral-resource-specific doc rules instead of resource or data source rules.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-docs-ephemeral-resource-shape/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/ephemeral-resources/example_secret.html.markdown"
+    ],
+    "notes": "Sanitized fixture models an ephemeral-resource docs review after the local docs workflow was extended to treat ephemeral-resource pages as a first-class doc type."
+  },
+  "expectedRules": [
+    "DOCS-STRUCT-*",
+    "DOCS-FMT-*",
+    "DOCS-EX-024",
+    "DOCS-WORD-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "ephemeral-doc-type-regression",
+      "severity": "high",
+      "file": "website/docs/ephemeral-resources/example_secret.html.markdown",
+      "description": "The review should catch when an ephemeral-resource page is written like an ordinary resource page instead of using the ephemeral-resource title, support note, sections, and `ephemeral` examples."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "managed-resource-import-required",
+      "description": "The review must not require a managed-resource Import section for an ephemeral-resource page."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "DETAILED TECHNICAL REVIEW",
+      "ISSUES"
+    ],
+    "mustIncludeMarkers": [
+      "Ephemeral",
+      "DOCS-EX-024"
+    ]
+  },
+  "notes": "Pair this case with the sample docs-review markdown output to benchmark ephemeral-resource docs review behavior."
+}

--- a/tools/regression/cases/review-docs-function-shape.json
+++ b/tools/regression/cases/review-docs-function-shape.json
@@ -1,0 +1,51 @@
+{
+  "id": "review-docs-function-shape",
+  "title": "Docs review enforces function page structure and examples",
+  "task": "code-review-docs",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized docs-review scenario where a function page drifts toward ordinary resource-doc structure. The correct review should apply the function-specific doc rules instead of resource or data source rules.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-docs-function-shape/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/functions/example_parse_resource_id.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a function docs review after the local docs workflow was extended to treat function pages as a first-class doc type."
+  },
+  "expectedRules": [
+    "DOCS-STRUCT-*",
+    "DOCS-EX-025",
+    "DOCS-WORD-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "function-doc-type-regression",
+      "severity": "high",
+      "file": "website/docs/functions/example_parse_resource_id.html.markdown",
+      "description": "The review should catch when a function page is written like an ordinary resource page instead of using the function title, support note, signature, arguments, and provider-function examples."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "provider-block-prohibited",
+      "description": "The review must not treat a provider block in a function example as automatically invalid when it is there to make the function example runnable."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "DETAILED TECHNICAL REVIEW",
+      "ISSUES"
+    ],
+    "mustIncludeMarkers": [
+      "Function",
+      "DOCS-EX-025"
+    ]
+  },
+  "notes": "Pair this case with the sample docs-review markdown output to benchmark function docs review behavior."
+}

--- a/tools/regression/cases/review-docs-list-resource-shape.json
+++ b/tools/regression/cases/review-docs-list-resource-shape.json
@@ -1,0 +1,52 @@
+{
+  "id": "review-docs-list-resource-shape",
+  "title": "Docs review enforces list-resource page structure and examples",
+  "task": "code-review-docs",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized docs-review scenario where a list-resource page drifts toward ordinary resource-doc structure. The correct review should apply the list-resource-specific doc rules instead of resource or data source rules.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-docs-list-resource-shape/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/list-resources/example_network_profile.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a list-resource docs review after the local docs workflow was extended to treat list-resource pages as a first-class doc type."
+  },
+  "expectedRules": [
+    "DOCS-STRUCT-*",
+    "DOCS-FMT-*",
+    "DOCS-EX-023",
+    "DOCS-WORD-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "list-resource-doc-type-regression",
+      "severity": "high",
+      "file": "website/docs/list-resources/example_network_profile.html.markdown",
+      "description": "The review should catch when a list-resource page is written like an ordinary resource page instead of using the list-resource title, summary, sections, and list query examples."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "resource-self-containedness-required",
+      "description": "The review must not apply resource-example self-containedness remediation to a list-resource page that should be teaching list query usage."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "DETAILED TECHNICAL REVIEW",
+      "ISSUES"
+    ],
+    "mustIncludeMarkers": [
+      "List resource",
+      "DOCS-EX-023"
+    ]
+  },
+  "notes": "Pair this case with the sample docs-review markdown output to benchmark list-resource docs review behavior."
+}

--- a/tools/regression/cases/review-local-new-resource-companions.json
+++ b/tools/regression/cases/review-local-new-resource-companions.json
@@ -1,0 +1,57 @@
+{
+  "id": "review-local-new-resource-companions",
+  "title": "Local review catches missing new-resource companion artifacts",
+  "task": "code-review-local-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized local-review scenario where a contributor adds a brand-new resource implementation but omits one or more mandatory companion artifacts. The correct review should flag the missing list-resource docs and the rest of the required new-resource workflow companions.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-local-new-resource-companions/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go",
+      "internal/services/example/registration.go"
+    ],
+    "notes": "Sanitized fixture models a new-resource PR where the base resource lands without the corresponding list-resource docs or other mandatory companions."
+  },
+  "expectedRules": [
+    "REVIEW-SCOPE-005",
+    "REVIEW-SCOPE-005A",
+    "IMPL-WF-002",
+    "IMPL-WF-003",
+    "TEST-WF-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "missing-new-resource-companions",
+      "severity": "high",
+      "file": "internal/services/example/example_resource.go",
+      "description": "The review should flag that the new resource is missing mandatory companion artifacts such as the list resource, list query tests, and list-resource docs."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "list-resource-docs-optional",
+      "description": "The review must not treat the list-resource docs as optional for a new resource when no explicit upstream exception path is present."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "AZURERM LINTER",
+      "ISSUES"
+    ],
+    "mustIncludeMarkers": [
+      "list-resource docs",
+      "website/docs/list-resources/"
+    ]
+  },
+  "notes": "Pair this case with the example review markdown output to benchmark new-resource companion-artifact review behavior."
+}

--- a/tools/regression/cases/skill-docs-writer-list-resource-shape.json
+++ b/tools/regression/cases/skill-docs-writer-list-resource-shape.json
@@ -1,0 +1,54 @@
+{
+  "id": "skill-docs-writer-list-resource-shape",
+  "title": "Docs-writer guidance applies list-resource doc-type rules",
+  "task": "docs-writer",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized direct docs-writer scenario where an existing list-resource page drifts on the list-resource title, summary, and example form, and the correct output should edit the page in place using the list-resource-specific rules rather than resource-doc defaults.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-docs-writer-list-resource-shape/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "website/docs/list-resources/example_network_profile.html.markdown"
+    ],
+    "notes": "Sanitized fixture models a docs-writer request against an existing list-resource page without retaining live PR identity."
+  },
+  "expectedRules": [
+    "DOCS-STRUCT-*",
+    "DOCS-FMT-*",
+    "DOCS-WORD-003",
+    "DOCS-EX-023",
+    "DOCS-EVID-001"
+  ],
+  "mustCatch": [
+    {
+      "key": "list-resource-title-summary",
+      "severity": "high",
+      "file": "website/docs/list-resources/example_network_profile.html.markdown",
+      "description": "The docs-writer response should restore the list-resource title and summary shape for the page."
+    },
+    {
+      "key": "list-query-example-form",
+      "severity": "high",
+      "file": "website/docs/list-resources/example_network_profile.html.markdown",
+      "description": "The docs-writer response should use Terraform `list` query examples instead of resource examples for the list-resource page."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "scaffold-existing-page",
+      "description": "The response must not treat scaffolding as the default remediation for an existing list-resource docs page."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustIncludeMarkers": [
+      "Preflight complete: yes",
+      "Skill used: docs-writer"
+    ]
+  },
+  "notes": "Use this as the direct docs-writer benchmark for list-resource page remediation without scaffold drift."
+}

--- a/tools/regression/cases/skill-resource-implementation-ephemeral-resource.json
+++ b/tools/regression/cases/skill-resource-implementation-ephemeral-resource.json
@@ -1,0 +1,57 @@
+{
+  "id": "skill-resource-implementation-ephemeral-resource",
+  "title": "Resource implementation guidance applies the framework ephemeral-resource pattern",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized implementation-guidance scenario where a contributor starts a provider ephemeral resource but drifts toward ordinary CRUD resource patterns. The correct guidance should require the framework ephemeral pattern and its companion artifacts.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-ephemeral-resource/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/keyvault/example_secret_ephemeral.go",
+      "internal/services/keyvault/registration.go"
+    ],
+    "notes": "Sanitized fixture models a real implementation-guidance pattern without retaining live PR identity."
+  },
+  "expectedRules": [
+    "IMPL-WF-004",
+    "TEST-WF-004"
+  ],
+  "mustCatch": [
+    {
+      "key": "ephemeral-open-pattern-required",
+      "severity": "high",
+      "file": "internal/services/keyvault/example_secret_ephemeral.go",
+      "description": "The guidance should require the framework ephemeral pattern with `sdk.EphemeralResource` and `Open(...)` rather than CRUD resource methods."
+    },
+    {
+      "key": "ephemeral-companion-artifacts",
+      "severity": "medium",
+      "file": "internal/services/keyvault/registration.go",
+      "description": "The guidance should require `EphemeralResources()` registration plus companion docs and Terraform 1.10-gated tests for the ephemeral resource."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "crud-resource-pattern",
+      "description": "The guidance must not steer the contributor toward ordinary CRUD resource lifecycle methods for an ephemeral resource."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this as the adjudicated implementation-guidance case for the framework ephemeral-resource workflow."
+}

--- a/tools/regression/cases/skill-resource-implementation-existing-resource-list-retrofit.json
+++ b/tools/regression/cases/skill-resource-implementation-existing-resource-list-retrofit.json
@@ -1,0 +1,53 @@
+{
+  "id": "skill-resource-implementation-existing-resource-list-retrofit",
+  "title": "Resource implementation guidance requires the full companion set when retrofitting list support",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized implementation-guidance scenario based on upstream PR #32192 where an existing resource is gaining Resource Identity and list support. The correct guidance should require the full companion workflow rather than treating registration, tests, or list-resource docs as optional follow-up work.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-existing-resource-list-retrofit/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/signalr/example_existing_resource.go",
+      "internal/services/signalr/registration.go"
+    ],
+    "notes": "Sanitized fixture models a real upstream PR pattern where an existing resource was retrofitted with Resource Identity and a list resource, along with the required list tests and list-resource docs."
+  },
+  "expectedRules": [
+    "IMPL-WF-002A",
+    "TEST-WF-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "existing-resource-list-retrofit-companions",
+      "severity": "high",
+      "file": "internal/services/signalr/example_existing_resource.go",
+      "description": "The guidance should require identity, list implementation, registration, list-query tests, and list-resource docs together when the task is to retrofit list support onto an existing resource."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "retrofit-follow-up-optional",
+      "description": "The guidance must not treat list registration, list tests, or list-resource docs as optional follow-up work once the list-support retrofit is in scope."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "list-resource docs",
+      "Resource Identity",
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this adjudicated case to keep implementation guidance aligned with the real upstream pattern for retrofitting list support onto an existing resource, based on PR #32192."
+}

--- a/tools/regression/cases/skill-resource-implementation-list-resource.json
+++ b/tools/regression/cases/skill-resource-implementation-list-resource.json
@@ -1,0 +1,54 @@
+{
+  "id": "skill-resource-implementation-list-resource",
+  "title": "Resource implementation guidance requires list resources for new resources",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized implementation-guidance scenario where a contributor asks for a brand-new typed resource. The correct guidance must require Resource Identity and a corresponding list resource by default, rather than treating the list resource as optional.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-list-resource/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go",
+      "internal/services/example/registration.go"
+    ],
+    "notes": "Sanitized fixture models a new-resource implementation request after the upstream guide-new-resource and guide-list-resource workflow update."
+  },
+  "expectedRules": [
+    "IMPL-WF-001",
+    "IMPL-WF-002",
+    "TEST-WF-003"
+  ],
+  "mustCatch": [
+    {
+      "key": "mandatory-list-resource",
+      "severity": "high",
+      "file": "internal/services/example/example_resource.go",
+      "description": "The guidance should require Resource Identity and a corresponding list resource for a new resource by default."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "list-resource-optional",
+      "description": "The guidance must not treat the list resource as optional for a new resource unless it explicitly uses the maintainer-reviewed exception path."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "list resource",
+      "Resource Identity",
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this adjudicated case to keep new-resource implementation guidance aligned with the upstream mandatory list-resource workflow."
+}

--- a/tools/regression/cases/skill-resource-implementation-provider-function.json
+++ b/tools/regression/cases/skill-resource-implementation-provider-function.json
@@ -1,0 +1,56 @@
+{
+  "id": "skill-resource-implementation-provider-function",
+  "title": "Resource implementation guidance applies the provider-defined function pattern",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "real-pr",
+  "sanitized": true,
+  "description": "A sanitized implementation-guidance scenario where a contributor starts a provider-defined function but drifts toward service-resource patterns. The correct guidance should require the internal provider-function workflow and its companion artifacts.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-provider-function/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/provider/function/example_resource_id.go"
+    ],
+    "notes": "Sanitized fixture models a real provider-function implementation-guidance pattern without retaining live PR identity."
+  },
+  "expectedRules": [
+    "IMPL-WF-005",
+    "TEST-WF-005"
+  ],
+  "mustCatch": [
+    {
+      "key": "provider-function-pattern-required",
+      "severity": "high",
+      "file": "internal/provider/function/example_resource_id.go",
+      "description": "The guidance should require the provider-defined function pattern with `Metadata`, `Definition`, and `Run`."
+    },
+    {
+      "key": "provider-function-companion-artifacts",
+      "severity": "medium",
+      "file": "internal/provider/function/example_resource_id.go",
+      "description": "The guidance should require the companion docs under `website/docs/functions/` and Terraform 1.8-gated unit tests under `internal/provider/function/*_test.go`."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "service-resource-pattern",
+      "description": "The guidance must not steer the contributor toward service-local CRUD resource patterns for a provider-defined function."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this as the adjudicated implementation-guidance case for the provider-defined function workflow."
+}

--- a/tools/regression/examples/review-committed-vendored-scope.result.json
+++ b/tools/regression/examples/review-committed-vendored-scope.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-committed-vendored-scope",
+  "runId": "sample-review-committed-vendored-001",
+  "timestampUtc": "2026-05-06T00:00:00Z",
+  "task": "code-review-committed-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "vendored-heavy-scope-callout"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the committed-review vendored-heavy scope case."
+}

--- a/tools/regression/examples/review-committed-vendored-scope.review.md
+++ b/tools/regression/examples/review-committed-vendored-scope.review.md
@@ -1,0 +1,65 @@
+# 📋 **Code Review**: committed review of vendored-heavy SDK update
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 6 files (0 new, 6 modified, 0 deleted)
+- **Scale**: 118 insertions, 32 deletions
+- **Branch**: fixture/committed-vendored-scope vs origin/main
+- **Scope**: updates dependency wiring and service client usage while most changed files are vendored SDK churn
+- **Skipped Vendored Files**: 3
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `go.mod`
+- `go.sum`
+- `internal/services/example/client/client.go`
+
+**Deleted Files:**
+- none
+
+**Skipped Vendored Files:** 3
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The modeled PR is vendored-heavy: the actionable review surface is limited to the non-vendored dependency and client wiring changes, while the vendored SDK churn is disclosed but intentionally excluded from direct remediation findings.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: committed-review path applied for explicit PR context and Go review scope
+- **Scope Rules**: `REVIEW-FILE-005`, `REVIEW-SCOPE-005`, and `REVIEW-LINT-*` were directly relevant because the diff is vendored-heavy but still includes an actionable provider Go file
+- **Docs Contract**: not applicable
+- **Notes**: this change-set is vendored-heavy, so the review reports only the skipped vendored-file count and keeps actionable commentary focused on the non-vendored control surface
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: PR-scoped diff for the committed review context
+- **Issue Count**: 0
+- **Summary**: linter completed successfully for the non-vendored provider Go changes in scope with no findings
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review keeps the useful signal on the actionable dependency and service wiring changes instead of drowning the result in vendored SDK path listings.
+
+### 🟡 **OBSERVATIONS**
+- Most of the diff is vendored churn, so the limited number of actionable findings is expected rather than a sign that review coverage was skipped.
+
+### 🔴 **ISSUES**
+- None.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Keep the review output count-only for vendored files and focus any future findings on the non-vendored control surface that introduced the vendored churn.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Reuse this fixture shape for future vendor-heavy PR regressions so generic review does not drift back toward path-by-path vendor noise.
+
+## 🏆 **OVERALL ASSESSMENT**
+The committed review behavior is correct when it reports vendored-heavy scope explicitly, counts skipped vendored files, and avoids directing contributors to edit vendored files directly.

--- a/tools/regression/examples/review-docs-ephemeral-resource-shape.result.json
+++ b/tools/regression/examples/review-docs-ephemeral-resource-shape.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "review-docs-ephemeral-resource-shape",
+  "runId": "sample-docs-ephemeral-001",
+  "timestampUtc": "2026-05-05T00:00:00Z",
+  "task": "code-review-docs",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "ephemeral-doc-type-regression"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the ephemeral-resource docs-review regression case."
+}

--- a/tools/regression/examples/review-docs-ephemeral-resource-shape.review.md
+++ b/tools/regression/examples/review-docs-ephemeral-resource-shape.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: docs ephemeral-resource page-shape regression
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 1 modified, 0 deleted)
+- **Scale**: 5 insertions, 2 deletions
+- **Branch**: fixture/docs-ephemeral-shape vs origin/main
+- **Scope**: updates an ephemeral-resource docs page but drifts toward ordinary resource-doc structure and examples
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `website/docs/ephemeral-resources/example_secret.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The docs update changes an ephemeral-resource page, but it uses the ordinary resource title and example form and omits the required Terraform 1.10 support note.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: docs compliance contract applied
+- **Repo Guidance**: documentation guidance loaded
+- **Scope Rules**: docs-only review path applied
+- **Docs Contract**: `DOCS-STRUCT-*`, `DOCS-FMT-*`, `DOCS-WORD-003`, and `DOCS-EX-024` were directly relevant
+- **Notes**: the review treats `website/docs/ephemeral-resources/**` as a first-class docs type instead of forcing ordinary resource-doc expectations onto the page
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: 0
+- **Summary**: docs-only scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review stays grounded in the ephemeral-resource doc type rather than treating the page like a generic resource page.
+
+### 🟡 **OBSERVATIONS**
+- The correct remediation is structural: restore the ephemeral-resource title, Terraform 1.10 support note, and Terraform `ephemeral` example shape.
+
+### 🔴 **ISSUES**
+- This page is under `website/docs/ephemeral-resources/`, so it should use the `Ephemeral:` title form and the required Terraform 1.10 support note rather than ordinary resource-doc wording.
+- The example should be a Terraform `ephemeral` example for the documented ephemeral resource, not a `resource` block example.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Rewrite the page to use the ephemeral-resource doc structure: `# Ephemeral: azurerm_example_secret`, the required Terraform 1.10 support note, and `ephemeral "azurerm_example_secret" "example"` examples.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Keep ephemeral-resource docs benchmarked separately from ordinary resource and data source pages so `/code-review-docs` does not regress back to the wrong doc type.
+
+## 🏆 **OVERALL ASSESSMENT**
+The page is not following the ephemeral-resource doc type yet and should be corrected before merge.

--- a/tools/regression/examples/review-docs-function-shape.result.json
+++ b/tools/regression/examples/review-docs-function-shape.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "review-docs-function-shape",
+  "runId": "sample-docs-function-001",
+  "timestampUtc": "2026-05-05T00:00:00Z",
+  "task": "code-review-docs",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "function-doc-type-regression"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the function docs-review regression case."
+}

--- a/tools/regression/examples/review-docs-function-shape.review.md
+++ b/tools/regression/examples/review-docs-function-shape.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: docs function page-shape regression
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 1 modified, 0 deleted)
+- **Scale**: 5 insertions, 2 deletions
+- **Branch**: fixture/docs-function-shape vs origin/main
+- **Scope**: updates a function docs page but drifts toward ordinary resource-doc structure and examples
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `website/docs/functions/example_parse_resource_id.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The docs update changes a function page, but it uses the ordinary resource title and section form, omits the required runtime-support note, and does not show the provider-defined function call pattern.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: docs compliance contract applied
+- **Repo Guidance**: documentation guidance loaded
+- **Scope Rules**: docs-only review path applied
+- **Docs Contract**: `DOCS-STRUCT-*`, `DOCS-WORD-003`, and `DOCS-EX-025` were directly relevant
+- **Notes**: the review treats `website/docs/functions/**` as a first-class docs type instead of forcing ordinary resource-doc expectations onto the page
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: 0
+- **Summary**: docs-only scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review stays grounded in the function doc type rather than treating the page like a generic resource page.
+
+### 🟡 **OBSERVATIONS**
+- The correct remediation is structural: restore the function title, runtime-support note, and provider-defined function example shape.
+
+### 🔴 **ISSUES**
+- This page is under `website/docs/functions/`, so it should use the `Function:` title form, the required provider-defined function runtime-support note, and the function-specific `Signature` / `Arguments` structure.
+- The example should call the documented function through `provider::azurerm::<name>(...)` rather than behaving like an ordinary resource or data source example.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Rewrite the page to use the function doc structure: `# Function: example_parse_resource_id`, the required runtime-support note, function-call examples using `provider::azurerm::example_parse_resource_id(...)`, `## Signature`, and `## Arguments`.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Keep function docs benchmarked separately from ordinary resource and data source pages so `/code-review-docs` does not regress back to the wrong doc type.
+
+## 🏆 **OVERALL ASSESSMENT**
+The page is not following the function doc type yet and should be corrected before merge.

--- a/tools/regression/examples/review-docs-list-resource-shape.result.json
+++ b/tools/regression/examples/review-docs-list-resource-shape.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "review-docs-list-resource-shape",
+  "runId": "sample-docs-list-resource-001",
+  "timestampUtc": "2026-05-04T00:00:00Z",
+  "task": "code-review-docs",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "list-resource-doc-type-regression"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the list-resource docs-review regression case."
+}

--- a/tools/regression/examples/review-docs-list-resource-shape.review.md
+++ b/tools/regression/examples/review-docs-list-resource-shape.review.md
@@ -1,0 +1,58 @@
+# 📋 **Code Review**: docs list-resource page-shape regression
+
+## 📊 **CHANGE SUMMARY**
+- **Files Changed**: 1 files (0 new, 1 modified, 0 deleted)
+- **Scale**: 6 insertions, 3 deletions
+- **Branch**: fixture/docs-list-resource-shape vs origin/main
+- **Scope**: updates a list-resource docs page but drifts toward ordinary resource-doc structure and examples
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `website/docs/list-resources/example_network_profile.html.markdown`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The docs update changes a list-resource page, but it uses the ordinary resource title, summary, section intro, and example form instead of the list-resource-specific doc shape.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: docs compliance contract applied
+- **Repo Guidance**: documentation guidance loaded
+- **Scope Rules**: docs-only review path applied
+- **Docs Contract**: `DOCS-STRUCT-*`, `DOCS-FMT-*`, `DOCS-WORD-003`, and `DOCS-EX-023` were directly relevant
+- **Notes**: the review treats `website/docs/list-resources/**` as a first-class docs type instead of forcing ordinary resource-doc expectations onto the page
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: 0
+- **Summary**: docs-only scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The review stays grounded in the list-resource doc type instead of treating the page like a generic resource page.
+
+### 🟡 **OBSERVATIONS**
+- The correct remediation is structural: restore the list-resource title, summary, section intro, and Terraform `list` query examples.
+
+### 🔴 **ISSUES**
+- This page is under `website/docs/list-resources/`, so it should use the list-resource title and summary shape rather than ordinary resource-doc wording.
+- The example should be a Terraform `list` query example for the documented list resource, not a `resource` block example.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Rewrite the page to use the list-resource doc structure: `# List resource: azurerm_example_network_profile`, a `Lists ... resources.` summary, `## Argument Reference`, and `list "azurerm_example_network_profile" "example"` examples.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Keep list-resource docs benchmarked separately from ordinary resource and data source pages so `/code-review-docs` does not regress back to the wrong doc type.
+
+## 🏆 **OVERALL ASSESSMENT**
+The page is not following the list-resource doc type yet and should be corrected before merge.

--- a/tools/regression/examples/review-local-new-resource-companions.result.json
+++ b/tools/regression/examples/review-local-new-resource-companions.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-local-new-resource-companions",
+  "runId": "sample-review-local-new-resource-001",
+  "timestampUtc": "2026-05-04T00:00:00Z",
+  "task": "code-review-local-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "missing-new-resource-companions"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "run"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the local-review new-resource companion-artifact case."
+}

--- a/tools/regression/examples/review-local-new-resource-companions.review.md
+++ b/tools/regression/examples/review-local-new-resource-companions.review.md
@@ -1,0 +1,59 @@
+# 📋 **Code Review**: local new-resource implementation without required companion artifacts
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 2 files (2 tracked new, 0 untracked, 0 modified, 0 deleted)
+- **Line Changes**: 96 insertions, 0 deletions (tracked files only)
+- **Branch**: fixture/local-new-resource
+- **Type**: unstaged local changes
+- **Scope**: adds a brand-new resource implementation and registration entry without the required list-resource companions
+
+## 📁 **FILES CHANGED**
+
+**Added Files (Tracked):**
+- `internal/services/example/example_resource.go`
+- `internal/services/example/registration.go`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The change introduces a new resource, but it stops at the base resource and registration path. Under the current implementation and testing workflow, that is incomplete because the new resource also needs the corresponding list resource, list query tests, and list-resource docs.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: implementation and testing guidance loaded for `internal/**/*.go` scope
+- **Scope Rules**: `REVIEW-SCOPE-005` and `REVIEW-SCOPE-005A` were directly relevant because the change adds a brand-new provider resource
+- **Docs Contract**: not applicable
+- **Notes**: for a new resource, the review must consider required companion artifacts even when those files are absent from the diff
+
+### 🧰 **AZURERM LINTER**
+- **Version**: v0.2.0
+- **Status**: No issues
+- **Run Scope**: filtered local-diff scope
+- **Issue Count**: 0
+- **Summary**: linter completed successfully with no findings for the changed packages
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The base resource registration path is present and the new resource is wired into the service registration.
+
+### 🟡 **OBSERVATIONS**
+- The issue here is workflow completeness, not a linter-detectable Go syntax or style problem.
+
+### 🔴 **ISSUES**
+- This adds a brand-new resource but does not include the mandatory companion artifacts required by the current upstream-backed workflow: the corresponding list resource, the list query tests, and the list-resource docs under `website/docs/list-resources/`. Without an explicit maintainer-reviewed exception path, that should be treated as incomplete new-resource work.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Add the `*_resource_list.go` implementation, the corresponding `*_resource_list_test.go` query coverage, and the list-resource docs page under `website/docs/list-resources/`, or explicitly document the maintainer-reviewed upstream exception path if listing is genuinely not supported.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Keep future new-resource reviews keyed to the companion-artifact workflow so the base resource path is not treated as sufficient on its own.
+
+## 🏆 **OVERALL ASSESSMENT**
+The base resource work is directionally correct, but the change is incomplete until the mandatory new-resource companion artifacts, including the list-resource docs, are present or explicitly excepted.

--- a/tools/regression/examples/skill-docs-writer-list-resource-shape.result.json
+++ b/tools/regression/examples/skill-docs-writer-list-resource-shape.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-docs-writer-list-resource-shape",
+  "runId": "sample-docswriter-list-resource-001",
+  "timestampUtc": "2026-05-04T00:00:00Z",
+  "task": "docs-writer",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "list-resource-title-summary",
+      "list-query-example-form"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the list-resource docs-writer regression case."
+}

--- a/tools/regression/examples/skill-resource-implementation-ephemeral-resource.result.json
+++ b/tools/regression/examples/skill-resource-implementation-ephemeral-resource.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-resource-implementation-ephemeral-resource",
+  "runId": "sample-impl-ephemeral-001",
+  "timestampUtc": "2026-05-05T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "ephemeral-open-pattern-required",
+      "ephemeral-companion-artifacts"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the ephemeral-resource implementation-guidance case."
+}

--- a/tools/regression/examples/skill-resource-implementation-existing-resource-list-retrofit.result.json
+++ b/tools/regression/examples/skill-resource-implementation-existing-resource-list-retrofit.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "skill-resource-implementation-existing-resource-list-retrofit",
+  "runId": "sample-impl-existing-list-retrofit-001",
+  "timestampUtc": "2026-05-05T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "existing-resource-list-retrofit-companions"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the existing-resource list-retrofit implementation-guidance case derived from upstream PR #32192."
+}

--- a/tools/regression/examples/skill-resource-implementation-list-resource.result.json
+++ b/tools/regression/examples/skill-resource-implementation-list-resource.result.json
@@ -1,0 +1,41 @@
+{
+  "caseId": "skill-resource-implementation-list-resource",
+  "runId": "sample-realcase-list-resource-001",
+  "timestampUtc": "2026-05-04T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "mandatory-list-resource"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the resource-implementation list-resource workflow case."
+}

--- a/tools/regression/examples/skill-resource-implementation-provider-function.result.json
+++ b/tools/regression/examples/skill-resource-implementation-provider-function.result.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "skill-resource-implementation-provider-function",
+  "runId": "sample-impl-function-001",
+  "timestampUtc": "2026-05-05T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "provider-function-pattern-required",
+      "provider-function-companion-artifacts"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the provider-defined function implementation-guidance case."
+}

--- a/tools/regression/fixtures/review-committed-vendored-scope/README.md
+++ b/tools/regression/fixtures/review-committed-vendored-scope/README.md
@@ -1,0 +1,43 @@
+# Sanitized Fixture: Committed Review For Vendored-Heavy Scope
+
+This fixture is synthetic and intentionally benchmarks a local safeguard rather than an upstream contributor rule.
+
+## Scenario
+
+A pull request updates an SDK dependency and regenerates vendored files, leaving only a small non-vendored control-surface change in the actionable review scope.
+
+The historical failure mode is that generic review either:
+
+- enumerates every vendored path and buries the useful findings in noise, or
+- tells the contributor to edit vendored files directly even though the actionable source is the dependency or generation input.
+
+## Simplified Change Shape
+
+```text
+Modified:
+- go.mod
+- go.sum
+- internal/services/example/client/client.go
+
+Vendored churn:
+- vendor/github.com/hashicorp/go-azure-sdk/resource-manager/example/2026-01-01/widgets/client.go
+- vendor/github.com/hashicorp/go-azure-sdk/resource-manager/example/2026-01-01/widgets/model_widget.go
+- vendor/modules.txt
+```
+
+## Expected Review Behavior
+
+A correct committed review should:
+
+- disclose only the count of skipped vendored files, not list every vendored path
+- explicitly say the diff is vendored-heavy so sparse actionable findings are easy to interpret
+- avoid raising findings that tell the contributor to edit files under `vendor/**` directly
+- focus any actionable commentary on the non-vendored control surface instead
+
+## Expected Must-Catch Outcomes
+
+- `vendored-heavy-scope-callout`
+
+## Expected Must-Not-Flag Outcomes
+
+- `edit-vendored-files-directly`

--- a/tools/regression/fixtures/review-docs-ephemeral-resource-shape/README.md
+++ b/tools/regression/fixtures/review-docs-ephemeral-resource-shape/README.md
@@ -1,0 +1,45 @@
+# Sanitized Fixture: Docs Review For Ephemeral Resource Page Shape
+
+This fixture is derived from a real docs-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+An ephemeral-resource page modeled as `website/docs/ephemeral-resources/example_secret.html.markdown` is updated, but the page drifts toward ordinary resource-doc structure.
+
+The modeled page introduces three review-relevant problems:
+
+- The top-level heading uses the ordinary resource form instead of the ephemeral-resource title form
+- The Terraform-version support note is missing
+- The example uses a `resource` block instead of a Terraform `ephemeral` block
+
+## Simplified Docs Shape
+
+```markdown
+# azurerm_example_secret
+
+Manages Example Secrets.
+
+## Example Usage
+
+```hcl
+resource "azurerm_example_secret" "example" {}
+```
+```
+
+## Expected Review Behavior
+
+A correct docs review should:
+
+- Load and apply the docs contract
+- Treat the page as an ephemeral-resource docs page under `website/docs/ephemeral-resources/`
+- Require the ephemeral-resource title and Terraform 1.10 support note
+- Require `ephemeral` query examples using Terraform `ephemeral` blocks
+- Avoid requiring an ordinary managed-resource `Import` section
+
+## Expected Must-Catch Outcomes
+
+- `ephemeral-doc-type-regression`
+
+## Expected Must-Not-Flag Outcomes
+
+- `managed-resource-import-required`

--- a/tools/regression/fixtures/review-docs-function-shape/README.md
+++ b/tools/regression/fixtures/review-docs-function-shape/README.md
@@ -1,0 +1,47 @@
+# Sanitized Fixture: Docs Review For Function Page Shape
+
+This fixture is derived from a real docs-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A function page modeled as `website/docs/functions/example_parse_resource_id.html.markdown` is updated, but the page drifts toward ordinary resource-doc structure.
+
+The modeled page introduces three review-relevant problems:
+
+- The top-level heading uses the ordinary resource form instead of the function title form
+- The provider-defined function runtime-support note is missing
+- The example does not call the function through `provider::azurerm::...`
+
+## Simplified Docs Shape
+
+```markdown
+# azurerm_example_parse_resource_id
+
+Manages Example Parse Resource IDs.
+
+## Arguments Reference
+
+The following arguments are supported:
+
+```hcl
+data "azurerm_client_config" "example" {}
+```
+```
+
+## Expected Review Behavior
+
+A correct docs review should:
+
+- Load and apply the docs contract
+- Treat the page as a function docs page under `website/docs/functions/`
+- Require the function title and provider-defined function runtime-support note
+- Require `provider::azurerm::<name>(...)` examples and the `Signature` / `Arguments` structure
+- Avoid treating a provider block in a function example as automatically invalid
+
+## Expected Must-Catch Outcomes
+
+- `function-doc-type-regression`
+
+## Expected Must-Not-Flag Outcomes
+
+- `provider-block-prohibited`

--- a/tools/regression/fixtures/review-docs-list-resource-shape/README.md
+++ b/tools/regression/fixtures/review-docs-list-resource-shape/README.md
@@ -1,0 +1,47 @@
+# Sanitized Fixture: Docs Review For List Resource Page Shape
+
+This fixture is derived from a real docs-review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A list-resource page modeled as `website/docs/list-resources/example_network_profile.html.markdown` is updated, but the page drifts toward ordinary resource-doc structure.
+
+The modeled page introduces three review-relevant problems:
+
+- The top-level heading uses the ordinary resource form instead of the list-resource title form
+- The summary sentence uses resource-style wording instead of list-resource wording
+- The example uses a `resource` block instead of a Terraform `list` query block
+
+## Simplified Docs Shape
+
+```markdown
+# azurerm_example_network_profile
+
+Manages Example Network Profiles.
+
+## Arguments Reference
+
+The following arguments are supported:
+
+```hcl
+resource "azurerm_example_network_profile" "example" {}
+```
+```
+
+## Expected Review Behavior
+
+A correct docs review should:
+
+- Load and apply the docs contract
+- Treat the page as a list-resource docs page under `website/docs/list-resources/`
+- Require the list-resource title and summary shape
+- Require list query examples using Terraform `list` blocks
+- Avoid applying ordinary resource-example self-containedness fixes to the page
+
+## Expected Must-Catch Outcomes
+
+- `list-resource-doc-type-regression`
+
+## Expected Must-Not-Flag Outcomes
+
+- `resource-self-containedness-required`

--- a/tools/regression/fixtures/review-local-new-resource-companions/README.md
+++ b/tools/regression/fixtures/review-local-new-resource-companions/README.md
@@ -1,0 +1,40 @@
+# Sanitized Fixture: Local Review For New Resource Companion Coverage
+
+This fixture is derived from a real new-resource review pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A local change adds a brand-new resource under `internal/services/example/` and registers it, but the change does not include the rest of the now-mandatory companion workflow.
+
+The historical failure mode is that review focuses only on the base resource implementation and misses the missing companion artifacts.
+
+## Simplified Change Shape
+
+```text
+Added:
+- internal/services/example/example_resource.go
+- internal/services/example/registration.go
+
+Missing:
+- internal/services/example/example_resource_list.go
+- internal/services/example/example_resource_list_test.go
+- website/docs/list-resources/example.html.markdown
+```
+
+## Expected Review Behavior
+
+A correct local code review should:
+
+- Activate the Go implementation review scope rules
+- Apply the new-resource workflow requirements from the implementation and testing guidance
+- Flag the missing companion artifacts as a review issue
+- Explicitly mention the missing list-resource docs under `website/docs/list-resources/`
+- Avoid treating the docs as optional when no explicit maintainer-reviewed exception path is present
+
+## Expected Must-Catch Outcomes
+
+- `missing-new-resource-companions`
+
+## Expected Must-Not-Flag Outcomes
+
+- `list-resource-docs-optional`

--- a/tools/regression/fixtures/skill-docs-writer-list-resource-shape/README.md
+++ b/tools/regression/fixtures/skill-docs-writer-list-resource-shape/README.md
@@ -1,0 +1,50 @@
+# Sanitized Fixture: Docs-Writer List Resource Page Shape
+
+This fixture is derived from a real docs-remediation pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer asks `docs-writer` to fix an existing list-resource page modeled as `website/docs/list-resources/example_network_profile.html.markdown`.
+
+The modeled page already exists, so the correct workflow is to edit it in place rather than regenerate it from scaffolding.
+
+The page has three contract-relevant drifts:
+
+- The top-level heading uses ordinary resource-doc syntax instead of the list-resource title form
+- The summary sentence uses `Manages ...` instead of `Lists ... resources.`
+- The primary example uses a `resource` block instead of a Terraform `list` query block
+
+## Simplified Docs Shape
+
+```markdown
+# azurerm_example_network_profile
+
+Manages Example Network Profiles.
+
+## Arguments Reference
+
+The following arguments are supported:
+
+```hcl
+resource "azurerm_example_network_profile" "example" {}
+```
+```
+
+## Expected Guidance
+
+A correct `docs-writer` response should:
+
+- Complete docs preflight and apply the docs contract rather than generic prose cleanup
+- Edit the existing page in place instead of treating scaffolding as the default remediation
+- Restore the list-resource title and summary shape
+- Restore the list-resource `Argument Reference` structure and intro line
+- Replace the example with a Terraform `list` query example for the list resource
+
+## Expected Must-Catch Outcomes
+
+- `list-resource-title-summary`
+- `list-query-example-form`
+
+## Expected Must-Not-Flag Outcomes
+
+- `scaffold-existing-page`

--- a/tools/regression/fixtures/skill-resource-implementation-ephemeral-resource/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-ephemeral-resource/README.md
@@ -1,0 +1,41 @@
+# Sanitized Fixture: Resource Implementation Ephemeral Resource Workflow
+
+This fixture is derived from a real implementation-guidance pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer or contributor is adding a provider ephemeral resource under `internal/services/keyvault/`.
+
+The change introduces two workflow-relevant drifts:
+
+- The implementation is being approached like an ordinary CRUD resource instead of a framework ephemeral resource with `Open(...)`
+- The contributor has not planned the required companion artifacts such as `EphemeralResources()` registration, docs under `website/docs/ephemeral-resources/`, and Terraform 1.10-gated tests
+
+## Simplified Code Shape
+
+```go
+func resourceExampleSecretEphemeral() *pluginsdk.Resource {
+    return &pluginsdk.Resource{
+        Create: resourceExampleSecretCreate,
+        Read:   resourceExampleSecretRead,
+    }
+}
+```
+
+## Expected Guidance
+
+A correct resource-implementation response should:
+
+- Load the implementation contract rather than relying on generic Go instincts
+- Require the `sdk.EphemeralResource` pattern with `Metadata`, `Configure`, `Schema`, and `Open`
+- Require service registration through `EphemeralResources()`
+- Require the companion docs under `website/docs/ephemeral-resources/` and Terraform 1.10-gated `*_ephemeral_test.go` coverage
+
+## Expected Must-Catch Outcomes
+
+- `ephemeral-open-pattern-required`
+- `ephemeral-companion-artifacts`
+
+## Expected Must-Not-Flag Outcomes
+
+- `crud-resource-pattern`

--- a/tools/regression/fixtures/skill-resource-implementation-existing-resource-list-retrofit/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-existing-resource-list-retrofit/README.md
@@ -1,0 +1,36 @@
+# Sanitized Fixture: Resource Implementation Existing Resource List Retrofit
+
+This fixture is derived from a real upstream PR pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer or contributor is updating an existing typed resource under `internal/services/signalr/` to add Resource Identity and list support.
+
+The historical failure mode is that guidance focuses on the new `*_resource_list.go` file only and does not require the rest of the companion workflow for the retrofit.
+
+This fixture is based on the upstream pattern in PR `#32192` for `azurerm_web_pubsub_custom_certificate`.
+
+## Simplified Request Shape
+
+```text
+Add Resource Identity and list support to an existing resource under internal/services/signalr/
+```
+
+## Expected Guidance
+
+A correct resource-implementation response should:
+
+- Load the implementation contract rather than relying on generic list-resource instincts
+- Require Resource Identity as the prerequisite for the retrofit
+- Require the `*_resource_list.go` implementation and service registration
+- Require list-query acceptance coverage
+- Require list-resource docs under `website/docs/list-resources/`
+- Avoid treating registration, tests, or list-resource docs as optional follow-up work
+
+## Expected Must-Catch Outcomes
+
+- `existing-resource-list-retrofit-companions`
+
+## Expected Must-Not-Flag Outcomes
+
+- `retrofit-follow-up-optional`

--- a/tools/regression/fixtures/skill-resource-implementation-list-resource/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-list-resource/README.md
@@ -1,0 +1,33 @@
+# Sanitized Fixture: Resource Implementation Requires List Resource
+
+This fixture is derived from a real new-resource workflow clarification, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer or contributor is asking for help creating a brand-new typed resource under `internal/services/example/`.
+
+The historical failure mode is that implementation guidance focused on the base resource CRUD path and did not require the corresponding list resource, even though the upstream contributor workflow now makes it mandatory for all new resources unless an exception label is used.
+
+## Simplified Request Shape
+
+```text
+Create a new typed resource under internal/services/example/
+```
+
+## Expected Guidance
+
+A correct resource-implementation response should:
+
+- Load the implementation contract rather than relying on a generic new-resource template
+- Require Resource Identity for the new resource
+- Require a corresponding list resource for the new resource by default
+- Mention the maintainer-reviewed exception path only when no list API exists
+- Plan list-resource acceptance coverage rather than stopping at base resource lifecycle tests
+
+## Expected Must-Catch Outcomes
+
+- `mandatory-list-resource`
+
+## Expected Must-Not-Flag Outcomes
+
+- `list-resource-optional`

--- a/tools/regression/fixtures/skill-resource-implementation-provider-function/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-provider-function/README.md
@@ -1,0 +1,40 @@
+# Sanitized Fixture: Resource Implementation Provider Function Workflow
+
+This fixture is derived from a real implementation-guidance pattern, but the final artifact is sanitized and does not retain live PR identity.
+
+## Scenario
+
+A maintainer or contributor is adding a provider-defined function under `internal/provider/function/`.
+
+The change introduces two workflow-relevant drifts:
+
+- The implementation is being approached like a service resource instead of a provider-defined function with `Metadata`, `Definition`, and `Run`
+- The contributor has not planned the required companion artifacts such as docs under `website/docs/functions/` and Terraform 1.8-gated unit tests under `internal/provider/function/*_test.go`
+
+## Simplified Code Shape
+
+```go
+func resourceExampleResourceID() *pluginsdk.Resource {
+    return &pluginsdk.Resource{
+        Read: resourceExampleRead,
+    }
+}
+```
+
+## Expected Guidance
+
+A correct resource-implementation response should:
+
+- Load the implementation contract rather than relying on generic Go instincts
+- Require the provider-defined function pattern under `internal/provider/function/`
+- Require `Metadata`, `Definition`, and `Run`
+- Require the companion docs under `website/docs/functions/` and Terraform 1.8-gated unit tests under `internal/provider/function/*_test.go`
+
+## Expected Must-Catch Outcomes
+
+- `provider-function-pattern-required`
+- `provider-function-companion-artifacts`
+
+## Expected Must-Not-Flag Outcomes
+
+- `service-resource-pattern`


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Summary

Extend the AI toolkit so it enforces newer HashiCorp contributor workflows around list resources, Ephemeral Resources, and provider-defined Functions, and tighten generic review so vendored SDK churn is treated as non-actionable review scope.

## Description

This PR updates the AI toolkit to better match the current Terraform AzureRM contributor workflow and review expectations.

What changed:

- Added first-class docs, implementation, and testing guidance for list-resource pages and list-resource companion workflows.
- Added first-class docs, implementation, and testing guidance for Ephemeral Resources.
- Added first-class docs, implementation, and testing guidance for provider-defined Functions.
- Updated local and committed review prompts so new-resource reviews explicitly check for:
  - Resource Identity
  - corresponding list resources
  - list-query tests
  - list-resource docs
- Added guidance for retrofitting list support onto existing resources, based on a real upstream PR pattern.
- Updated generic review behavior for `vendor/**` so vendored files are:
  - treated as non-actionable review scope
  - reported as a skipped vendored-file count instead of a path-by-path list
  - called out explicitly when a diff is vendored-only or vendored-heavy
- Added/updated adjudicated regression cases to benchmark the new behavior, including:
  - list-resource docs and implementation workflows
  - Ephemeral docs and implementation workflows
  - Function docs and implementation workflows
  - existing-resource list retrofit workflow
  - vendored-heavy committed-review behavior

Why this change:

The main goal is to stop the toolkit from silently letting newer HashiCorp-required workflows slide through review. Even if prompt behavior is not perfect in every scenario yet, the policy surface is now explicit, testable, and enforced by the toolkit instead of relying on tribal knowledge.

Reviewer notes:

- This is primarily a contract/prompt/skill/regression update across the AI toolkit.
- The branch was validated with the one-shot maintainer validator and smoke-tested against a real upstream-style review scenario.
- The smoke test correctly identified a missing list/identity issue on a real HashiCorp PR candidate, which gives confidence that the new rule surface is actually being applied.

## Type of Change

- [x] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Bug fix
- [ ] Breaking change

## Scope

- [x] Installer
- [ ] Bash
- [ ] PowerShell
- [x] AI prompts (`.github/prompts/`)
- [x] AI instructions (`.github/instructions/`)
- [x] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

N/A

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

Validated with:

- `pwsh -NoProfile -File .\tools\validate-ai-toolkit.ps1`
- regression artifact validation
- adjudicated regression suite scoring

Validation highlights:

- contracts: passed
- markdown: passed
- regression harness: passed
- upstream drift: passed

Also performed a smoke test against a real upstream-style review scenario after bootstrapping the toolkit into a real HashiCorp repository branch. The updated review prompt correctly identified the missing list/identity issue, which was the most important behavior change to prove.

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

AI was used to help draft and refine the AI-toolkit contract changes, prompt updates, skills updates, regression cases, documentation changes, and validation workflow. All changes were iteratively reviewed, adjusted, validated, and smoke-tested by the author.

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [ ] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github_actions`)
```

If you want, I can also give you a shorter alternative title in case you want something tighter for the PR list.