### PR TITLE
[ENHANCEMENT:] tighten `GetRawConfig` `CustomizeDiff` `IsKnown` guidance and add regression test coverage

### DIFF
--- a/.github/instructions/azure-patterns.instructions.md
+++ b/.github/instructions/azure-patterns.instructions.md
@@ -126,7 +126,40 @@ Azure resources have unique validation requirements that CustomizeDiff functions
 
 **For comprehensive multi-function CustomizeDiff patterns and complex validation examples, see:** [Implementation Guide - CustomizeDiff Import Requirements](./implementation-guide.instructions.md#customizediff-import-requirements)
 
-For the authoritative `CustomizeDiff` requirement on `GetRawConfig()`, configured-versus-unknown values, and enum helper boundaries, see `IMPL-SCHEMA-013` in `.github/instructions/implementation-compliance-contract.instructions.md`.
+For the authoritative `CustomizeDiff` requirement on `GetRawConfig()`, configured-versus-unknown values, raw `cty.Value` shape inspection, and enum helper boundaries, see `IMPL-SCHEMA-013` in `.github/instructions/implementation-compliance-contract.instructions.md`.
+
+### Unknown `cty.Value` Traversal Pattern
+
+When `CustomizeDiff` reads nested raw config from `GetRawConfig()`, guard shape-inspection methods with `IsKnown()` first. Unknown plan values are common during planning, and calling `LengthInt()`, `AsValueSlice()`, or `AsValueMap()` on an unknown value can panic instead of deferring validation cleanly.
+
+Bad:
+
+```go
+conditions := rawConfig.GetAttr("conditions")
+if conditions.IsNull() || conditions.LengthInt() == 0 {
+    return nil
+}
+conditionBlock := conditions.AsValueSlice()[0].AsValueMap()
+```
+
+Good:
+
+```go
+conditions := rawConfig.GetAttr("conditions")
+if !conditions.IsKnown() || conditions.IsNull() || conditions.LengthInt() == 0 {
+    return nil
+}
+conditionBlock := conditions.AsValueSlice()[0].AsValueMap()
+```
+
+For nested values, apply the same guard before more shape inspection:
+
+```go
+matchValues := conditionValue.AsValueSlice()[0].AsValueMap()["match_values"]
+if !matchValues.IsKnown() || matchValues.IsNull() || matchValues.LengthInt() == 0 {
+    return nil
+}
+```
 
 ### Zero Value Validation Pattern
 
@@ -263,14 +296,18 @@ When Azure resources have irreversible configuration changes (like enabling secu
 - **Test Framework**: Acceptance tests require visible state changes to validate ForceNew behavior
 
 **Implementation Pattern:**
+
+This example is limited to top-level field-presence detection. Guard the top-level `rawConfig` value so it is known and non-null before `AsValueMap()` is used; if later logic traverses nested values from that map, follow the `IsKnown()` guard pattern above before any further shape inspection.
+
 ```go
 pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
     var featureExists, policyExists bool
 
     // Check if fields exist in the raw configuration (not computed/inferred values)
-    if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-        featureExists = !rawConfig.AsValueMap()["irreversible_feature_enabled"].IsNull()
-        policyExists = !rawConfig.AsValueMap()["security_policy_enabled"].IsNull()
+    if rawConfig := diff.GetRawConfig(); rawConfig.IsKnown() && !rawConfig.IsNull() {
+        rawConfigMap := rawConfig.AsValueMap()
+        featureExists = !rawConfigMap["irreversible_feature_enabled"].IsNull()
+        policyExists = !rawConfigMap["security_policy_enabled"].IsNull()
     }
 
     // Only apply ForceNew logic during updates (not during initial creation)
@@ -313,7 +350,7 @@ pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDi
 
 **Key Requirements:**
 - **Irreversible Changes**: Only use for Azure features that cannot be disabled once enabled
-- **Raw Config Detection**: Use `GetRawConfig().AsValueMap()` to detect field presence vs absence in configuration
+- **Raw Config Detection**: When using `AsValueMap()` for top-level field presence detection, first ensure the top-level `GetRawConfig()` value is known and non-null
 - **Update-Only Logic**: Check `diff.Id() != ""` to ensure logic only applies to existing resources, not during creation
 - **State Visibility**: SetNew must be called before ForceNew to create visible plan entry
 - **Error Handling**: SetNew errors should be caught and wrapped with descriptive context
@@ -323,7 +360,7 @@ pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDi
 - **ForceNew without SetNew**: Plan won't show why recreation is needed - users will be confused by ForceNew without visible changes
 - **SetNew without ForceNew**: State changes but resource doesn't recreate when Azure constraints require it
 - **Missing Error Handling**: SetNew failures can break plan generation if not properly handled
-- **Wrong Field Detection**: Use `GetRawConfig().AsValueMap()[field].IsNull()` to detect field removal, not `diff.Get()`
+- **Wrong Field Detection**: Detect field removal from top-level raw config only after confirming `GetRawConfig()` is known and non-null; do not use `diff.Get()` for that presence check
 - **Creation vs Update**: Apply logic only during updates (`diff.Id() != ""`), not during initial resource creation
 
 **For comprehensive `GetRawConfig()` usage guidance, see:** <a href="#🔄-state-management-with-dgetrawconfig">State Management with d.GetRawConfig()</a>

--- a/.github/instructions/implementation-compliance-contract.instructions.md
+++ b/.github/instructions/implementation-compliance-contract.instructions.md
@@ -295,12 +295,14 @@ If evidence is missing for a behavior-changing claim, do not guess.
 ### IMPL-SCHEMA-013: Use `GetRawConfig()` in `CustomizeDiff` when validation must distinguish configured values from unknown or zero values
 - Rule: In `CustomizeDiff`, prefer `GetRawConfig()` over `diff.Get(...)` or decoded zero values when validation must distinguish unset fields from known-after-apply or Go zero values.
 - Rule: Use this pattern for cross-field validation where unknown values would otherwise collapse to zero values and trigger false positives.
+- Rule: When `CustomizeDiff` or other diff-time validation traverses nested raw `cty.Value` config, call `IsKnown()` before `LengthInt()`, `AsValueSlice()`, `AsValueMap()`, `Index()`, or other shape-inspection methods. If a value is unknown, defer validation and return `nil` rather than treating the value as empty or letting shape inspection panic.
 - Rule: Prefer direct `diff.Get(...)` access for required values whose presence is guaranteed by schema and where no configured-versus-unknown distinction is needed.
 - Rule: Do not use `pointer.FromEnum(...)` or `pointer.ToEnum[...]` with `diff.Get(...)`, `GetRawConfig()`, decoded schema maps, or other Terraform values inside `CustomizeDiff`; reserve those helpers for the SDK or API enum-pointer boundary.
-- **Provenance**: Published upstream standard.
+- **Provenance**: Local safeguard.
 - **Evidence**:
-  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/best-practices.md` under `Consider the use of GetRawConfig() in CustomizeDiff to handle known-after-apply values`
-  - That guidance uses `GetRawConfig()` as the preferred pattern when `d.Get()` or decoded values would make unknowns look unset
+  - Upstream contributor guidance in `hashicorp/terraform-provider-azurerm/contributing/topics/best-practices.md` under `Consider the use of GetRawConfig() in CustomizeDiff to handle known-after-apply values` establishes `GetRawConfig()` as the baseline pattern when `d.Get()` or decoded values would make unknowns look unset
+  - Terraform unknown values are common during planning, especially in `GetRawConfig()`-based `CustomizeDiff` validation
+  - Raw `cty.Value` traversal without `IsKnown()` can panic when `LengthInt()`, `AsValueSlice()`, or similar shape-inspection methods are called on unknown values
 
 ## PATCH and residual state
 

--- a/.github/skills/resource-implementation/SKILL.md
+++ b/.github/skills/resource-implementation/SKILL.md
@@ -156,6 +156,7 @@ return fmt.Errorf("creating %s: %+v", id, err)
    - Use consistent validation and error message formats.
    - Reuse shared validators first, keep short helper composition inline, and for new or materially updated bespoke `ValidateFunc` logic move it into the same service's `validate/` folder as a file-specific validator with matching unit coverage instead of relying on long anonymous inline closures.
    - Do not spend scope churning untouched legacy validator placement unless the task is already modifying that validator.
+   - When `CustomizeDiff` traverses nested `cty.Value` data from `GetRawConfig()`, guard `LengthInt()`, `AsValueSlice()`, and `AsValueMap()` with `IsKnown()` first and defer validation for unknown values, following `IMPL-SCHEMA-013`.
    - Treat read-side ID handling as case-insensitive by parsing import input, stored IDs, and Azure-returned IDs through the shared typed parser instead of comparing raw strings.
    - Parse resource IDs through their typed parser before writing them into Terraform state when the value came from Azure API output, a scoped ID, or an API response property, so casing is normalized and phantom diffs are avoided.
    - When the provider emits or rewrites a resource ID for state or other provider-managed outbound usage, use the canonical parser or provider `.ID()` form rather than preserving arbitrary external casing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Maintainer/Workflow:**
+  - **[Internal]** - Added an adjudicated `resource-implementation` regression case for raw `cty.Value` traversal in `CustomizeDiff`, so the `IMPL-SCHEMA-013` `IsKnown()` guard requirement is now benchmarked directly in the implementation-guidance corpus.
+
 ### Changed
+
+- **Maintainer/Workflow:**
+  - **[Implementation]** - Implementation guidance now consistently requires `CustomizeDiff` logic that traverses raw `cty.Value` config to guard shape-inspection calls with `IsKnown()` first, deferring validation for unknown plan values and keeping raw-config presence-detection examples aligned with that rule.
 
 ### Fixed
 

--- a/tools/regression/cases/skill-resource-implementation-customizediff-isknown-guard.json
+++ b/tools/regression/cases/skill-resource-implementation-customizediff-isknown-guard.json
@@ -1,0 +1,67 @@
+{
+  "id": "skill-resource-implementation-customizediff-isknown-guard",
+  "title": "Resource implementation guidance requires IsKnown guards before raw cty shape inspection in CustomizeDiff",
+  "task": "resource-implementation",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A synthetic implementation-guidance scenario where a contributor walks nested raw `cty.Value` data from `GetRawConfig()` inside `CustomizeDiff` and calls shape-inspection methods directly. The correct guidance should anchor on `IMPL-SCHEMA-013`, require `IsKnown()` before shape inspection, and defer validation for unknown values without broadening the rule into generic `IsKnown()` everywhere advice.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/skill-resource-implementation-customizediff-isknown-guard/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      "internal/services/example/example_resource.go"
+    ],
+    "notes": "Synthetic implementation-guidance scenario focused on raw cty traversal in CustomizeDiff rather than ordinary schema validation or acceptance-test coverage."
+  },
+  "expectedRules": [
+    "IMPL-SCHEMA-013"
+  ],
+  "mustCatch": [
+    {
+      "key": "isknown-before-shape-inspection",
+      "severity": "high",
+      "file": "internal/services/example/example_resource.go",
+      "description": "The guidance should say raw `cty.Value` traversal in `CustomizeDiff` must call `IsKnown()` before `LengthInt()`, `AsValueSlice()`, `AsValueMap()`, `Index()`, or similar shape-inspection methods."
+    },
+    {
+      "key": "defer-unknown-validation",
+      "severity": "medium",
+      "file": "internal/services/example/example_resource.go",
+      "description": "The guidance should defer validation and return `nil` when the traversed value is unknown, rather than treating unknown values as empty or allowing shape inspection to panic."
+    },
+    {
+      "key": "presence-detection-note-stays-narrow",
+      "severity": "low",
+      "file": "internal/services/example/example_resource.go",
+      "description": "The guidance should keep any raw-config `AsValueMap()` example limited to top-level field-presence detection with an explicit known/non-null assumption or guard, rather than presenting it as universally safe nested traversal."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "generic-isknown-everywhere",
+      "description": "The guidance must not broaden the requirement into generic advice to call `IsKnown()` everywhere regardless of whether raw diff-time shape inspection is happening."
+    },
+    {
+      "key": "unknown-equals-empty",
+      "description": "The guidance must not approve treating unknown raw config values as equivalent to empty configuration during `CustomizeDiff` validation."
+    }
+  ],
+  "expectedTools": {},
+  "outputChecks": {
+    "mustHaveSections": [
+      "plan",
+      "schema + CRUD mapping decisions",
+      "minimal set of code changes needed",
+      "How you validated"
+    ],
+    "mustIncludeMarkers": [
+      "IMPL-SCHEMA-013",
+      "IsKnown()",
+      "Skill used: resource-implementation"
+    ]
+  },
+  "notes": "Use this as the adjudicated implementation-guidance case for raw `cty.Value` traversal in `CustomizeDiff` so the `IsKnown()` guard requirement stays benchmarked explicitly."
+}

--- a/tools/regression/examples/skill-resource-implementation-customizediff-isknown-guard.result.json
+++ b/tools/regression/examples/skill-resource-implementation-customizediff-isknown-guard.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "skill-resource-implementation-customizediff-isknown-guard",
+  "runId": "sample-impl-customizediff-isknown-001",
+  "timestampUtc": "2026-06-10T00:00:00Z",
+  "task": "resource-implementation",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "isknown-before-shape-inspection",
+      "defer-unknown-validation",
+      "presence-detection-note-stays-narrow"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 3,
+    "total": 3
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {},
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the raw cty CustomizeDiff IsKnown guard implementation-guidance case."
+}

--- a/tools/regression/fixtures/skill-resource-implementation-customizediff-isknown-guard/README.md
+++ b/tools/regression/fixtures/skill-resource-implementation-customizediff-isknown-guard/README.md
@@ -1,0 +1,49 @@
+# Sanitized Fixture: Resource Implementation CustomizeDiff IsKnown Guard
+
+This fixture is synthetic and is intentionally validating a local toolkit implementation-guidance rule.
+
+## Scenario
+
+A maintainer or contributor is adding `CustomizeDiff` validation under `internal/services/example/`.
+
+The code reads nested raw config from `GetRawConfig()` and walks into a `conditions` block using `LengthInt()` and `AsValueSlice()` directly. The contributor asks for implementation guidance on whether this is a safe pattern.
+
+The historical failure mode is that generic `GetRawConfig()` guidance stops at configured-versus-unknown values and does not require `IsKnown()` before raw `cty.Value` shape inspection, or it broadens the fix into generic `IsKnown()` advice instead of keeping it specific to diff-time raw traversal.
+
+## Simplified Code Shape
+
+```go
+rawConfig := diff.GetRawConfig()
+conditions := rawConfig.GetAttr("conditions")
+
+if conditions.IsNull() || conditions.LengthInt() == 0 {
+    return nil
+}
+
+condition := conditions.AsValueSlice()[0].AsValueMap()
+matchValues := condition["match_values"]
+if matchValues.LengthInt() == 0 {
+    return nil
+}
+```
+
+## Expected Guidance
+
+A correct `resource-implementation` response should:
+
+- anchor on `IMPL-SCHEMA-013` as the authoritative rule
+- require `IsKnown()` before `LengthInt()`, `AsValueSlice()`, `AsValueMap()`, `Index()`, or similar raw `cty.Value` shape-inspection methods in `CustomizeDiff`
+- say unknown values should defer validation and return `nil` instead of being treated as empty or allowed to panic
+- keep any `AsValueMap()` discussion narrow to top-level field-presence detection when the top-level raw config value is already known and non-null
+- include `Skill used: resource-implementation` in the final response marker
+
+## Expected Must-Catch Outcomes
+
+- `isknown-before-shape-inspection`
+- `defer-unknown-validation`
+- `presence-detection-note-stays-narrow`
+
+## Expected Must-Not-Flag Outcomes
+
+- `generic-isknown-everywhere`
+- `unknown-equals-empty`


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

This PR tightens the implementation guidance for `CustomizeDiff` when code traverses raw `cty.Value` data from `GetRawConfig()`.

The main change is to make `IMPL-SCHEMA-013` explicitly require `IsKnown()` before diff-time shape inspection such as `LengthInt()`, `AsValueSlice()`, `AsValueMap()`, or `Index()`, and to defer validation for unknown values instead of treating them as empty or allowing shape inspection to panic.

The companion guidance was then aligned to that contract rule so examples no longer send mixed signals. In particular, the Azure-specific `CustomizeDiff` examples now distinguish between:
- raw nested `cty.Value` traversal, which must use `IsKnown()` guards first
- top-level raw-config field-presence detection, which is only shown when the top-level raw config value is already known and non-null

This PR also adds an adjudicated `resource-implementation` regression case so the `IsKnown()` requirement is benchmarked directly in the implementation-guidance corpus.

## Summary

- add an authoritative `IMPL-SCHEMA-013` rule for `IsKnown()` before raw `cty.Value` shape inspection in `CustomizeDiff`
- align companion `CustomizeDiff` examples and notes with that rule
- add adjudicated regression coverage for the new implementation-guidance requirement
- update `CHANGELOG.md` for both the guidance change and the new regression case

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [ ] Installer
- [ ] Bash
- [ ] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [x] AI instructions (`.github/instructions/`)
- [x] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

N/A

## Testing / Validation

- [x] Validated behavior locally

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [ ] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github_actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.