### PR TITLE
[ENHANCEMENT:] Add review-advocate regression coverage and align maintainer docs

### DIFF
--- a/.github/workflows/RELEASING.md
+++ b/.github/workflows/RELEASING.md
@@ -45,8 +45,16 @@ Recommended pre-PR maintainer smoke:
 
 - run a bootstrap install from the working tree so the user-profile installer is refreshed from the branch
 - confirm the branch still installs correctly through the bootstrap path
+- build a release-shaped installer bundle locally with `tools/build-release-bundle_dry_run.ps1`
+- run one install smoke from that dry-run bundle before cutting any public release
 
-This bootstrap check is the right pre-release install smoke because the release bundle does not exist yet.
+The bootstrap check confirms the contributor path, while the dry-run release bundle confirms the release-artifact path without publishing anything publicly.
+
+Example dry-run bundle command:
+
+```powershell
+pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 9.9.9 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
+```
 
 ### 3. Open and merge the release PR to `main`
 
@@ -187,19 +195,22 @@ The release tag is also the source of truth for installer bundle version stampin
 
 ## Testing a Release
 
-Before creating an official release, you can test locally:
+Before creating an official release, build and test a local release-shaped bundle first:
 
-```bash
-# Create a test tag
-git tag -a v0.0.1-test -m "Test release"
-
-# Push to test the workflow
-git push origin v0.0.1-test
-
-# Delete test release and tag after verification
-git push --delete origin v0.0.1-test
-git tag -d v0.0.1-test
+```powershell
+pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 9.9.9 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
 ```
+
+That dry run:
+
+- stages the same installer layout as the release workflow
+- stamps `VERSION`, `commit`, and `aii.checksum`
+- verifies the staged bundle checksum
+- creates the same ZIP and TAR.GZ installer archives without publishing them
+
+After the dry run succeeds, run one installer smoke from the staged bundle against a local `terraform-provider-azurerm` checkout.
+
+Use a throwaway test tag only if you specifically need to validate the GitHub release workflow itself rather than the bundle contents.
 
 ## Troubleshooting
 
@@ -231,8 +242,9 @@ After creating a release:
 
 Important distinction:
 
-- the bootstrap install is the pre-release maintainer smoke because it can be run from the branch before a release exists
-- the release-bundle install smoke is a post-release verification step because it depends on the published artifact
+- the bootstrap install is still the pre-release maintainer smoke for the contributor path
+- the dry-run release bundle is the pre-release maintainer smoke for the release-artifact path
+- the published release-bundle install smoke remains a post-release verification step against the real public artifact
 
 ## Rollback Process
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,10 @@ jobs:
           overall_hash="$(hash_file "${tmp_file}")"
 
           version="$(cat "${installer_root}/VERSION" | tr -d '\r\n')"
+          commit="$(printf "%s" "${GITHUB_SHA}" | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
           timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-          printf "version=%s\ntimestamp=%s\nhash=%s\n" "${version}" "${timestamp}" "${overall_hash}" > "${checksum_file}"
+          printf "version=%s\ntimestamp=%s\nhash=%s\ncommit=%s\n" "${version}" "${timestamp}" "${overall_hash}" "${commit}" > "${checksum_file}"
 
           rm -f "${tmp_file}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Maintainer/Workflow:**
   - **[Internal]** - Added the `review-advocate` runtime skill and its dedicated `review-advocate-compliance-contract.instructions.md` contract (`REVIEW-ADV-*` rules) so the advocate second-pass method and its deterministic `Confirmed`/`Downgraded`/`Dismissed` outcome mapping live in the skill-plus-contract structure rather than a side instruction file, and shipped both in the installer payload.
   - **[Internal]** - Added adjudicated local-review regression cases for the `review-advocate` skip path and dismissed-versus-downgraded outcome mapping, so the advocate second-pass behavior is now benchmarked through the generic review prompts without adding a new direct harness task type.
+  - **[Internal]** - Added `tools/build-release-bundle_dry_run.ps1` and updated maintainer release guidance to run that dry-run bundle before a public release, so maintainers can stage and verify a release-shaped installer bundle locally, including stamped version, commit, checksum, and archives, without publishing a public GitHub release.
 
 ### Changed
+
+- **User-Priority:**
+  - **[Installer]** - Installer summaries now show a composite manifest-and-build fingerprint instead of only the manifest short hash, including a `-DIRTY` suffix for dirty bootstrap-built installer copies, so end users can see which source commit produced an installed toolkit bundle even when `file-manifest.config` itself stays unchanged between builds.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Maintainer/Workflow:**
   - **[Internal]** - Added the `review-advocate` runtime skill and its dedicated `review-advocate-compliance-contract.instructions.md` contract (`REVIEW-ADV-*` rules) so the advocate second-pass method and its deterministic `Confirmed`/`Downgraded`/`Dismissed` outcome mapping live in the skill-plus-contract structure rather than a side instruction file, and shipped both in the installer payload.
+  - **[Internal]** - Added adjudicated local-review regression cases for the `review-advocate` skip path and dismissed-versus-downgraded outcome mapping, so the advocate second-pass behavior is now benchmarked through the generic review prompts without adding a new direct harness task type.
 
 ### Changed
 
 ### Fixed
+
+- **Maintainer/Workflow:**
+  - **[Internal]** - Fixed regression-suite validation to pass selected case and example-result paths cleanly into `validate-regression-artifacts.ps1`, so the top-level regression harness and one-shot maintainer validator no longer fail while scoring the full adjudicated corpus.
 
 ## [3.4.3] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ tar -xzf /tmp/terraform-azurerm-ai-installer.tar.gz -C ~/.terraform-azurerm-ai-i
 ### What the Installer Does
 
 - 🔧 **Installs AI instruction files** to your target repository's `.github/` directory
-- 🔧 **Installs Agent Skills** to your target repository's `.github/skills/` directory (invocable via slash commands like `/docs-writer`)
+- 🔧 **Installs Agent Skills** to your target repository's `.github/skills/` directory (invocable via slash commands like `/docs-writer` and `/review-advocate`)
 - 🔧 **Configures workspace settings** in `.vscode/settings.json` for AI assistance
 - 🔧 **Works per-repository** - each repo gets its own AI infrastructure
 - 🔧 **Non-invasive** - doesn't modify your personal VS Code settings
@@ -261,6 +261,13 @@ AI Chat: "Create a new Azure CDN Front Door Profile resource using typed impleme
 ```
 /code-review-committed-changes
 ```
+
+### Run The Advocate Second Pass Directly
+```
+/review-advocate
+```
+
+Use this when you already have candidate Issues and want the dedicated second-pass advocate skill to challenge them, defend intentional design, and apply the deterministic `Confirmed` / `Downgraded` / `Dismissed` outcome mapping.
 
 Both generic review prompts now report the count of vendored files under `vendor/**` when they are in scope, but treat them as skipped non-actionable files rather than asking contributors to edit vendored third-party content directly.
 
@@ -401,7 +408,7 @@ As you type, Copilot suggests:
 ### 🎓 Instruction Files (Comprehensive Guidelines)
 
 | File | Purpose |
-|------|---------|
+| ---- | ------- |
 | **implementation-guide** | Complete Go implementation patterns for typed and untyped resources |
 | **azure-patterns** | Azure-specific PATCH operations, CustomizeDiff patterns |
 | **testing-guidelines** | Test execution protocols and acceptance testing patterns |

--- a/docs/AI_CUSTOMIZATION_ARCHITECTURE_STANDARD.md
+++ b/docs/AI_CUSTOMIZATION_ARCHITECTURE_STANDARD.md
@@ -268,6 +268,7 @@ Near-term target state:
 - `.github/skills/custom-poller-migration/SKILL.md`
 - `.github/skills/acceptance-testing/SKILL.md`
 - `.github/skills/docs-writer/SKILL.md`
+- `.github/skills/review-advocate/SKILL.md`
 
 Current classification:
 

--- a/docs/AI_CUSTOMIZATION_MIGRATION_INVENTORY.md
+++ b/docs/AI_CUSTOMIZATION_MIGRATION_INVENTORY.md
@@ -67,6 +67,7 @@ Current runtime skills already map well to the desired architecture:
 | `.github/skills/custom-poller-migration/SKILL.md` | Strong fit for a narrow specialized migration workflow | Keep as a focused specialist skill |
 | `.github/skills/acceptance-testing/SKILL.md` | Strong fit for test workflow behavior | Absorb more execution procedure content from `testing-guidelines` |
 | `.github/skills/docs-writer/SKILL.md` | Strong fit for docs authoring and review workflow | Absorb more procedural content from `documentation-guidelines` and docs review supporting text |
+| `.github/skills/review-advocate/SKILL.md` | Strong fit for reusable second-pass review challenge workflow | Keep advocate behavior behind the generic review prompts while the dedicated advocate contract owns deterministic outcome mapping |
 
 Skill conclusion:
 

--- a/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
+++ b/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
@@ -59,6 +59,7 @@ The current contract-driven domains are:
 - `.github/instructions/code-review-compliance-contract.instructions.md`
 - `.github/instructions/docs-compliance-contract.instructions.md`
 - `.github/instructions/implementation-compliance-contract.instructions.md`
+- `.github/instructions/review-advocate-compliance-contract.instructions.md`
 - `.github/instructions/testing-compliance-contract.instructions.md`
 
 ## Current High-Signal Implementation Rule

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@
 │  │  │   └── website/docs/                                   │  │ │
 │  │  │                                                       │  │ │
 │  │  │   ┌────────────────────────────────────────────────┐  │  │ │
-│  │  │   │   AI Infrustructure file install locations     │  │  │ │
+│  │  │   │   AI Infrastructure file install locations     │  │  │ │
 │  │  │   │                                                │  │  │ │
 │  │  │   │  ├──.github/                                   │  │  │ │
 │  │  │   │  │  ├── copilot-instructions.md (Main)         │  │  │ │
@@ -33,14 +33,16 @@
 │  │  │   │  │  │   ├── acceptance-testing/SKILL.md        │  │  │ │
 │  │  │   │  │  │   ├── custom-poller-migration/SKILL.md   │  │  │ │
 │  │  │   │  │  │   ├── docs-writer/SKILL.md               │  │  │ │
-│  │  │   │  │  │   └── resource-implementation/SKILL.md   │  │  │ │
+│  │  │   │  │  │   ├── resource-implementation/SKILL.md   │  │  │ │
+│  │  │   │  │  │   └── review-advocate/SKILL.md           │  │  │ │
 │  │  │   │  │  └── instructions/                          │  │  │ │
 │  │  │   │  │      ├── code-review-compliance-contract... │  │  │ │
 │  │  │   │  │      ├── implementation-compliance-contr... │  │  │ │
 │  │  │   │  │      ├── docs-compliance-contract...        │  │  │ │
+│  │  │   │  │      ├── review-advocate-compliance...      │  │  │ │
 │  │  │   │  │      ├── testing-compliance-contract...     │  │  │ │
 │  │  │   │  │      ├── ai-skill-routing-*.instructions... │  │  │ │
-│  │  │   │  │      └── [20 runtime instruction files]     │  │  │ │
+│  │  │   │  │      └── [21 runtime instruction files]     │  │  │ │
 │  │  │   │  └── .vscode/settings.json                     │  │  │ │
 │  │  │   └────────────────────────────────────────────────┘  │  │ │
 │  │  └───────────────────────────────────────────────────────┘  │ │
@@ -113,14 +115,16 @@
 │  │   ├── code-review-compliance-contract.instructions.md    │
 │  │   ├── implementation-compliance-contract.instructions.md │
 │  │   ├── docs-compliance-contract.instructions.md           │
+│  │   ├── review-advocate-compliance-contract.instructions.md│
 │  │   ├── testing-compliance-contract.instructions.md        │
 │  │   ├── ai-skill-routing-*.instructions.md                 │
-│  │   └── [20 instruction files total]                       │
+│  │   └── [21 instruction files total]                       │
 │  ├── .github/skills/                                        │
 │  │   ├── acceptance-testing/SKILL.md                        │
 │  │   ├── custom-poller-migration/SKILL.md                   │
 │  │   ├── docs-writer/SKILL.md                               │
-│  │   └── resource-implementation/SKILL.md                   │
+│  │   ├── resource-implementation/SKILL.md                   │
+│  │   └── review-advocate/SKILL.md                           │
 │  └── .vscode/settings.json                                  │
 └────────────────────────────┬────────────────────────────────┘
                              │
@@ -242,7 +246,7 @@ instructions/*.instructions.md (Specialized - Applied by file pattern)
 ├── implementation/docs/testing companion guides
 │   └── Examples, heuristics, and companion patterns
 │
-└── [20 runtime instruction files in total]
+└── [21 runtime instruction files in total]
     │
     ▼
 skills/*/SKILL.md (On-demand - Applied when invoked via /<skill>)
@@ -251,7 +255,8 @@ skills/*/SKILL.md (On-demand - Applied when invoked via /<skill>)
 │   ├── acceptance-testing
 │   ├── custom-poller-migration
 │   ├── docs-writer
-│   └── resource-implementation
+│   ├── resource-implementation
+│   └── review-advocate
 │
 └── Repo-only maintainer skills in this repository
   ├── ai-toolkit-maintenance
@@ -311,6 +316,7 @@ terraform-azurerm-ai-assisted-development/
 │   │   ├── migration-guide.instructions.md
 │   │   ├── performance-optimization.instructions.md
 │   │   ├── provider-guidelines.instructions.md
+│   │   ├── review-advocate-compliance-contract.instructions.md
 │   │   ├── schema-patterns.instructions.md
 │   │   ├── security-compliance.instructions.md
 │   │   ├── testing-compliance-contract.instructions.md
@@ -332,8 +338,9 @@ terraform-azurerm-ai-assisted-development/
 │   │   ├── ai-toolkit-maintenance/SKILL.md
 │   │   ├── changelog-maintenance/SKILL.md
 │   │   ├── custom-poller-migration/SKILL.md
+│   │   ├── docs-writer/SKILL.md
 │   │   ├── resource-implementation/SKILL.md
-│   │   └── docs-writer/SKILL.md
+│   │   └── review-advocate/SKILL.md
 │   │
 │   ├── workflows/
 │   │   ├── contracts-validation.yml
@@ -415,7 +422,7 @@ terraform-azurerm-ai-assisted-development/
 The repository contains both shipped runtime guidance and repo-only maintainer tooling.
 
 - Runtime payload is defined by `installer/file-manifest.config` and installed into target repositories.
-- Runtime payload currently includes `.github/copilot-instructions.md`, `.github/instructions/**`, `.github/prompts/**`, four shipped runtime skills under `.github/skills/`, and `.vscode/settings.json`.
+- Runtime payload currently includes `.github/copilot-instructions.md`, `.github/instructions/**`, `.github/prompts/**`, five shipped runtime skills under `.github/skills/`, and `.vscode/settings.json`.
 - Repo-only maintenance surfaces stay in this repository and are not installed into target repos.
 - Repo-only surfaces include maintainer skills such as `ai-toolkit-maintenance` and `changelog-maintenance`, the `docs/` architecture and alignment references, and the validation and regression tooling under `tools/`.
 
@@ -442,6 +449,7 @@ Docs components (quick links):
 - `/code-review-local-changes`: reviews local workspace changes and uses local-diff linting.
 - `/code-review-committed-changes`: reviews committed branch changes against `origin/main`, prefers authoritative PR scope when available, and uses PR-scoped linting. When PR context is not already available, users can pass a PR number explicitly, for example `/code-review-committed-changes PR 12345`.
 - `/code-review-docs`: deterministic docs review for `website/docs/**` pages (enforces `hcl` code fences in Terraform examples, self-contained resource examples, existing-object lookup data source examples, list-resource query examples, ephemeral-resource doc shape, function doc shape, import example ID shape validation, and human-readable timeout defaults).
+- `/review-advocate`: slash-invokable runtime skill, not a prompt file. The generic code review prompts invoke it as the second-pass advocate quality gate when candidate Issues exist.
 - Rule citations such as `REVIEW-SCOPE-005` and `DOCS-EX-003` are explained in `docs/CODE_REVIEW_RULES.md`.
 
 ### Docs governance (contract, prompt, skill)

--- a/docs/CODE_REVIEW_RULES.md
+++ b/docs/CODE_REVIEW_RULES.md
@@ -19,9 +19,10 @@ The IDs are there to make the review explainable and deterministic. They are ref
 
 ## Where The Rules Live
 
-There are four main contract files:
+There are five main contract files:
 
 - Generic code review contract: `.github/instructions/code-review-compliance-contract.instructions.md`
+- Advocate second-pass contract: `.github/instructions/review-advocate-compliance-contract.instructions.md`
 - Docs review contract: `.github/instructions/docs-compliance-contract.instructions.md`
 - Implementation contract: `.github/instructions/implementation-compliance-contract.instructions.md`
 - Testing contract: `.github/instructions/testing-compliance-contract.instructions.md`
@@ -30,10 +31,14 @@ The prompts, skills, and routing instructions consume those contracts:
 
 - `/code-review-local-changes`
 - `/code-review-committed-changes`
+- `/review-advocate`
 - `/code-review-docs`
 - `/docs-writer`
 - `/resource-implementation`
 - `/acceptance-testing`
+
+The `review-advocate` skill is the dedicated advocate second-pass quality gate.
+The generic code review prompts invoke it when candidate Issues exist, while the dedicated advocate contract owns the deterministic `REVIEW-ADV-*` rules that govern `Confirmed`, `Downgraded`, and `Dismissed` outcomes.
 
 The important architectural point is that these contract files are now the normative rule sources.
 
@@ -172,6 +177,22 @@ These rules explain how `azurerm-linter` should be handled. If you see a `REVIEW
 
 The contract-first model matters here too: the linter execution policy, status mapping, and output-shape requirements now live in the shared review contract, while troubleshooting and companion docs explain the runtime behavior and known failure modes around those rules.
 
+## `REVIEW-ADV-*` Rule Area
+
+These IDs come from `.github/instructions/review-advocate-compliance-contract.instructions.md` and are consumed by `/review-advocate`, which the generic code review prompts invoke as the second-pass advocate quality gate when candidate Issues exist.
+
+| Prefix | Meaning | What it usually tells the user |
+| ------ | ------- | ------------------------------ |
+| `REVIEW-ADV-*` | Advocate second-pass evaluation | How candidate Issues are challenged, confirmed, downgraded, or dismissed before review output is frozen |
+
+In practice, `REVIEW-ADV-*` rules explain things such as:
+
+- when the advocate pass is allowed to run
+- what counts as a valid defense
+- how trust-boundary defenses must be justified
+- why a finding stayed in `ISSUES` at lower severity versus moving to `OBSERVATIONS`
+- why a dismissed finding carries a `[⚖️ ADVOCATE: ...]` annotation instead of disappearing entirely
+
 ## `DOCS-*` Rule Areas
 
 These IDs come from `.github/instructions/docs-compliance-contract.instructions.md` and are primarily used by `/code-review-docs` and `/docs-writer` for `website/docs/**/*.html.markdown` pages.
@@ -242,6 +263,7 @@ This reference is most useful when:
 ## Short Version
 
 - `REVIEW-*` IDs are generic code review contract rules.
+- `REVIEW-ADV-*` IDs are advocate second-pass contract rules consumed by `/review-advocate`.
 - `DOCS-*` IDs are documentation review contract rules.
 - `IMPL-*` IDs are Go implementation contract rules.
 - `TEST-*` IDs are acceptance-testing contract rules.

--- a/installer/modules/bash/fileoperations.sh
+++ b/installer/modules/bash/fileoperations.sh
@@ -728,13 +728,36 @@ show_installation_summary() {
     local manifest_value="${INSTALLER_MANIFEST_FILE:-}"
     if [[ -n "${manifest_value}" ]]; then
         local manifest_hash=""
+        local build_commit=""
+        local build_dirty="false"
         if command -v sha256sum >/dev/null 2>&1; then
             manifest_hash=$(sha256sum "${manifest_value}" 2>/dev/null | awk '{print $1}')
         elif command -v shasum >/dev/null 2>&1; then
             manifest_hash=$(shasum -a 256 "${manifest_value}" 2>/dev/null | awk '{print $1}')
         fi
+        local checksum_file="$(dirname "${manifest_value}")/aii.checksum"
+        if [[ -f "${checksum_file}" ]]; then
+            build_commit="$(grep '^commit=' "${checksum_file}" | head -n 1 | cut -d= -f2- | tr -d '\r\n')"
+            local bundle_version
+            bundle_version="$(grep '^version=' "${checksum_file}" | head -n 1 | cut -d= -f2- | tr -d '\r\n')"
+            if [[ "${bundle_version}" == *-dirty ]]; then
+                build_dirty="true"
+            fi
+        fi
         if [[ -n "${manifest_hash}" ]]; then
-            manifest_value="${manifest_value} (${manifest_hash:0:8})"
+            local manifest_fingerprint="${manifest_hash:0:8}"
+            local manifest_fingerprint_upper="$(printf '%s' "${manifest_fingerprint}" | tr '[:lower:]' '[:upper:]')"
+            if [[ -n "${build_commit}" ]]; then
+                local build_fingerprint="${build_commit:0:8}"
+                local build_fingerprint_upper="$(printf '%s' "${build_fingerprint}" | tr '[:lower:]' '[:upper:]')"
+                local manifest_composite="${manifest_fingerprint_upper}-${build_fingerprint_upper}"
+                if [[ "${build_dirty}" == "true" ]]; then
+                    manifest_composite="${manifest_composite}-DIRTY"
+                fi
+                manifest_value="${manifest_value} (${manifest_composite})"
+            else
+                manifest_value="${manifest_value} (${manifest_fingerprint_upper})"
+            fi
         fi
     fi
 
@@ -1232,7 +1255,7 @@ bootstrap_files_to_profile() {
     fi
     echo "${bootstrap_version}" > "${user_profile}/VERSION"
 
-    if ! write_installer_checksum "${user_profile}"; then
+    if ! write_installer_checksum "${user_profile}" "${sha:-}"; then
         write_error_message "Failed to generate installer checksum"
         return 1
     fi

--- a/installer/modules/bash/validationengine.sh
+++ b/installer/modules/bash/validationengine.sh
@@ -693,6 +693,7 @@ prune_stale_installer_payload() {
 
 write_installer_checksum() {
     local installer_root="$1"
+    local commit="${2:-}"
     local checksum_file="${installer_root}/aii.checksum"
 
     prune_stale_installer_payload "${installer_root}" || return 1
@@ -702,6 +703,10 @@ write_installer_checksum() {
         version="$(tr -d '\r\n' < "${installer_root}/VERSION")"
     fi
 
+    if [[ -z "${commit}" && "${version}" =~ ^dev-([0-9a-f]{7,40})(-dirty)?$ ]]; then
+        commit="${BASH_REMATCH[1]}"
+    fi
+
     local timestamp
     timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
@@ -709,6 +714,9 @@ write_installer_checksum() {
     overall_hash="$(compute_installer_checksum "${installer_root}")" || return 1
 
     printf "version=%s\ntimestamp=%s\nhash=%s\n" "${version}" "${timestamp}" "${overall_hash}" > "${checksum_file}"
+    if [[ -n "${commit}" ]]; then
+        printf "commit=%s\n" "${commit}" >> "${checksum_file}"
+    fi
 }
 
 verify_installer_checksum() {

--- a/installer/modules/powershell/FileOperations.psm1
+++ b/installer/modules/powershell/FileOperations.psm1
@@ -1114,9 +1114,11 @@ function Invoke-Bootstrap {
         }
 
         $bootstrapVersion = "dev"
+        $bootstrapCommit = $null
         try {
             $sha = (git -C $Global:WorkspaceRoot rev-parse --short HEAD 2>$null).Trim()
             if ($sha) {
+                $bootstrapCommit = $sha.ToLowerInvariant()
                 $bootstrapVersion = "dev-$sha"
             }
             $dirty = git -C $Global:WorkspaceRoot status --porcelain 2>$null
@@ -1134,7 +1136,7 @@ function Invoke-Bootstrap {
         catch {
         }
 
-        $checksumResult = Write-InstallerChecksum -InstallerRoot $targetDirectory -Version $bootstrapVersion
+        $checksumResult = Write-InstallerChecksum -InstallerRoot $targetDirectory -Version $bootstrapVersion -Commit $bootstrapCommit
         if (-not $checksumResult.Valid) {
             $details = @(
                 "Checksum error: $($checksumResult.Reason)"
@@ -1372,7 +1374,31 @@ function Invoke-InstallInfrastructure {
 
             $manifestValue = $Global:InstallerManifestPath
             if ($manifestValue -and $Global:InstallerManifestHash) {
-                $manifestValue = "$manifestValue ($($Global:InstallerManifestHash.Substring(0,8)))"
+                $manifestFingerprint = $Global:InstallerManifestHash.Substring(0,8)
+                $buildFingerprint = $null
+                $buildSuffix = $null
+
+                $installerRoot = Split-Path $Global:InstallerManifestPath -Parent
+                if ($installerRoot -and (Test-Path $installerRoot)) {
+                    $bundleChecksum = Test-InstallerChecksum -InstallerRoot $installerRoot
+                    if ($bundleChecksum.Valid -and $bundleChecksum.Commit) {
+                        $buildFingerprint = $bundleChecksum.Commit.Substring(0, [Math]::Min(8, $bundleChecksum.Commit.Length)).ToUpperInvariant()
+                        if ($bundleChecksum.Dirty) {
+                            $buildSuffix = 'DIRTY'
+                        }
+                    }
+                }
+
+                if ($buildFingerprint) {
+                    $manifestComposite = "$($manifestFingerprint.ToUpperInvariant())-$buildFingerprint"
+                    if ($buildSuffix) {
+                        $manifestComposite = "$manifestComposite-$buildSuffix"
+                    }
+                    $manifestValue = "$manifestValue ($manifestComposite)"
+                }
+                else {
+                    $manifestValue = "$manifestValue ($($manifestFingerprint.ToUpperInvariant()))"
+                }
             }
             if ($manifestValue) {
                 $details["Manifest"] = $manifestValue

--- a/installer/modules/powershell/ValidationEngine.psm1
+++ b/installer/modules/powershell/ValidationEngine.psm1
@@ -698,7 +698,9 @@ function Write-InstallerChecksum {
         [Parameter(Mandatory)]
         [string]$InstallerRoot,
 
-        [string]$Version
+        [string]$Version,
+
+        [string]$Commit
     )
 
     $checksumPath = Join-Path $InstallerRoot "aii.checksum"
@@ -723,14 +725,24 @@ function Write-InstallerChecksum {
         $Version = "dev"
     }
 
+    if (-not $Commit -and $Version -match '^dev-([0-9a-f]{7,40})(?:-dirty)?$') {
+        $Commit = $matches[1].ToLowerInvariant()
+    }
+
     $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-    @(
+    $checksumLines = @(
         "version=$Version",
         "timestamp=$timestamp",
         "hash=$($result.Hash)"
-    ) | Set-Content -Path $checksumPath
+    )
 
-    return @{ Valid = $true; Hash = $result.Hash; Path = $checksumPath }
+    if ($Commit) {
+        $checksumLines += "commit=$($Commit.ToLowerInvariant())"
+    }
+
+    $checksumLines | Set-Content -Path $checksumPath
+
+    return @{ Valid = $true; Hash = $result.Hash; Path = $checksumPath; Commit = $Commit }
 }
 
 function Test-InstallerChecksum {
@@ -744,9 +756,33 @@ function Test-InstallerChecksum {
         return @{ Valid = $false; Reason = "Installer checksum file not found" }
     }
 
-    $hashLine = Get-Content -Path $checksumPath | Where-Object { $_ -match '^hash=' } | Select-Object -First 1
+    $checksumLines = Get-Content -Path $checksumPath
+
+    $hashLine = $checksumLines | Where-Object { $_ -match '^hash=' } | Select-Object -First 1
     if (-not $hashLine) {
         return @{ Valid = $false; Reason = "Installer checksum file missing hash" }
+    }
+
+    $versionLine = $checksumLines | Where-Object { $_ -match '^version=' } | Select-Object -First 1
+    $version = $null
+    $dirty = $false
+    if ($versionLine) {
+        $version = $versionLine.Substring(8).Trim()
+        if (-not $version) {
+            $version = $null
+        }
+        elseif ($version -match '-dirty$') {
+            $dirty = $true
+        }
+    }
+
+    $commitLine = $checksumLines | Where-Object { $_ -match '^commit=' } | Select-Object -First 1
+    $commit = $null
+    if ($commitLine) {
+        $commit = $commitLine.Substring(7).Trim().ToLowerInvariant()
+        if (-not $commit) {
+            $commit = $null
+        }
     }
 
     $expected = $hashLine.Substring(5).Trim()
@@ -771,7 +807,7 @@ function Test-InstallerChecksum {
         return @{ Valid = $false; Reason = "Installer checksum mismatch"; Expected = $expected; Actual = $computed.Hash }
     }
 
-    return @{ Valid = $true; Hash = $computed.Hash }
+    return @{ Valid = $true; Hash = $computed.Hash; Commit = $commit; Version = $version; Dirty = $dirty }
 }
 
 function Test-PreInstallation {

--- a/tools/build-release-bundle_dry_run.ps1
+++ b/tools/build-release-bundle_dry_run.ps1
@@ -1,0 +1,241 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$Commit,
+
+    [string]$OutputRoot,
+
+    [switch]$SkipArchive,
+
+    [switch]$SkipVerifyChecksum,
+
+    [switch]$SkipWsl,
+
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Copy-ItemSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$Destination
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Required path not found: $Path"
+    }
+
+    $parent = Split-Path -Parent $Destination
+    if ($parent) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    Copy-Item -Path $Path -Destination $Destination -Recurse -Force
+}
+
+function Copy-DirectoryContentsSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$DestinationDirectory
+    )
+
+    if (-not (Test-Path $SourceDirectory)) {
+        throw "Required path not found: $SourceDirectory"
+    }
+
+    New-Item -ItemType Directory -Path $DestinationDirectory -Force | Out-Null
+
+    Get-ChildItem -Path $SourceDirectory -Force | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination (Join-Path $DestinationDirectory $_.Name) -Recurse -Force
+    }
+}
+
+function Get-ManifestSectionEntries {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ManifestPath,
+
+        [Parameter(Mandatory)]
+        [string[]]$Sections
+    )
+
+    $entries = [System.Collections.Generic.List[string]]::new()
+    $currentSection = ''
+
+    foreach ($line in Get-Content -Path $ManifestPath) {
+        $trimmed = $line.Trim()
+        if ($trimmed -match '^\[(.+)\]$') {
+            $currentSection = $matches[1]
+            continue
+        }
+
+        if (-not $trimmed -or $trimmed.StartsWith('#')) {
+            continue
+        }
+
+        if ($currentSection -in $Sections) {
+            $entries.Add($trimmed)
+        }
+    }
+
+    return @($entries | Select-Object -Unique)
+}
+
+function Resolve-ShortCommit {
+    param([string]$RepoRoot)
+
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($null -eq $git) {
+        throw 'git is required to resolve the default commit for the dry-run bundle'
+    }
+
+    $sha = @(& $git.Source -C $RepoRoot rev-parse --short HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'failed to resolve git commit from the current repository'
+    }
+
+    $resolved = ($sha | Select-Object -First 1).Trim().ToLowerInvariant()
+    if (-not $resolved) {
+        throw 'resolved git commit was empty'
+    }
+
+    return $resolved
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$installerSourceRoot = Join-Path $repoRoot 'installer'
+$manifestPath = Join-Path $installerSourceRoot 'file-manifest.config'
+$verifyScriptPath = Join-Path $PSScriptRoot 'verify-bundle-checksum.ps1'
+$validationModulePath = Join-Path $installerSourceRoot 'modules/powershell/ValidationEngine.psm1'
+
+if (-not $Commit) {
+    $Commit = Resolve-ShortCommit -RepoRoot $repoRoot
+}
+
+$Commit = $Commit.Trim().ToLowerInvariant()
+if ($Commit -notmatch '^[0-9a-f]{7,40}$') {
+    throw 'commit must be a 7-40 character hexadecimal git sha'
+}
+
+if (-not $OutputRoot) {
+    $OutputRoot = Join-Path $repoRoot 'release-dry-run'
+}
+
+$stageName = ('v{0}-{1}' -f $Version, $Commit) -replace '[^0-9A-Za-z._-]', '_'
+$stageRoot = Join-Path $OutputRoot $stageName
+$installerRoot = Join-Path $stageRoot '.terraform-azurerm-ai-installer'
+
+if (Test-Path $stageRoot) {
+    if (-not $Force) {
+        throw "dry-run output already exists: $stageRoot`nUse -Force to replace it."
+    }
+
+    Remove-Item -Path $stageRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $installerRoot -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $installerRoot 'modules/powershell') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $installerRoot 'modules/bash') -Force | Out-Null
+
+Copy-ItemSafe -Path (Join-Path $installerSourceRoot 'install-copilot-setup.ps1') -Destination (Join-Path $installerRoot 'install-copilot-setup.ps1')
+Copy-ItemSafe -Path (Join-Path $installerSourceRoot 'install-copilot-setup.sh') -Destination (Join-Path $installerRoot 'install-copilot-setup.sh')
+Copy-ItemSafe -Path $manifestPath -Destination (Join-Path $installerRoot 'file-manifest.config')
+Copy-DirectoryContentsSafe -SourceDirectory (Join-Path $installerSourceRoot 'modules/powershell') -DestinationDirectory (Join-Path $installerRoot 'modules/powershell')
+Copy-DirectoryContentsSafe -SourceDirectory (Join-Path $installerSourceRoot 'modules/bash') -DestinationDirectory (Join-Path $installerRoot 'modules/bash')
+Set-Content -Path (Join-Path $installerRoot 'VERSION') -Value $Version -NoNewline -Force
+
+$payloadRoot = Join-Path $installerRoot 'aii'
+New-Item -ItemType Directory -Path $payloadRoot -Force | Out-Null
+
+$manifestSections = @('MAIN_FILES', 'INSTRUCTION_FILES', 'PROMPT_FILES', 'SKILL_FILES', 'UNIVERSAL_FILES')
+$manifestEntries = Get-ManifestSectionEntries -ManifestPath $manifestPath -Sections $manifestSections
+foreach ($entry in $manifestEntries) {
+    $sourcePath = Join-Path $repoRoot $entry
+    $destinationPath = Join-Path $payloadRoot $entry
+    Copy-ItemSafe -Path $sourcePath -Destination $destinationPath
+}
+
+Import-Module $validationModulePath -Force | Out-Null
+$checksumResult = Write-InstallerChecksum -InstallerRoot $installerRoot -Version $Version -Commit $Commit
+if (-not $checksumResult.Valid) {
+    throw "failed to generate installer checksum: $($checksumResult.Reason)"
+}
+
+if (-not $SkipVerifyChecksum) {
+    & $verifyScriptPath -InstallerRoot $installerRoot -SkipWsl:$SkipWsl
+    if ($LASTEXITCODE -ne 0) {
+        throw 'installer bundle checksum verification failed'
+    }
+}
+
+Push-Location $stageRoot
+try {
+    $createdArtifacts = [System.Collections.Generic.List[string]]::new()
+
+    if (-not $SkipArchive) {
+        $versionedZip = Join-Path $stageRoot ("terraform-azurerm-ai-installer-v{0}.zip" -f $Version)
+        Compress-Archive -Path '.terraform-azurerm-ai-installer' -DestinationPath $versionedZip -Force
+        $createdArtifacts.Add($versionedZip)
+
+        $stableZip = Join-Path $stageRoot 'terraform-azurerm-ai-installer.zip'
+        Copy-Item -Path $versionedZip -Destination $stableZip -Force
+        $createdArtifacts.Add($stableZip)
+
+        $tarCommand = Get-Command tar -ErrorAction SilentlyContinue
+        if ($null -ne $tarCommand) {
+            $versionedTar = Join-Path $stageRoot ("terraform-azurerm-ai-installer-v{0}.tar.gz" -f $Version)
+            & $tarCommand.Source -czf $versionedTar '.terraform-azurerm-ai-installer'
+            if ($LASTEXITCODE -ne 0) {
+                throw 'failed to create tar.gz archive for dry-run bundle'
+            }
+            $createdArtifacts.Add($versionedTar)
+
+            $stableTar = Join-Path $stageRoot 'terraform-azurerm-ai-installer.tar.gz'
+            Copy-Item -Path $versionedTar -Destination $stableTar -Force
+            $createdArtifacts.Add($stableTar)
+        }
+        else {
+            Write-Host 'tar was not found; skipping tar.gz archive generation' -ForegroundColor Yellow
+        }
+
+        if ($createdArtifacts.Count -gt 0) {
+            $checksumsPath = Join-Path $stageRoot 'checksums.txt'
+            $checksums = foreach ($artifact in $createdArtifacts) {
+                $hash = (Get-FileHash -Path $artifact -Algorithm SHA256).Hash.ToLowerInvariant()
+                '{0}  {1}' -f $hash, (Split-Path -Leaf $artifact)
+            }
+            $checksums | Set-Content -Path $checksumsPath
+            $createdArtifacts.Add($checksumsPath)
+        }
+    }
+
+    Write-Host ''
+    Write-Host 'Dry-run release bundle created successfully' -ForegroundColor Green
+    Write-Host ('  Version        : {0}' -f $Version) -ForegroundColor Cyan
+    Write-Host ('  Commit         : {0}' -f $Commit.ToUpperInvariant()) -ForegroundColor Cyan
+    Write-Host ('  Installer Root : {0}' -f $installerRoot) -ForegroundColor Cyan
+    Write-Host ('  Output Root    : {0}' -f $stageRoot) -ForegroundColor Cyan
+    if (-not $SkipArchive) {
+        Write-Host '  Artifacts:' -ForegroundColor Cyan
+        Get-ChildItem -Path $stageRoot -File | Sort-Object Name | ForEach-Object {
+            Write-Host ('    - {0}' -f $_.FullName) -ForegroundColor White
+        }
+    }
+
+    Write-Host ''
+    Write-Host 'Next step:' -ForegroundColor Cyan
+    Write-Host ('  & "{0}" -RepoDirectory "<path-to-terraform-provider-azurerm>"' -f (Join-Path $installerRoot 'install-copilot-setup.ps1')) -ForegroundColor White
+}
+finally {
+    Pop-Location
+}

--- a/tools/regression/cases/review-local-advocate-dismissed-and-downgraded.json
+++ b/tools/regression/cases/review-local-advocate-dismissed-and-downgraded.json
@@ -1,0 +1,62 @@
+{
+  "id": "review-local-advocate-dismissed-and-downgraded",
+  "title": "Local review applies advocate outcomes for dismissed and downgraded findings",
+  "task": "code-review-local-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A sanitized local-review scenario where the primary review pass produces multiple candidate Issues and the advocate pass must resolve them deterministically: one false positive is dismissed into Observations with rationale, while one real but less severe problem remains in Issues at reduced severity.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-local-advocate-dismissed-and-downgraded/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      ".github/prompts/code-review-committed-changes.prompt.md",
+      ".github/instructions/review-advocate-compliance-contract.instructions.md"
+    ],
+    "notes": "Sanitized fixture models a prompt-orchestration update plus advocate-contract wording where the primary review pass can over-flag one design choice, but a second pass should dismiss that false positive while preserving a narrower wording-drift issue."
+  },
+  "expectedRules": [
+    "REVIEW-SCOPE-004",
+    "REVIEW-CLASS-006",
+    "REVIEW-ADV-005",
+    "REVIEW-ADV-007",
+    "REVIEW-ADV-009"
+  ],
+  "mustCatch": [
+    {
+      "key": "advocate-dismissed-finding-observation",
+      "severity": "observation",
+      "description": "A false-positive candidate finding should be dismissed into `OBSERVATIONS` with a `[⚖️ ADVOCATE: ...]` annotation rather than staying in `ISSUES` or disappearing entirely."
+    },
+    {
+      "key": "advocate-downgraded-finding-stays-in-issues",
+      "severity": "medium",
+      "description": "A real but less severe prompt-orchestration problem should stay in `ISSUES` at reduced severity after the advocate pass instead of moving into `OBSERVATIONS`."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "dismissed-finding-left-in-issues",
+      "description": "The dismissed false-positive finding must not remain in `ISSUES` after the advocate pass."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "not-applicable"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "DETAILED TECHNICAL REVIEW",
+      "OVERALL ASSESSMENT"
+    ],
+    "mustIncludeMarkers": [
+      "Preflight complete: yes",
+      "Skill used: review-advocate",
+      "[⚖️ ADVOCATE:"
+    ]
+  },
+  "notes": "Use this case to benchmark dismissed-versus-downgraded advocate outcomes through the generic local review prompt without adding a direct review-advocate task type."
+}

--- a/tools/regression/cases/review-local-advocate-skip-no-candidates.json
+++ b/tools/regression/cases/review-local-advocate-skip-no-candidates.json
@@ -1,0 +1,54 @@
+{
+  "id": "review-local-advocate-skip-no-candidates",
+  "title": "Local review skips advocate pass when no candidate Issues exist",
+  "task": "code-review-local-changes",
+  "caseStatus": "adjudicated",
+  "sourceKind": "synthetic",
+  "sanitized": true,
+  "description": "A sanitized local-review scenario where AI-toolkit files change, but the primary review pass should produce no candidate Issues. The advocate pass must not run and the final output must not include the review-advocate skill marker.",
+  "fixture": {
+    "mode": "files",
+    "path": "tools/regression/fixtures/review-local-advocate-skip-no-candidates/README.md"
+  },
+  "scope": {
+    "changedFiles": [
+      ".github/skills/review-advocate/SKILL.md",
+      ".github/instructions/review-advocate-compliance-contract.instructions.md"
+    ],
+    "notes": "Sanitized fixture models benign wording-alignment updates in the advocate skill and contract. The generic local review should stay issue-free, so Step 6 must not run."
+  },
+  "expectedRules": [
+    "REVIEW-SCOPE-004",
+    "REVIEW-CLASS-006",
+    "REVIEW-OUT-*"
+  ],
+  "mustCatch": [
+    {
+      "key": "advocate-skip-when-no-candidate-issues",
+      "severity": "medium",
+      "description": "When the primary review pass produces no candidate Issues, the final review should remain issue-free and must not invoke the advocate pass or emit the review-advocate verification marker."
+    }
+  ],
+  "mustNotFlag": [
+    {
+      "key": "spurious-review-advocate-marker",
+      "description": "The review must not emit `Skill used: review-advocate` when the primary pass produced no candidate Issues."
+    }
+  ],
+  "expectedTools": {
+    "azurermLinter": "not-applicable"
+  },
+  "outputChecks": {
+    "mustHaveSections": [
+      "CHANGE SUMMARY",
+      "FILES CHANGED",
+      "DETAILED TECHNICAL REVIEW",
+      "OVERALL ASSESSMENT"
+    ],
+    "mustNotIncludeMarkers": [
+      "Skill used: review-advocate",
+      "[⚖️ ADVOCATE:"
+    ]
+  },
+  "notes": "Use this case to benchmark the advocate skip path through the generic local review prompt without expanding the harness task model."
+}

--- a/tools/regression/examples/review-local-advocate-dismissed-and-downgraded.result.json
+++ b/tools/regression/examples/review-local-advocate-dismissed-and-downgraded.result.json
@@ -1,0 +1,44 @@
+{
+  "caseId": "review-local-advocate-dismissed-and-downgraded",
+  "runId": "sample-review-advocate-outcomes-001",
+  "timestampUtc": "2026-06-23T00:00:00Z",
+  "task": "code-review-local-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "advocate-dismissed-finding-observation",
+      "advocate-downgraded-finding-stays-in-issues"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 2,
+    "total": 2
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "not-applicable"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the local review advocate dismissed-versus-downgraded outcome regression case."
+}

--- a/tools/regression/examples/review-local-advocate-dismissed-and-downgraded.review.md
+++ b/tools/regression/examples/review-local-advocate-dismissed-and-downgraded.review.md
@@ -1,0 +1,62 @@
+# 📋 **Code Review**: local advocate pass resolves dismissed and downgraded findings
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 2 files (0 tracked new, 0 untracked, 2 modified, 0 deleted)
+- **Line Changes**: 14 insertions, 5 deletions (tracked files only)
+- **Branch**: fixture/local-review-advocate-outcomes
+- **Type**: unstaged local changes
+- **Scope**: updates committed-review prompt orchestration alongside the dedicated advocate contract
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `.github/prompts/code-review-committed-changes.prompt.md`
+- `.github/instructions/review-advocate-compliance-contract.instructions.md`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The change keeps the prompt wired to the dedicated advocate skill and contract, but one prompt sentence still overstates a verification requirement. A second apparent problem is not a real defect because the dedicated advocate contract intentionally owns that outcome behavior.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: AI-customization review scope applied for `.github/prompts/**` and `.github/instructions/**`
+- **Scope Rules**: `REVIEW-SCOPE-004` and `REVIEW-CLASS-006` were directly relevant because the change touched prompt orchestration and the dedicated advocate contract
+- **Docs Contract**: not applicable
+- **Notes**: the advocate pass ran because the primary review produced candidate Issues, so the final output must reflect deterministic post-advocate outcomes
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: n/a
+- **Summary**: no provider Go files are in scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The prompt continues to delegate advocate behavior to the dedicated skill and contract instead of re-embedding rule text locally.
+
+### 🟡 **OBSERVATIONS**
+- The change does not restate the dismissed-versus-downgraded outcome mapping locally in the prompt. `[⚖️ ADVOCATE: the dedicated advocate contract intentionally owns outcome mapping, so local restatement would reintroduce drift.]`
+
+### 🔴 **ISSUES**
+- The committed-review prompt wording still overstates the observable proof requirement by making the verification-footer behavior sound broader than the final output contract requires. That is a real issue, but it is narrower than a full behavior-break claim and should remain in `ISSUES` at reduced severity after the advocate pass.
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- Narrow the prompt wording so it describes the verification-footer requirement precisely without overstating the broader output contract.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve this regression case so future prompt or advocate-contract edits keep dismissed and downgraded findings in their correct final sections.
+
+## 🏆 **OVERALL ASSESSMENT**
+The advocate pass is wired correctly and the dismissed-versus-downgraded outcomes land in the right sections, but the remaining prompt wording issue should be corrected before merge.
+
+Preflight complete: yes
+Skill used: review-advocate

--- a/tools/regression/examples/review-local-advocate-skip-no-candidates.result.json
+++ b/tools/regression/examples/review-local-advocate-skip-no-candidates.result.json
@@ -1,0 +1,43 @@
+{
+  "caseId": "review-local-advocate-skip-no-candidates",
+  "runId": "sample-review-advocate-skip-001",
+  "timestampUtc": "2026-06-23T00:00:00Z",
+  "task": "code-review-local-changes",
+  "model": "sample",
+  "pass": true,
+  "overallScore": 100,
+  "scores": {
+    "mustCatchRecall": 100,
+    "falsePositiveControl": 100,
+    "severityCorrectness": 100,
+    "scopeAndToolCorrectness": 100,
+    "outputCompliance": 100,
+    "determinism": 100
+  },
+  "findings": {
+    "caught": [
+      "advocate-skip-when-no-candidate-issues"
+    ],
+    "missed": [],
+    "falsePositives": []
+  },
+  "severityChecks": {
+    "matched": 1,
+    "total": 1
+  },
+  "scopeChecks": {
+    "ruleFamiliesAppliedCorrectly": true,
+    "toolingBehaviorCorrect": true
+  },
+  "toolExecution": {
+    "azurermLinter": "not-applicable"
+  },
+  "outputChecks": {
+    "requiredSectionsPresent": true,
+    "requiredMarkersPresent": true
+  },
+  "determinismChecks": {
+    "materiallyEquivalentAcrossRuns": true
+  },
+  "notes": "Example adjudicated result for the local review advocate skip-path regression case."
+}

--- a/tools/regression/examples/review-local-advocate-skip-no-candidates.review.md
+++ b/tools/regression/examples/review-local-advocate-skip-no-candidates.review.md
@@ -1,0 +1,60 @@
+# 📋 **Code Review**: local AI-toolkit wording alignment with no candidate Issues
+
+## 🔄 **CHANGE SUMMARY**
+- **Files Changed**: 2 files (0 tracked new, 0 untracked, 2 modified, 0 deleted)
+- **Line Changes**: 10 insertions, 6 deletions (tracked files only)
+- **Branch**: fixture/local-review-advocate-skip
+- **Type**: unstaged local changes
+- **Scope**: aligns advocate skill and contract wording without changing prompt wiring or deterministic outcome behavior
+
+## 📁 **FILES CHANGED**
+
+**Modified Files:**
+- `.github/skills/review-advocate/SKILL.md`
+- `.github/instructions/review-advocate-compliance-contract.instructions.md`
+
+## 🎯 **PRIMARY CHANGES ANALYSIS**
+The change aligns wording between the dedicated advocate skill and the advocate contract, but it does not alter prompt orchestration, contract ownership boundaries, or the deterministic outcome mapping.
+
+## 📋 **DETAILED TECHNICAL REVIEW**
+
+### 🔄 **RECURSION PREVENTION**
+- **File Skipped**: none
+
+### 🔍 **STANDARDS CHECK**
+- **Contract**: shared review contract applied
+- **Repo Guidance**: AI-customization review scope applied for `.github/instructions/**` and `.github/skills/**`
+- **Scope Rules**: `REVIEW-SCOPE-004` was directly relevant because the change touched AI customization files
+- **Docs Contract**: not applicable
+- **Notes**: the change is wording alignment only and does not alter shipped runtime boundaries or output semantics
+
+### 🧰 **AZURERM LINTER**
+- **Version**: n/a
+- **Status**: Not applicable
+- **Run Scope**: n/a
+- **Issue Count**: n/a
+- **Summary**: no provider Go files are in scope
+
+### 🎯 **MUST FIX**
+- None
+
+### 🟢 **STRENGTHS**
+- The skill and contract continue to keep authority boundaries clear: the skill describes the method and the contract owns the deterministic rules.
+- The update does not reintroduce the removed instruction-file design.
+
+### 🟡 **OBSERVATIONS**
+- None.
+
+### 🔴 **ISSUES**
+- None
+
+## ✅ **RECOMMENDATIONS**
+
+### 🎯 **IMMEDIATE**
+- No blocking follow-up is required for this wording-alignment change.
+
+### 🔄 **FUTURE CONSIDERATIONS**
+- Preserve this regression case so future advocate-surface edits do not accidentally emit verification markers when no candidate Issues exist.
+
+## 🏆 **OVERALL ASSESSMENT**
+The change is acceptable. The primary review pass produces no candidate Issues, so the advocate second pass should not run and no advocate-specific verification marker should appear.

--- a/tools/regression/fixtures/review-local-advocate-dismissed-and-downgraded/README.md
+++ b/tools/regression/fixtures/review-local-advocate-dismissed-and-downgraded/README.md
@@ -1,0 +1,38 @@
+# Sanitized Fixture: Local Review Advocate Outcomes
+
+This fixture is synthetic and sanitized. It exists to prove that the generic local review prompt routes candidate Issues through the advocate second pass and lands dismissed versus downgraded outcomes in the correct final sections.
+
+## Scenario
+
+The modeled local change touches these files:
+
+- `.github/prompts/code-review-committed-changes.prompt.md`
+- `.github/instructions/review-advocate-compliance-contract.instructions.md`
+
+The prompt edit keeps Step 6 wired to the advocate skill and contract, but one narrow wording change still overstates a prompt requirement. At the same time, a naive first-pass review is tempted to raise a second issue against a contract-backed design choice that is actually intentional.
+
+## Simplified Change Shape
+
+- The prompt still delegates outcome mapping to the advocate contract.
+- One changed sentence in the prompt overstates a verification requirement and should remain a reduced-severity Issue after review.
+- Another apparent problem is a false positive because the dedicated advocate contract intentionally owns that behavior, so the advocate pass should dismiss it.
+
+## Expected Review Behavior
+
+A correct local code review should:
+
+- Apply AI-customization scope rules to the prompt and contract files
+- Produce candidate Issues during the primary pass
+- Invoke the `review-advocate` skill as the second-pass quality gate
+- Keep the real wording-drift problem in `ISSUES` at reduced severity
+- Move the false-positive finding into `OBSERVATIONS` with a `[⚖️ ADVOCATE: ...]` note
+- Emit the `review-advocate` skill verification marker in the final footer because the advocate pass actually ran
+
+## Expected Must-Catch Outcomes
+
+- `advocate-dismissed-finding-observation`
+- `advocate-downgraded-finding-stays-in-issues`
+
+## Expected Must-Not-Flag Outcomes
+
+- `dismissed-finding-left-in-issues`

--- a/tools/regression/fixtures/review-local-advocate-skip-no-candidates/README.md
+++ b/tools/regression/fixtures/review-local-advocate-skip-no-candidates/README.md
@@ -1,0 +1,36 @@
+# Sanitized Fixture: Local Review Skip Path For Review Advocate
+
+This fixture is synthetic and sanitized. It exists to prove the generic local review prompt does not invoke the advocate second pass when the primary review produces no candidate Issues.
+
+## Scenario
+
+Two AI-toolkit files change together:
+
+- `.github/skills/review-advocate/SKILL.md`
+- `.github/instructions/review-advocate-compliance-contract.instructions.md`
+
+The edits are benign wording alignment only. They do not introduce contradictory rules, stale paths, output-contract drift, or missing shipped-payload wiring.
+
+## Simplified Change Shape
+
+- The skill wording is clarified to match the contract terminology.
+- The contract wording is clarified without changing the deterministic outcome mapping.
+- No prompt text, hard-stop text, or manifest wiring is changed.
+
+## Expected Review Behavior
+
+A correct local code review should:
+
+- Apply the AI-customization review scope because the change is under `.github/skills/` and `.github/instructions/`
+- Conclude that the change introduces no candidate Issues
+- Skip the advocate second pass entirely
+- Produce no `Skill used: review-advocate` verification marker
+- Produce no `[⚖️ ADVOCATE: ...]` annotation because no finding was dismissed
+
+## Expected Must-Catch Outcomes
+
+- `advocate-skip-when-no-candidate-issues`
+
+## Expected Must-Not-Flag Outcomes
+
+- `spurious-review-advocate-marker`

--- a/tools/regression/run-regression-suite.ps1
+++ b/tools/regression/run-regression-suite.ps1
@@ -119,16 +119,18 @@ $selectedCases = @($allCases | Where-Object {
     })
 
 if ($selectedCases.Count -gt 0) {
+    $selectedCasePaths = @($selectedCases | ForEach-Object { $_.casePath } | Select-Object -Unique)
+    $selectedResultPaths = @($selectedCases | Where-Object { $_.exampleResultPath } | ForEach-Object { $_.exampleResultPath } | Select-Object -Unique)
+
     $validatorArguments = @{
-        CasePath = @($selectedCases | ForEach-Object { $_.casePath } | Select-Object -Unique)
+        CasePath = $selectedCasePaths
     }
 
-    $selectedResultPaths = @($selectedCases | Where-Object { $_.exampleResultPath } | ForEach-Object { $_.exampleResultPath } | Select-Object -Unique)
     if ($selectedResultPaths.Count -gt 0) {
         $validatorArguments.ResultPath = $selectedResultPaths
     }
 
-    & pwsh -NoProfile -File (Join-Path $PSScriptRoot "validate-regression-artifacts.ps1") @validatorArguments | Out-Null
+    & (Join-Path $PSScriptRoot 'validate-regression-artifacts.ps1') @validatorArguments | Out-Null
 }
 
 $caseResults = @()


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

This PR follows up the merged `review-advocate` runtime skill and `advocate contract` by adding prompt-level regression coverage for the second-pass advocate flow, fixing a regression-suite validation handoff bug that the new cases exposed, and aligning the maintainer/reference docs with the current shipped runtime surface.

**The Main Changes Are:**

- Add adjudicated local-review regression coverage for:
  - Advocate skip behavior when no candidate issues exist
  - Advocate dismissed-versus-downgraded outcome mapping
- Fix the regression-suite validator invocation in `tools/regression/run-regression-suite.ps1` so the top-level harness and one-shot maintainer validator can score the full adjudicated corpus cleanly
- Align maintainer/reference docs and the top-level README with the current `review-advocate` skill and advocate contract surface
- Add `Unreleased` changelog entries for the new regression coverage and the harness fix

## Summary

- Added 2 adjudicated `review-advocate` prompt-level regression cases plus fixtures and expected example artifacts
- Fixed `run-regression-suite.ps1` to pass selected case/result paths cleanly into `validate-regression-artifacts.ps1`
- Updated maintainer/reference docs to reflect the current advocate contract family and shipped runtime skill inventory
- Updated `README.md` for top-level `review-advocate` discoverability
- Added 2 `CHANGELOG.md` `Unreleased` bullets covering the new regression coverage and the harness fix

## Type of Change

- [x] Bug fix
- [x] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [ ] Installer
- [ ] Bash
- [x] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [ ] AI instructions (`.github/instructions/`)
- [ ] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

N/A

## Testing / Validation

- [x] Validated behavior locally