### PR TITLE
[ENHANCEMENT:] Add installer version provenance metadata

### DIFF
--- a/.github/workflows/RELEASING.md
+++ b/.github/workflows/RELEASING.md
@@ -56,6 +56,12 @@ Example dry-run bundle command:
 pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 9.9.9 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
 ```
 
+Maintainer note:
+
+- the standalone installer version commands (`-Version` in PowerShell and `--version` in Bash) read stamped bundle metadata rather than recomputing provenance at runtime
+- a plain source checkout can therefore show `Unavailable` for the support metadata block, because those fields are stamped only during bootstrap or release-bundle assembly
+- validate support output from the bootstrapped installer copy or the dry-run/release-shaped bundle, not from a raw source checkout
+
 ### 3. Open and merge the release PR to `main`
 
 The normal workflow is PR-based.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,11 @@ jobs:
           commit="$(printf "%s" "${GITHUB_SHA}" | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
           timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-          printf "version=%s\ntimestamp=%s\nhash=%s\ncommit=%s\n" "${version}" "${timestamp}" "${overall_hash}" "${commit}" > "${checksum_file}"
+          manifest_fingerprint="$(printf "%s" "${manifest_hash}" | cut -c1-8 | tr '[:lower:]' '[:upper:]')"
+          build_fingerprint="$(printf "%s" "${commit}" | cut -c1-8 | tr '[:lower:]' '[:upper:]')"
+          manifest_composite="${manifest_fingerprint}-${build_fingerprint}"
+
+          printf "version=%s\ntimestamp=%s\nhash=%s\ncommit=%s\nmanifest_fingerprint=%s\nbuild_fingerprint=%s\nmanifest_composite=%s\n" "${version}" "${timestamp}" "${overall_hash}" "${commit}" "${manifest_fingerprint}" "${build_fingerprint}" "${manifest_composite}" > "${checksum_file}"
 
           rm -f "${tmp_file}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **User-Priority:**
   - **[Installer]** - Installer summaries now show a composite manifest-and-build fingerprint instead of only the manifest short hash, including a `-DIRTY` suffix for dirty bootstrap-built installer copies, so end users can see which source commit produced an installed toolkit bundle even when `file-manifest.config` itself stays unchanged between builds.
+  - **[Installer]** - PowerShell and bash installers now expose standalone version/provenance commands (`-Version` and `--version`) backed by bundle-stamped checksum metadata rather than runtime recomputation, so support tickets collect the exact published version and manifest composite the bundle was built to report, and missing metadata now surfaces as `Unavailable` with reinstall guidance instead of drifting guesses.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ tar -xzf /tmp/terraform-azurerm-ai-installer.tar.gz -C ~/.terraform-azurerm-ai-i
 ~/.terraform-azurerm-ai-installer/install-copilot-setup.sh -help
 ```
 
+> [!TIP]
+> **Support / provenance command**: the installer exposes a standalone version command that prints the installer version, manifest composite, and bundle source without running a full install flow.
+>
+> PowerShell:
+> ```powershell
+> & "$env:USERPROFILE\.terraform-azurerm-ai-installer\install-copilot-setup.ps1" -Version
+> ```
+>
+> Bash:
+> ```bash
+> ~/.terraform-azurerm-ai-installer/install-copilot-setup.sh --version
+> ```
+>
+> Ask users to include that output in help tickets when they are reporting installer issues.
+<!-- -->
 > [!NOTE]
 > **About `-Verify` / `-verify`:** verification has two modes:
 > - **Bundle self-check (no repo directory):** when run from the user-profile installer directory *without* `-RepoDirectory` / `-repo-directory`, it verifies the installer bundle itself (manifest/modules/payload/checksum).

--- a/installer/README.md
+++ b/installer/README.md
@@ -50,6 +50,25 @@ pwsh ./install-copilot-setup.ps1 -RepoDirectory "/path/to/terraform-provider-azu
 ./install-copilot-setup.sh -repo-directory "/path/to/terraform-provider-azurerm"
 ```
 
+### Support / Provenance Command
+
+Use the standalone version command when you need the installer's stamped support metadata without running a full install flow.
+
+PowerShell:
+```powershell
+.\install-copilot-setup.ps1 -Version
+```
+
+Bash:
+```bash
+./install-copilot-setup.sh --version
+```
+
+That output is the preferred thing to request in support tickets because it prints:
+- installer version
+- manifest composite
+- local bundle source path
+
 ### 🔧 Installation Paths
 - **Windows**: `%USERPROFILE%\.terraform-azurerm-ai-installer`
 - **macOS/Linux**: `~/.terraform-azurerm-ai-installer`

--- a/installer/install-copilot-setup.ps1
+++ b/installer/install-copilot-setup.ps1
@@ -52,6 +52,7 @@ $LocalPath = ""
 $Verify = $false
 $Clean = $false
 $Help = $false
+$VersionOnly = $false
 
 #endregion Variable Initialization
 
@@ -71,7 +72,7 @@ function Show-EarlyErrorHeader {
 function Show-EarlyValidationError {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('BootstrapNoArgs', 'BootstrapRequiresGitRepo', 'EmptyLocalPath', 'LocalPathNotFound', 'EmptyRepoDirectory', 'RepoDirectoryNotFound')]
+        [ValidateSet('BootstrapNoArgs', 'BootstrapRequiresGitRepo', 'VersionNoArgs', 'EmptyLocalPath', 'LocalPathNotFound', 'EmptyRepoDirectory', 'RepoDirectoryNotFound')]
         [string]$ErrorType,
 
         [string]$Path = ""
@@ -100,6 +101,14 @@ function Show-EarlyValidationError {
                 Write-Host ""
             }
             Write-Host " -Bootstrap is for contributors working on this repo. It is not supported from a release bundle or user-profile copy." -ForegroundColor Cyan
+        }
+
+        'VersionNoArgs' {
+            Write-Host " Error:" -ForegroundColor Red -NoNewline
+            Write-Host " -Version must be used by itself" -ForegroundColor Cyan
+            Write-Host ""
+            Write-Host " Run the standalone version/provenance command:" -ForegroundColor Cyan
+            Write-Host "   .\install-copilot-setup.ps1 -Version" -ForegroundColor White
         }
 
         'EmptyLocalPath' {
@@ -162,13 +171,15 @@ function Get-ParameterSuggestion {
     # Prefix matching (higher priority)
     if ($cleanParam -match '^bo') { $suggestion = 'Bootstrap' }
     elseif ($cleanParam -match '^cl') { $suggestion = 'Clean' }
-    elseif ($cleanParam -match '^ve') { $suggestion = 'Verify' }
+    elseif ($cleanParam -match '^vers') { $suggestion = 'Version' }
+    elseif ($cleanParam -match '^veri|^ve') { $suggestion = 'Verify' }
     elseif ($cleanParam -match '^he') { $suggestion = 'Help' }
     elseif ($cleanParam -match '^re') { $suggestion = 'RepoDirectory' }
     elseif ($cleanParam -match '^lo') { $suggestion = 'LocalPath' }
     # Fuzzy matching (lower priority)
     elseif ($cleanParam -like '*cle*') { $suggestion = 'Clean' }
     elseif ($cleanParam -like '*boo*') { $suggestion = 'Bootstrap' }
+    elseif ($cleanParam -like '*version*') { $suggestion = 'Version' }
     elseif ($cleanParam -like '*ver*') { $suggestion = 'Verify' }
     elseif ($cleanParam -like '*hel*') { $suggestion = 'Help' }
     elseif ($cleanParam -like '*repo*') { $suggestion = 'RepoDirectory' }
@@ -192,7 +203,7 @@ while ($i -lt $args.Count) {
         Write-Host " Invalid parameter '$($args[$i])' (incomplete parameter)" -ForegroundColor Cyan
         Write-Host ""
         Write-Host " Valid parameters:" -ForegroundColor Cyan
-        Write-Host "   -Bootstrap, -Verify, -Clean, -Help, -RepoDirectory <path>" -ForegroundColor White
+        Write-Host "   -Bootstrap, -Verify, -Version, -Clean, -Help, -RepoDirectory <path>" -ForegroundColor White
         Write-Host "   -LocalPath <path>" -ForegroundColor White
         Write-Host ""
         Write-Host " Examples:" -ForegroundColor Green
@@ -225,6 +236,14 @@ while ($i -lt $args.Count) {
         }
         '-verify' {
             $Verify = $true
+            $i++
+        }
+        '-version' {
+            $VersionOnly = $true
+            $i++
+        }
+        '--version' {
+            $VersionOnly = $true
             $i++
         }
         '-clean' {
@@ -289,6 +308,11 @@ if ($args.Count -eq 0 -and -not ($Bootstrap -or $RepoDirectory -or $LocalPath -o
 # PRIORITY 1: -Bootstrap must be a standalone operation (no additional flags)
 if ($Bootstrap -and ($RepoDirectory -or $LocalPath -or $Verify -or $Clean -or $Help)) {
     Show-EarlyValidationError -ErrorType 'BootstrapNoArgs'
+    exit 1
+}
+
+if ($VersionOnly -and ($Bootstrap -or $RepoDirectory -or $LocalPath -or $Verify -or $Clean -or $Help)) {
+    Show-EarlyValidationError -ErrorType 'VersionNoArgs'
     exit 1
 }
 
@@ -460,6 +484,81 @@ $Global:InstallerCommandLine = $MyInvocation.Line
 $Global:InstallerManifestPath = $null
 $Global:InstallerManifestHash = $null
 
+function Get-InstallerSupportInfo {
+    param(
+        [Parameter(Mandatory)]
+        [string]$InstallerRoot,
+
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+
+    $metadataResult = Get-InstallerChecksumMetadata -InstallerRoot $InstallerRoot
+
+    $displayVersion = 'Unavailable'
+    $displayManifest = 'Unavailable'
+    $metadataAvailable = $false
+
+    if ($metadataResult.Valid) {
+        $metadata = $metadataResult.Metadata
+        if ($metadata['version']) {
+            $displayVersion = $metadata['version']
+        }
+        if ($metadata['manifest_composite']) {
+            $displayManifest = $metadata['manifest_composite']
+        }
+        $metadataAvailable = ($displayVersion -ne 'Unavailable' -and $displayManifest -ne 'Unavailable')
+    }
+
+    $info = [ordered]@{
+        Version = $displayVersion
+        Manifest = $displayManifest
+    }
+
+    $sourcePath = Join-Path $InstallerRoot 'aii'
+    if (Test-Path $sourcePath) {
+        $info['Source'] = $sourcePath
+    }
+    else {
+        $info['Source'] = $InstallerRoot
+    }
+
+    $info['MetadataAvailable'] = $metadataAvailable
+
+    return $info
+}
+
+function Show-InstallerVersionInfo {
+    param(
+        [Parameter(Mandatory)]
+        [string]$InstallerRoot,
+
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+
+    $supportInfo = Get-InstallerSupportInfo -InstallerRoot $InstallerRoot -Version $Version
+
+    $displayVersion = $supportInfo['Version']
+    Write-Header -Title "Terraform AzureRM Provider - AI Infrastructure Installer" -Version $displayVersion
+    Write-Host "VERSION INFORMATION:" -ForegroundColor Cyan
+
+    foreach ($entry in $supportInfo.GetEnumerator()) {
+        if ($entry.Key -eq 'MetadataAvailable') {
+            continue
+        }
+        Write-Host ("  {0,-8}: " -f $entry.Key) -NoNewline -ForegroundColor White
+        Write-Host $entry.Value -ForegroundColor Yellow
+    }
+
+    if (-not $supportInfo['MetadataAvailable']) {
+        Write-Host ""
+        Write-Host "  Reinstall the official bundle to restore installer metadata." -ForegroundColor Cyan
+    }
+
+    Write-Host ""
+}
+
 #endregion Module Loading
 
 #region Workspace Detection
@@ -499,6 +598,11 @@ function Main {
     #>
 
      try {
+        if ($VersionOnly) {
+            Show-InstallerVersionInfo -InstallerRoot $ScriptDirectory -Version $script:InstallerVersion
+            return
+        }
+
         # Step 1: Initialize workspace
         # Detect workspace root from -RepoDirectory or current script directory.
         $Global:WorkspaceRoot = Get-WorkspaceRoot -RepoDirectory $RepoDirectory -ScriptDirectory $ScriptDirectory

--- a/installer/install-copilot-setup.ps1
+++ b/installer/install-copilot-setup.ps1
@@ -493,7 +493,7 @@ function Get-InstallerSupportInfo {
         [string]$Version
     )
 
-    $metadataResult = Get-InstallerChecksumMetadata -InstallerRoot $InstallerRoot
+    $metadataResult = Get-InstallerChecksumInfo -InstallerRoot $InstallerRoot
 
     $displayVersion = 'Unavailable'
     $displayManifest = 'Unavailable'

--- a/installer/install-copilot-setup.sh
+++ b/installer/install-copilot-setup.sh
@@ -20,6 +20,7 @@ LOCAL_SOURCE_PATH=""
 VERIFY="false"
 CLEAN="false"
 HELP="false"
+VERSION_ONLY="false"
 
 # ============================================================================
 # PARAMETER DEFINITIONS
@@ -196,6 +197,11 @@ main() {
     # STEP 1: Parse command line arguments first
     parse_arguments "$@"
 
+    if [[ "${VERSION_ONLY}" == "true" ]] && { [[ "${BOOTSTRAP}" == "true" ]] || [[ -n "${REPO_DIRECTORY}" ]] || [[ -n "${LOCAL_SOURCE_PATH}" ]] || [[ "${VERIFY}" == "true" ]] || [[ "${CLEAN}" == "true" ]] || [[ "${HELP}" == "true" ]]; }; then
+        show_early_validation_error "VersionNoArgs" "$0"
+        exit 1
+    fi
+
     # STEP 1.0: Validate -repo-directory is not empty/whitespace when explicitly provided
     if [[ "${REPO_DIRECTORY_EXPLICIT}" == "true" ]] && [[ -z "${REPO_DIRECTORY//[[:space:]]/}" ]]; then
         show_early_validation_error "EmptyRepoDirectory" "$0"
@@ -235,6 +241,11 @@ main() {
     if [[ -n "${LOCAL_SOURCE_PATH}" ]] && [[ ! -d "${LOCAL_SOURCE_PATH}" ]]; then
         show_early_validation_error "LocalPathNotFound" "$0" "${LOCAL_SOURCE_PATH}"
         exit 1
+    fi
+
+    if [[ "${VERSION_ONLY}" == "true" ]]; then
+        show_installer_version_info
+        exit 0
     fi
 
     # STEP 2: Show header immediately for consistent user experience
@@ -560,6 +571,7 @@ main() {
 check_typos() {
     local param="$1"
     local suggestion=""
+    local suggestion_display=""
 
     # Handle bare dash edge case
     if [[ "${param}" == "-" ]] || [[ "${param}" == "--" ]]; then
@@ -582,6 +594,8 @@ check_typos() {
         suggestion="clean"
     elif echo "${lower_param}" | grep -q '^bo'; then
         suggestion="bootstrap"
+    elif echo "${lower_param}" | grep -q '^vers'; then
+        suggestion="version"
     elif echo "${lower_param}" | grep -q '^ve'; then
         suggestion="verify"
     elif echo "${lower_param}" | grep -q '^he'; then
@@ -595,6 +609,8 @@ check_typos() {
         suggestion="clean"
     elif [[ "${lower_param}" == *boo* ]]; then
         suggestion="bootstrap"
+    elif [[ "${lower_param}" == *version* ]]; then
+        suggestion="version"
     elif [[ "${lower_param}" == *ver* ]]; then
         suggestion="verify"
     elif [[ "${lower_param}" == *hel* ]]; then
@@ -608,9 +624,15 @@ check_typos() {
     fi
 
     if [[ -n "${suggestion}" ]]; then
+        if [[ "${suggestion}" == "version" ]]; then
+            suggestion_display="--version"
+        else
+            suggestion_display="-${suggestion}"
+        fi
+
         printf " \033[31mError:\033[0m\033[36m Failed to parse command-line argument:\033[0m\n"
         printf " \033[36mArgument provided but not defined:\033[0m \033[33m${param}\033[0m\n"
-        printf " \033[36mDid you mean:\033[0m \033[32m-${suggestion}\033[0m\033[36m?\033[0m\n"
+        printf " \033[36mDid you mean:\033[0m \033[32m${suggestion_display}\033[0m\033[36m?\033[0m\n"
         echo ""
         printf " \033[36mFor more help on using this command, run:\033[0m\n"
         printf "   \033[37m$0 -help\033[0m\n"
@@ -624,6 +646,10 @@ parse_arguments() {
         case $1 in
             -bootstrap)
                 BOOTSTRAP=true
+                shift
+                ;;
+            -version|--version)
+                VERSION_ONLY=true
                 shift
                 ;;
             -repo-directory)

--- a/installer/modules/bash/fileoperations.sh
+++ b/installer/modules/bash/fileoperations.sh
@@ -727,38 +727,18 @@ show_installation_summary() {
 
     local manifest_value="${INSTALLER_MANIFEST_FILE:-}"
     if [[ -n "${manifest_value}" ]]; then
-        local manifest_hash=""
-        local build_commit=""
-        local build_dirty="false"
-        if command -v sha256sum >/dev/null 2>&1; then
-            manifest_hash=$(sha256sum "${manifest_value}" 2>/dev/null | awk '{print $1}')
-        elif command -v shasum >/dev/null 2>&1; then
-            manifest_hash=$(shasum -a 256 "${manifest_value}" 2>/dev/null | awk '{print $1}')
-        fi
-        local checksum_file="$(dirname "${manifest_value}")/aii.checksum"
-        if [[ -f "${checksum_file}" ]]; then
-            build_commit="$(grep '^commit=' "${checksum_file}" | head -n 1 | cut -d= -f2- | tr -d '\r\n')"
-            local bundle_version
-            bundle_version="$(grep '^version=' "${checksum_file}" | head -n 1 | cut -d= -f2- | tr -d '\r\n')"
-            if [[ "${bundle_version}" == *-dirty ]]; then
-                build_dirty="true"
+        local installer_root="$(dirname "${manifest_value}")"
+        local metadata_output=""
+        metadata_output="$(get_installer_checksum_metadata "${installer_root}" 2>/dev/null || true)"
+        local manifest_composite="Unavailable"
+        if [[ -n "${metadata_output}" ]]; then
+            local metadata_manifest
+            metadata_manifest="$(printf '%s\n' "${metadata_output}" | grep '^manifest_composite=' | head -n 1 | cut -d= -f2- | tr -d '\r\n')"
+            if [[ -n "${metadata_manifest}" ]]; then
+                manifest_composite="${metadata_manifest}"
             fi
         fi
-        if [[ -n "${manifest_hash}" ]]; then
-            local manifest_fingerprint="${manifest_hash:0:8}"
-            local manifest_fingerprint_upper="$(printf '%s' "${manifest_fingerprint}" | tr '[:lower:]' '[:upper:]')"
-            if [[ -n "${build_commit}" ]]; then
-                local build_fingerprint="${build_commit:0:8}"
-                local build_fingerprint_upper="$(printf '%s' "${build_fingerprint}" | tr '[:lower:]' '[:upper:]')"
-                local manifest_composite="${manifest_fingerprint_upper}-${build_fingerprint_upper}"
-                if [[ "${build_dirty}" == "true" ]]; then
-                    manifest_composite="${manifest_composite}-DIRTY"
-                fi
-                manifest_value="${manifest_value} (${manifest_composite})"
-            else
-                manifest_value="${manifest_value} (${manifest_fingerprint_upper})"
-            fi
-        fi
+        manifest_value="${manifest_value} (${manifest_composite})"
     fi
 
     show_operation_summary "Installation" "${success_status}" \

--- a/installer/modules/bash/ui.sh
+++ b/installer/modules/bash/ui.sh
@@ -112,6 +112,13 @@ show_early_validation_error() {
             echo -e "${CYAN} -bootstrap is for contributors working on this repo. It is not supported from a release bundle or user-profile copy.${NC}"
             ;;
 
+        "VersionNoArgs")
+            echo -e "${RED} Error:${NC}${CYAN} -version must be used by itself${NC}"
+            echo ""
+            echo -e "${CYAN} Run the standalone version/provenance command:${NC}"
+            echo -e "   ${WHITE}${script_name} --version${NC}"
+            ;;
+
         "EmptyLocalPath")
             echo -e "${RED} Error:${NC}${CYAN} -local-path parameter cannot be empty${NC}"
             echo ""
@@ -742,6 +749,7 @@ show_usage() {
     write_plain "  Installer operations are offline-only and use the bundled payload (aii/)."
     write_plain "  No network downloads occur during install, verify, or clean."
     write_plain "  Install and verify validate the bundled payload checksum (aii.checksum)."
+    write_plain "  Use --version to print a support-friendly version and manifest provenance summary."
     echo ""
     write_plain "  Target installs require a terraform-provider-azurerm clone with an origin remote."
     write_plain "  The AI development repo is a source-only workspace and is not a valid target."
@@ -777,6 +785,7 @@ show_source_branch_help() {
     write_plain "  -bootstrap        Copy installer to user profile (~/.terraform-azurerm-ai-installer/)"
     write_plain "                    Must be run from a git clone (.git present)"
     write_plain "  -verify           Check current workspace status and validate setup"
+    write_plain "  --version         Show installer version and manifest provenance information"
     write_plain "  -help             Show this help information"
     echo ""
     write_cyan "EXAMPLES:"
@@ -785,6 +794,9 @@ show_source_branch_help() {
     echo ""
     write_plain "  Verify setup:"
     write_plain "    ./install-copilot-setup.sh -verify"
+    echo ""
+    write_plain "  Show installer version/provenance:"
+    write_plain "    ./install-copilot-setup.sh --version"
     echo ""
 
     # Show command-specific help if a command was attempted
@@ -816,6 +828,7 @@ show_feature_branch_help() {
     write_plain "  -repo-directory   Path to your terraform-provider-azurerm working copy"
     write_plain "  -local-path       Local directory to copy AI files from (source override; instead of bundled payload)"
     write_plain "  -verify           Check current workspace status and validate setup"
+    write_plain "  --version         Show installer version and manifest provenance information"
     write_plain "  -clean            Remove AI infrastructure from workspace"
     write_plain "  -help             Show this help information"
     echo ""
@@ -831,6 +844,9 @@ show_feature_branch_help() {
     write_cyan "  Clean removal:"
     write_plain "    cd ~/.terraform-azurerm-ai-installer/"
     write_plain "    ./install-copilot-setup.sh -repo-directory \"/path/to/terraform-provider-azurerm\" -clean"
+    echo ""
+    write_cyan "  Show installer version/provenance:"
+    write_plain "    ./install-copilot-setup.sh --version"
     echo ""
 
     # Show command-specific help if a command was attempted.
@@ -904,6 +920,7 @@ show_unknown_branch_help() {
     write_plain "  -repo-directory   Path to your terraform-provider-azurerm working copy"
     write_plain "  -local-path       Local directory to copy AI files from (source override; instead of bundled payload)"
     write_plain "  -verify           Check current workspace status and validate setup"
+    write_plain "  --version         Show installer version and manifest provenance information"
     write_plain "  -clean            Remove AI infrastructure from workspace"
     write_plain "  -help             Show this help information"
     echo ""
@@ -912,6 +929,7 @@ show_unknown_branch_help() {
     write_dark_cyan "  Source Branch Operations:"
     write_plain "    ./install-copilot-setup.sh -bootstrap"
     write_plain "    ./install-copilot-setup.sh -verify"
+    write_plain "    ./install-copilot-setup.sh --version"
     echo ""
     write_dark_cyan "  Feature Branch Operations:"
     write_plain "    cd ~/.terraform-azurerm-ai-installer"
@@ -924,6 +942,70 @@ show_unknown_branch_help() {
 
     write_cyan "BRANCH DETECTION:"
     write_plain "  The installer automatically detects your branch type and shows appropriate options."
+    echo ""
+}
+
+get_installer_support_info() {
+    local installer_root="${SCRIPT_DIR}"
+    local version_value="Unavailable"
+    local source_path="${installer_root}"
+    local manifest_value="Unavailable"
+    local metadata_available="false"
+
+    if [[ -d "${installer_root}/aii" ]]; then
+        source_path="${installer_root}/aii"
+    fi
+
+    local metadata_output=""
+    metadata_output="$(get_installer_checksum_metadata "${installer_root}" 2>/dev/null || true)"
+    if [[ -n "${metadata_output}" ]]; then
+        local metadata_version
+        metadata_version=$(printf '%s\n' "${metadata_output}" | awk -F= '/^version=/{print substr($0, index($0, "=")+1); exit}' | tr -d '\r\n')
+        local metadata_manifest
+        metadata_manifest=$(printf '%s\n' "${metadata_output}" | awk -F= '/^manifest_composite=/{print substr($0, index($0, "=")+1); exit}' | tr -d '\r\n')
+
+        if [[ -n "${metadata_version}" ]]; then
+            version_value="${metadata_version}"
+        fi
+        if [[ -n "${metadata_manifest}" ]]; then
+            manifest_value="${metadata_manifest}"
+        fi
+        if [[ "${version_value}" != "Unavailable" && "${manifest_value}" != "Unavailable" ]]; then
+            metadata_available="true"
+        fi
+    fi
+
+    printf 'Version=%s\n' "${version_value}"
+    printf 'Manifest=%s\n' "${manifest_value}"
+    printf 'Source=%s\n' "${source_path}"
+    printf 'MetadataAvailable=%s\n' "${metadata_available}"
+}
+
+show_installer_version_info() {
+    write_header "Terraform AzureRM Provider - AI Infrastructure Installer" "${VERSION:-${INSTALLER_VERSION}}"
+    write_cyan "VERSION INFORMATION:"
+
+    local support_info
+    support_info="$(get_installer_support_info)"
+
+    local line key value
+    while IFS= read -r line; do
+        [[ -z "${line}" ]] && continue
+        key="${line%%=*}"
+        value="${line#*=}"
+        if [[ "${key}" == "MetadataAvailable" ]]; then
+            continue
+        fi
+        printf "${WHITE}  %-8s:${NC} ${YELLOW}%s${NC}\n" "${key}" "${value}"
+    done <<< "${support_info}"
+
+    local metadata_available
+    metadata_available="$(printf '%s\n' "${support_info}" | awk -F= '/^MetadataAvailable=/{print substr($0, index($0, "=")+1); exit}' | tr -d '\r\n')"
+    if [[ "${metadata_available}" != "true" ]]; then
+        echo ""
+        write_cyan "  Reinstall the official bundle to restore installer metadata."
+    fi
+
     echo ""
 }
 

--- a/installer/modules/bash/ui.sh
+++ b/installer/modules/bash/ui.sh
@@ -508,7 +508,7 @@ write_success_message() {
 
 # Function to get user profile directory
 get_user_profile() {
-    # Return the full expanded path (not using ~ shorthand) to match PowerShell behavio
+    # Return the full expanded path (not using ~ shorthand) to match PowerShell behavior
     local expanded_home
     expanded_home="${HOME:-/home/$(whoami)}"
     echo "${expanded_home}/.terraform-azurerm-ai-installer"

--- a/installer/modules/bash/validationengine.sh
+++ b/installer/modules/bash/validationengine.sh
@@ -145,6 +145,27 @@ test_system_requirements() {
     echo "Commands=${commands_result}"
 }
 
+get_installer_checksum_metadata() {
+    local installer_root="$1"
+    local checksum_file="${installer_root}/aii.checksum"
+
+    if [[ ! -f "${checksum_file}" ]]; then
+        echo "valid=false"
+        echo "reason=Installer checksum file not found"
+        return 1
+    fi
+
+    echo "valid=true"
+    while IFS= read -r line; do
+        [[ -z "${line}" ]] && continue
+        if [[ "${line}" == *=* ]]; then
+            echo "${line%$'\r'}"
+        fi
+    done < "${checksum_file}"
+
+    return 0
+}
+
 # Function to test workspace validity
 test_workspace_valid() {
     local workspace_path="${1:-$(pwd)}"

--- a/installer/modules/powershell/FileOperations.psm1
+++ b/installer/modules/powershell/FileOperations.psm1
@@ -1373,32 +1373,18 @@ function Invoke-InstallInfrastructure {
             }
 
             $manifestValue = $Global:InstallerManifestPath
-            if ($manifestValue -and $Global:InstallerManifestHash) {
-                $manifestFingerprint = $Global:InstallerManifestHash.Substring(0,8)
-                $buildFingerprint = $null
-                $buildSuffix = $null
+            if ($manifestValue) {
+                $manifestDisplay = 'Unavailable'
 
                 $installerRoot = Split-Path $Global:InstallerManifestPath -Parent
                 if ($installerRoot -and (Test-Path $installerRoot)) {
                     $bundleChecksum = Test-InstallerChecksum -InstallerRoot $installerRoot
-                    if ($bundleChecksum.Valid -and $bundleChecksum.Commit) {
-                        $buildFingerprint = $bundleChecksum.Commit.Substring(0, [Math]::Min(8, $bundleChecksum.Commit.Length)).ToUpperInvariant()
-                        if ($bundleChecksum.Dirty) {
-                            $buildSuffix = 'DIRTY'
-                        }
+                    if ($bundleChecksum.Valid -and $bundleChecksum.ManifestComposite) {
+                        $manifestDisplay = $bundleChecksum.ManifestComposite
                     }
                 }
 
-                if ($buildFingerprint) {
-                    $manifestComposite = "$($manifestFingerprint.ToUpperInvariant())-$buildFingerprint"
-                    if ($buildSuffix) {
-                        $manifestComposite = "$manifestComposite-$buildSuffix"
-                    }
-                    $manifestValue = "$manifestValue ($manifestComposite)"
-                }
-                else {
-                    $manifestValue = "$manifestValue ($($manifestFingerprint.ToUpperInvariant()))"
-                }
+                $manifestValue = "$manifestValue ($manifestDisplay)"
             }
             if ($manifestValue) {
                 $details["Manifest"] = $manifestValue

--- a/installer/modules/powershell/UI.psm1
+++ b/installer/modules/powershell/UI.psm1
@@ -375,6 +375,7 @@ function Show-Help {
     Write-Host "  Installer operations are offline-only and use the bundled payload (aii/)." -ForegroundColor White
     Write-Host "  No network downloads occur during install, verify, or clean." -ForegroundColor White
     Write-Host "  Install and verify validate the bundled payload checksum (aii.checksum)." -ForegroundColor White
+    Write-Host "  Use -Version to print a support-friendly version and manifest provenance summary." -ForegroundColor White
     Write-Host ""
     Write-Host "  Target installs require a terraform-provider-azurerm clone with an origin remote." -ForegroundColor White
     Write-Host "  The AI development repo is a source-only workspace and is not a valid target." -ForegroundColor White
@@ -412,6 +413,7 @@ function Show-SourceBranchHelp {
     Write-Host "  -Bootstrap        Copy installer to user profile (~\.terraform-azurerm-ai-installer\)"
     Write-Host "                    Must be run from a git clone (.git present)"
     Write-Host "  -Verify           Check current workspace status and validate setup"
+    Write-Host "  -Version          Show installer version and manifest provenance information"
     Write-Host "  -Help             Show this help information"
     Write-Host ""
     Write-Host "EXAMPLES:" -ForegroundColor Cyan
@@ -420,6 +422,9 @@ function Show-SourceBranchHelp {
     Write-Host ""
     Write-Host "  Verify setup:"
     Write-Host "    .\install-copilot-setup.ps1 -Verify"
+    Write-Host ""
+    Write-Host "  Show installer version/provenance:"
+    Write-Host "    .\install-copilot-setup.ps1 -Version"
     Write-Host ""
     Write-Host "BOOTSTRAP WORKFLOW:" -ForegroundColor Cyan
     Write-Host "  1. Run -Bootstrap from a git clone to copy installer to user profile"
@@ -443,6 +448,7 @@ function Show-FeatureBranchHelp {
     Write-Host "  -RepoDirectory    Path to your terraform-provider-azurerm working copy"
     Write-Host "  -LocalPath        Local directory to copy AI files from (source override; instead of bundled payload)"
     Write-Host "  -Verify           Check current workspace status and validate setup"
+    Write-Host "  -Version          Show installer version and manifest provenance information"
     Write-Host "  -Clean            Remove AI infrastructure from workspace"
     Write-Host "  -Help             Show this help information"
     Write-Host ""
@@ -456,6 +462,9 @@ function Show-FeatureBranchHelp {
     Write-Host ""
     Write-Host "  Clean removal:"
     Write-Host "    & `"$(Join-Path (Get-CrossPlatformInstallerPath -Raw) 'install-copilot-setup.ps1')`" -RepoDirectory `"/path/to/terraform-provider-azurerm`" -Clean"
+    Write-Host ""
+    Write-Host "  Show installer version/provenance:"
+    Write-Host "    & `"$(Join-Path (Get-CrossPlatformInstallerPath -Raw) 'install-copilot-setup.ps1')`" -Version"
     Write-Host ""
 
     Write-Host "WORKFLOW:" -ForegroundColor Cyan
@@ -514,6 +523,7 @@ function Show-UnknownBranchHelp {
     Write-Host "  -RepoDirectory    Path to your terraform-provider-azurerm working copy"
     Write-Host "  -LocalPath        Local directory to copy AI files from (source override; instead of bundled payload)"
     Write-Host "  -Verify           Check current workspace status and validate setup"
+    Write-Host "  -Version          Show installer version and manifest provenance information"
     Write-Host "  -Clean            Remove AI infrastructure from workspace"
     Write-Host "  -Help             Show this help information"
     Write-Host ""
@@ -522,6 +532,7 @@ function Show-UnknownBranchHelp {
     Write-Host "  Source Branch Operations:" -ForegroundColor DarkCyan
     Write-Host "    .\install-copilot-setup.ps1 -Bootstrap"
     Write-Host "    .\install-copilot-setup.ps1 -Verify"
+    Write-Host "    .\install-copilot-setup.ps1 -Version"
     Write-Host ""
     Write-Host "  Feature Branch Operations:" -ForegroundColor DarkCyan
     Write-Host "    & `"$(Join-Path (Get-CrossPlatformInstallerPath -Raw) 'install-copilot-setup.ps1')`" -RepoDirectory `"/path/to/terraform-provider-azurerm`""

--- a/installer/modules/powershell/ValidationEngine.psm1
+++ b/installer/modules/powershell/ValidationEngine.psm1
@@ -729,6 +729,30 @@ function Write-InstallerChecksum {
         $Commit = $matches[1].ToLowerInvariant()
     }
 
+    $manifestFingerprint = $null
+    $buildFingerprint = $null
+    $manifestComposite = $null
+
+    $manifestPath = Join-Path $InstallerRoot "file-manifest.config"
+    if (Test-Path $manifestPath) {
+        $manifestHash = (Get-FileHash -Path $manifestPath -Algorithm SHA256 -ErrorAction Stop).Hash
+        $manifestFingerprint = $manifestHash.Substring(0, [Math]::Min(8, $manifestHash.Length)).ToUpperInvariant()
+    }
+
+    if ($Commit) {
+        $buildFingerprint = $Commit.Substring(0, [Math]::Min(8, $Commit.Length)).ToUpperInvariant()
+    }
+
+    if ($manifestFingerprint) {
+        $manifestComposite = $manifestFingerprint
+        if ($buildFingerprint) {
+            $manifestComposite = "$manifestComposite-$buildFingerprint"
+            if ($Version -match '-dirty$') {
+                $manifestComposite = "$manifestComposite-DIRTY"
+            }
+        }
+    }
+
     $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     $checksumLines = @(
         "version=$Version",
@@ -740,12 +764,24 @@ function Write-InstallerChecksum {
         $checksumLines += "commit=$($Commit.ToLowerInvariant())"
     }
 
+    if ($manifestFingerprint) {
+        $checksumLines += "manifest_fingerprint=$manifestFingerprint"
+    }
+
+    if ($buildFingerprint) {
+        $checksumLines += "build_fingerprint=$buildFingerprint"
+    }
+
+    if ($manifestComposite) {
+        $checksumLines += "manifest_composite=$manifestComposite"
+    }
+
     $checksumLines | Set-Content -Path $checksumPath
 
-    return @{ Valid = $true; Hash = $result.Hash; Path = $checksumPath; Commit = $Commit }
+    return @{ Valid = $true; Hash = $result.Hash; Path = $checksumPath; Commit = $Commit; ManifestComposite = $manifestComposite }
 }
 
-function Test-InstallerChecksum {
+function Get-InstallerChecksumMetadata {
     param(
         [Parameter(Mandatory)]
         [string]$InstallerRoot
@@ -756,39 +792,39 @@ function Test-InstallerChecksum {
         return @{ Valid = $false; Reason = "Installer checksum file not found" }
     }
 
-    $checksumLines = Get-Content -Path $checksumPath
+    $metadata = @{}
+    foreach ($line in Get-Content -Path $checksumPath) {
+        if ($line -match '^([A-Za-z0-9_]+)=(.*)$') {
+            $metadata[$matches[1].ToLowerInvariant()] = $matches[2].Trim()
+        }
+    }
 
-    $hashLine = $checksumLines | Where-Object { $_ -match '^hash=' } | Select-Object -First 1
-    if (-not $hashLine) {
+    return @{ Valid = $true; Metadata = $metadata; Path = $checksumPath }
+}
+
+function Test-InstallerChecksum {
+    param(
+        [Parameter(Mandatory)]
+        [string]$InstallerRoot
+    )
+
+    $metadataResult = Get-InstallerChecksumMetadata -InstallerRoot $InstallerRoot
+    if (-not $metadataResult.Valid) {
+        return $metadataResult
+    }
+
+    $metadata = $metadataResult.Metadata
+    $expected = $metadata['hash']
+    if (-not $expected) {
         return @{ Valid = $false; Reason = "Installer checksum file missing hash" }
     }
 
-    $versionLine = $checksumLines | Where-Object { $_ -match '^version=' } | Select-Object -First 1
-    $version = $null
-    $dirty = $false
-    if ($versionLine) {
-        $version = $versionLine.Substring(8).Trim()
-        if (-not $version) {
-            $version = $null
-        }
-        elseif ($version -match '-dirty$') {
-            $dirty = $true
-        }
-    }
-
-    $commitLine = $checksumLines | Where-Object { $_ -match '^commit=' } | Select-Object -First 1
-    $commit = $null
-    if ($commitLine) {
-        $commit = $commitLine.Substring(7).Trim().ToLowerInvariant()
-        if (-not $commit) {
-            $commit = $null
-        }
-    }
-
-    $expected = $hashLine.Substring(5).Trim()
-    if (-not $expected) {
-        return @{ Valid = $false; Reason = "Installer checksum hash is empty" }
-    }
+    $version = $metadata['version']
+    $commit = $metadata['commit']
+    $dirty = [bool]($version -and $version -match '-dirty$')
+    $manifestFingerprint = $metadata['manifest_fingerprint']
+    $buildFingerprint = $metadata['build_fingerprint']
+    $manifestComposite = $metadata['manifest_composite']
 
     $prune = Remove-StaleInstallerPayload -InstallerRoot $InstallerRoot
     if (-not $prune.Valid) {
@@ -807,7 +843,7 @@ function Test-InstallerChecksum {
         return @{ Valid = $false; Reason = "Installer checksum mismatch"; Expected = $expected; Actual = $computed.Hash }
     }
 
-    return @{ Valid = $true; Hash = $computed.Hash; Commit = $commit; Version = $version; Dirty = $dirty }
+    return @{ Valid = $true; Hash = $computed.Hash; Commit = $commit; Version = $version; Dirty = $dirty; ManifestFingerprint = $manifestFingerprint; BuildFingerprint = $buildFingerprint; ManifestComposite = $manifestComposite }
 }
 
 function Test-PreInstallation {
@@ -1356,6 +1392,7 @@ function Invoke-VerifyInstallerBundle {
 Export-ModuleMember -Function @(
     'Test-WorkspaceValid',
     'Test-PreInstallation',
+    'Get-InstallerChecksumMetadata',
     'Test-InstallerChecksum',
     'Write-InstallerChecksum',
     'Invoke-VerifyInstallerBundle',

--- a/installer/modules/powershell/ValidationEngine.psm1
+++ b/installer/modules/powershell/ValidationEngine.psm1
@@ -781,7 +781,7 @@ function Write-InstallerChecksum {
     return @{ Valid = $true; Hash = $result.Hash; Path = $checksumPath; Commit = $Commit; ManifestComposite = $manifestComposite }
 }
 
-function Get-InstallerChecksumMetadata {
+function Get-InstallerChecksumInfo {
     param(
         [Parameter(Mandatory)]
         [string]$InstallerRoot
@@ -808,7 +808,7 @@ function Test-InstallerChecksum {
         [string]$InstallerRoot
     )
 
-    $metadataResult = Get-InstallerChecksumMetadata -InstallerRoot $InstallerRoot
+    $metadataResult = Get-InstallerChecksumInfo -InstallerRoot $InstallerRoot
     if (-not $metadataResult.Valid) {
         return $metadataResult
     }
@@ -1392,7 +1392,7 @@ function Invoke-VerifyInstallerBundle {
 Export-ModuleMember -Function @(
     'Test-WorkspaceValid',
     'Test-PreInstallation',
-    'Get-InstallerChecksumMetadata',
+    'Get-InstallerChecksumInfo',
     'Test-InstallerChecksum',
     'Write-InstallerChecksum',
     'Invoke-VerifyInstallerBundle',


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

This PR adds standalone installer version/provenance commands and moves installer support metadata to a bundle-authored model.

The installer bundle now stamps version and manifest provenance metadata into `aii.checksum` during bootstrap and release/dry-run bundle generation. PowerShell and Bash read that stamped metadata for support/version output and show `Unavailable` with reinstall guidance when bundle metadata is not present instead of guessing.

The PR also updates public installer docs to mention the new support command and updates maintainer release docs with the source-checkout versus bundle-authored metadata nuance.

## Summary

- Add standalone version/provenance commands for PowerShell and Bash installers
- Stamp installer provenance metadata into `aii.checksum` during bootstrap and release bundle generation
- Update installer and maintainer docs to match the new behavior

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Documentation / examples
- [ ] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [x] Installer
- [x] Bash
- [x] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [ ] AI instructions (`.github/instructions/`)
- [ ] AI skills (`.github/skills/`)
- [x] GitHub Actions

## Related Issue(s)

N/A

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

- Ran `.\installer\install-copilot-setup.ps1 -Version`
- Ran `bash ./installer/install-copilot-setup.sh --version`
- Verified source-tree behavior returns `Unavailable` plus reinstall guidance when stamped bundle metadata is not present
- Built a dry-run release bundle with `pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 9.9.9 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force -SkipWsl`
- Verified staged bundle output in PowerShell and Bash shows stamped version and manifest provenance
- Ran `bash -n ./installer/install-copilot-setup.sh ./installer/modules/bash/ui.sh`
- Ran `npx -y markdownlint-cli2 README.md --config .github/.markdownlint.json`
- Ran `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -SkipUpstreamDrift`

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

Used AI assistance for implementation, refactoring, validation guidance, and documentation updates.

## Checklist

- [x] Followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [ ] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github_actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.