### PR TITLE
[BUG:] Fix clean main regression scope validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **[Implementation]** - Write-only attribute guidance now follows HashiCorp's accepted schema pattern by making the original and write-only fields conflict symmetrically, requiring the write-only field and its version trigger together, and validating configured trigger versions as positive integers.
   - **[Internal]** - Upstream contributor drift detection now recursively discovers HashiCorp contributor topics from the `/contributing/topics` directory, tracks the pull request template as a separate non-catalog source, and dynamically maps exact evidence references to affected local rules so new topics, template changes, and checklist changes trigger semantic review before baselines are refreshed.
 
+### Fixed
+
+- **Maintainer/Workflow:**
+  - **[Internal]** - Fixed clean `main` toolkit validation to accept an empty changed-path collection when no branch-local regression cases need runnability checks.
+
 ## [3.7.0] - 2026-07-07
 
 ### Added

--- a/tools/validate-ai-toolkit.ps1
+++ b/tools/validate-ai-toolkit.ps1
@@ -311,6 +311,7 @@ function Get-ChangedRegressionCases {
         [string]$RepoRoot,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [string[]]$ChangedPaths
     )
 


### PR DESCRIPTION
## Community Note

<!-- Please leave this section as-is. -->
* Please vote on this PR by adding a ≡ƒæì reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

Fixes the one-shot AI toolkit validator on clean `main` builds where no branch-local regression paths exist.

After PR #35 was squash-merged, the `Validate AI Toolkit` push workflow failed before evaluating changed regression cases because `Resolve-ChangedRegressionScopePaths` correctly returned an empty path array, while the mandatory `ChangedPaths` parameter on `Get-ChangedRegressionCases` rejected that empty collection during parameter binding.

This change marks the parameter with `AllowEmptyCollection`, allowing the helper's existing empty-input behavior to return no changed cases. It also records the maintainer-facing fix in the changelog.

## Summary

Allows clean `main` toolkit validation to complete when there are no branch-local regression artifacts to check.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

- [ ] Installer
- [ ] Bash
- [x] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [ ] AI instructions (`.github/instructions/`)
- [ ] AI skills (`.github/skills/`)
- [ ] GitHub Actions

## Related Issue(s)

No related issue confirmed.

## Testing / Validation

- [x] Validated behavior locally (details below)

**Details:**

- `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -SkipRegressionHarness -AllowCatalogIssues` passes.
- `pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1 -SkipRegressionHarness -AllowCatalogIssues -ChangedRegressionScope Branch` passes with the empty branch-diff collection that reproduces clean `main` behavior.
- Changelog taxonomy, changelog consistency, contracts, Markdown, architecture layout, copied Markdown links, and upstream drift checks pass.
- `git diff --check` passes.

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

**Extent of AI usage (optional but helpful):**

AI assistance was used to diagnose the clean-main parameter-binding failure, implement the focused fix, and run the validation commands above.

## Checklist

- [x] Followed [CONTRIBUTING.md](https://github.com/WodansSon/terraform-azurerm-ai-assisted-development/blob/main/CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [x] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github-actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.