### PR TITLE
[BUG:] Harden release bundle validation boundaries

### DIFF
--- a/.github/workflows/RELEASING.md
+++ b/.github/workflows/RELEASING.md
@@ -13,14 +13,23 @@ The established release path has four distinct phases:
 
 Do not collapse these phases into one checklist. In particular, pre-release checks happen before the changelog release cut, and pushing the version tag is the action that starts public release publication.
 
+### Release validation boundary
+
+This repository is the source of the AI infrastructure. Release validation MUST preserve these boundaries:
+
+- Do not run `installer/install-copilot-setup.ps1 -Bootstrap` or `installer/install-copilot-setup.sh -bootstrap`. Bootstrap is a contributor workflow that overwrites the persistent user-profile installer; it is not a release validation step.
+- Do not stage dry-run output anywhere inside this source repository or under the persistent user-profile installer. `tools/build-release-bundle_dry_run.ps1` defaults to an external temporary directory and rejects those protected roots.
+- Run only the staged installer's standalone `-Version` command during the dry run. Do not pass `-RepoDirectory`, `-repo-directory`, or any installation target; the dry run does not install AI files.
+- Do not checkout, pull, or otherwise change the active source-repository branch during release validation without explicit maintainer approval.
+
 ### 1. Confirm pre-release checks are complete
 
 Before starting release preparation, confirm that the maintainer has completed the pre-release checks against the current `main` release candidate:
 
 - the full one-shot validation passed
-- the bootstrap installer path was smoke-tested
-- a release-shaped dry-run bundle was built and its checksum verified
-- one install smoke from that dry-run bundle passed against a local `terraform-provider-azurerm` checkout
+- a reserved-version `0.0.1` release bundle was built under an external temporary fake user directory
+- the staged bundle checksum passed PowerShell validation and matched the Bash implementation
+- the staged installer reported version `0.0.1`
 
 The normal one-shot validation command is:
 
@@ -31,10 +40,12 @@ pwsh -NoProfile -File ./tools/validate-ai-toolkit.ps1
 The normal dry-run bundle command is:
 
 ```powershell
-pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version X.Y.Z -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
+pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 0.0.1 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -SkipWsl -Force
 ```
 
-The bootstrap check confirms the contributor path. The dry-run release bundle confirms the release-artifact path without publishing anything publicly.
+This Windows command validates the release-shaped package and checksum with PowerShell without invoking WSL. The non-Windows installer-validation jobs MUST pass `-RequireBash`, which recomputes the staged payload checksum with Bash and fails on an unavailable runtime, execution error, or mismatch. Do not consider the checksum gate complete unless both the Windows PowerShell job and a non-Windows Bash-required job pass for the release candidate.
+
+Version `0.0.1` is the reserved dry-run sentinel: the project is already beyond the `0.x` release line, and it differs from the in-repo `0.0.0` placeholder so the dry run proves that version stamping occurred. The dry-run bundle confirms the release-artifact, checksum, and version-reporting paths without publishing anything publicly or modifying the source repository or persistent user-profile installer.
 
 When assisting with a release, ask whether these checks are already complete. If the maintainer confirms that they are complete, do not rerun or restart the pre-release phase. Proceed to release-structure and changelog validation.
 
@@ -244,7 +255,7 @@ The release tag is also the source of truth for installer bundle version stampin
 This is the detailed reference for the dry-run bundle check in pre-release phase 1. Complete it before starting the changelog release cut:
 
 ```powershell
-pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 9.9.9 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
+pwsh -NoProfile -File ./tools/build-release-bundle_dry_run.ps1 -Version 0.0.1 -OutputRoot "$env:TEMP\azurerm-ai-release-dry-run" -Force
 ```
 
 That dry run:
@@ -252,9 +263,10 @@ That dry run:
 - stages the same installer layout as the release workflow
 - stamps `VERSION`, `commit`, and `aii.checksum`
 - verifies the staged bundle checksum
+- runs the staged PowerShell installer with `-Version` and requires it to report `0.0.1`
 - creates the same ZIP and TAR.GZ installer archives without publishing them
 
-After the dry run succeeds, run one installer smoke from the staged bundle against a local `terraform-provider-azurerm` checkout.
+Checksum and version reporting are the only purposes of this pre-release dry run. It is complete only when PowerShell validation succeeds, the Bash-computed hash matches, and the staged installer reports `0.0.1`. Use `-RequireBashChecksum` on a Bash-capable environment to make that cross-check mandatory; on Windows without a permitted Bash runtime, use `-SkipWsl` and rely on the required non-Windows CI job for the Bash half.
 
 Use a throwaway test tag only if you specifically need to validate the GitHub release workflow itself rather than the bundle contents.
 
@@ -288,8 +300,8 @@ After creating a release:
 
 Important distinction:
 
-- the bootstrap install is still the pre-release maintainer smoke for the contributor path
-- the dry-run release bundle is the pre-release maintainer smoke for the release-artifact path
+- bootstrap is a contributor-only workflow and is excluded from release validation because it overwrites the persistent user-profile installer
+- the externally staged reserved `0.0.1` bundle is the pre-release checksum and version-reporting smoke for the release-artifact path on PowerShell and Bash
 - the published release-bundle install smoke remains a post-release verification step against the real public artifact
 
 ## Rollback Process

--- a/.github/workflows/installer-validation.yml
+++ b/.github/workflows/installer-validation.yml
@@ -7,6 +7,7 @@ on:
       - 'installer/**'
       - 'tools/PSAnalyzer/**'
       - 'tools/BashAnalyzer/**'
+      - 'tools/build-release-bundle_dry_run.ps1'
       - 'tools/verify-bundle-checksum.ps1'
       - '.github/workflows/installer-validation.yml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'installer/**'
       - 'tools/PSAnalyzer/**'
       - 'tools/BashAnalyzer/**'
+      - 'tools/build-release-bundle_dry_run.ps1'
       - 'tools/verify-bundle-checksum.ps1'
       - '.github/workflows/installer-validation.yml'
 
@@ -125,7 +127,7 @@ jobs:
         if: runner.os != 'Windows'
         shell: pwsh
         run: |
-          pwsh -NoProfile -File ./tools/verify-bundle-checksum.ps1 -StageFromRepo
+          pwsh -NoProfile -File ./tools/verify-bundle-checksum.ps1 -StageFromRepo -RequireBash
 
   validate-bash:
     name: Validate Bash Scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ These rules govern maintainer collaboration behavior before any formal review wo
 - Shipped runtime guidance belongs only in files intentionally included by `installer/file-manifest.config`.
 - Repo-only maintainer workflow guidance must stay outside the shipped payload by default.
 
+## Release Validation Safety
+
+- Treat this repository as source-only during release validation.
+- Never run `installer/install-copilot-setup.ps1 -Bootstrap` or `installer/install-copilot-setup.sh -bootstrap` as a release check. Bootstrap overwrites the persistent user-profile installer and belongs only to an explicitly requested contributor workflow.
+- Stage release dry-run output in an external temporary directory, never inside this repository or the persistent user-profile installer.
+- Use reserved version `0.0.1` for release dry runs and require successful checksum validation from both PowerShell and Bash-capable CI before release preparation.
+- Verify the staged installer only through its standalone `-Version` command and require it to report `0.0.1`. Do not pass a repository target or install AI files during the dry run.
+- Treat the active source checkout, persistent user-profile installer, and existing provider working copies as protected state. Do not change branches or write to any of them without explicit maintainer approval for that exact operation.
+
 ## Edit Gate
 
 Before editing AI-toolkit files for a surfaced issue, identify all of the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **[Implementation]** - Breaking-change guidance now follows the AzureRM provider's current `SixPointOh` feature flag, v6.0 deprecation target, compatibility-test pattern, and beta environment variable.
   - **[Implementation]** - Schema validation guidance now follows accepted HashiCorp review precedent by keeping understandable compositions of established helpers inline and reserving service-local validator files with unit tests for genuinely complex bespoke logic.
   - **[Internal]** - The one-shot toolkit validator now opens with a divider-framed execution header, consistently uppercases human-readable statuses, relays aligned regression-harness and upstream-drift substeps, renders compact validation tables, and separates its text output from surrounding shell prompts while preserving lowercase JSON status contracts and buffered failure details.
-  - **[Internal]** - The release guide now separates pre-release confirmation, changelog approval, direct-to-`main` release preparation, tag-triggered publication, and post-release verification so completed checks are not repeated and approval gates are explicit.
+  - **[Internal]** - Release validation now treats this repository as source-only, stages reserved `0.0.1` bundles under an external temporary root, rejects source-tree and persistent-installer output paths, excludes bootstrap and repository installation from dry runs, and requires PowerShell/Bash checksum agreement plus matching staged-installer version output.
 
 ### Fixed
 

--- a/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
+++ b/docs/AI_TOOLKIT_ALIGNMENT_CHECKLIST.md
@@ -220,6 +220,7 @@ That command runs the current repo-level maintainer validation flow in one pass:
 - Branch-local regression case runnability validation for changed cases and fixtures
 - Markdown lint for `.github/`, `docs/`, and `CHANGELOG.md`
 - System Architecture diagram width, right-edge, and border-padding validation
+- Release dry-run output boundary validation for the source repository and persistent user-profile installer
 - Absolute HTTPS link validation for Markdown copied from the pull request template
 - Regression harness validation and suite scoring
 - Upstream contributor drift detection
@@ -301,6 +302,8 @@ Practical recovery step:
 - Reload the VS Code window so the YAML language service rebuilds diagnostics from the current on-disk files
 
 ### 8. Bootstrap payload matches expectations
+
+Release validation does not use bootstrap. Treat this repository as source-only and stage a reserved-version `0.0.1` dry-run bundle under an external temporary root. The dry run has exactly two outcomes: PowerShell and Bash checksum agreement, and staged-installer `-Version` output equal to `0.0.1`. Attempted Bash mismatches and execution failures must fail rather than warn. Do not pass a repository target or install AI files during this check. The one-shot validator checks that the bundle builder rejects output roots inside this repository and under the persistent user-profile installer.
 
 When the runtime payload changes, confirm bootstrap/install copies the expected runtime files from the manifest and does not accidentally include maintenance tooling.
 

--- a/tools/build-release-bundle_dry_run.ps1
+++ b/tools/build-release-bundle_dry_run.ps1
@@ -13,11 +13,19 @@ param(
 
     [switch]$SkipWsl,
 
-    [switch]$Force
+    [switch]$RequireBashChecksum,
+
+    [switch]$Force,
+
+    [switch]$ValidateOutputRootOnly
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+if ($SkipWsl -and $RequireBashChecksum) {
+    throw 'SkipWsl and RequireBashChecksum cannot be used together'
+}
 
 function Copy-ItemSafe {
     param(
@@ -112,11 +120,74 @@ function Resolve-ShortCommit {
     return $resolved
 }
 
-$repoRoot = Split-Path -Parent $PSScriptRoot
+function Resolve-NormalizedFullPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $pathRoot = [System.IO.Path]::GetPathRoot($fullPath)
+    if ($fullPath.Length -gt $pathRoot.Length) {
+        return $fullPath.TrimEnd([char[]]@(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        ))
+    }
+
+    return $fullPath
+}
+
+function Test-IsSameOrChildPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$CandidatePath,
+
+        [Parameter(Mandatory)]
+        [string]$RootPath
+    )
+
+    $comparison = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+        [System.StringComparison]::OrdinalIgnoreCase
+    }
+    else {
+        [System.StringComparison]::Ordinal
+    }
+
+    if ([string]::Equals($CandidatePath, $RootPath, $comparison)) {
+        return $true
+    }
+
+    $rootPrefix = $RootPath + [System.IO.Path]::DirectorySeparatorChar
+    return $CandidatePath.StartsWith($rootPrefix, $comparison)
+}
+
+$repoRoot = Resolve-NormalizedFullPath -Path (Split-Path -Parent $PSScriptRoot)
 $installerSourceRoot = Join-Path $repoRoot 'installer'
 $manifestPath = Join-Path $installerSourceRoot 'file-manifest.config'
 $verifyScriptPath = Join-Path $PSScriptRoot 'verify-bundle-checksum.ps1'
 $validationModulePath = Join-Path $installerSourceRoot 'modules/powershell/ValidationEngine.psm1'
+
+if (-not $OutputRoot) {
+    $OutputRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'azurerm-ai-release-dry-run'
+}
+
+$OutputRoot = Resolve-NormalizedFullPath -Path $OutputRoot
+$persistentInstallerRoot = Resolve-NormalizedFullPath -Path (Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)) '.terraform-azurerm-ai-installer')
+
+if (Test-IsSameOrChildPath -CandidatePath $OutputRoot -RootPath $repoRoot) {
+    throw "OutputRoot must be outside the AI source repository: $repoRoot"
+}
+
+if (Test-IsSameOrChildPath -CandidatePath $OutputRoot -RootPath $persistentInstallerRoot) {
+    throw "OutputRoot must not use the persistent user-profile installer: $persistentInstallerRoot"
+}
+
+if ($ValidateOutputRootOnly) {
+    Write-Output 'Release bundle output boundary validation passed'
+    Write-Output ("  Output Root : {0}" -f $OutputRoot)
+    return
+}
 
 if (-not $Commit) {
     $Commit = Resolve-ShortCommit -RepoRoot $repoRoot
@@ -125,10 +196,6 @@ if (-not $Commit) {
 $Commit = $Commit.Trim().ToLowerInvariant()
 if ($Commit -notmatch '^[0-9a-f]{7,40}$') {
     throw 'commit must be a 7-40 character hexadecimal git sha'
-}
-
-if (-not $OutputRoot) {
-    $OutputRoot = Join-Path $repoRoot 'release-dry-run'
 }
 
 $stageName = ('v{0}-{1}' -f $Version, $Commit) -replace '[^0-9A-Za-z._-]', '_'
@@ -172,11 +239,24 @@ if (-not $checksumResult.Valid) {
 }
 
 if (-not $SkipVerifyChecksum) {
-    & $verifyScriptPath -InstallerRoot $installerRoot -SkipWsl:$SkipWsl
+    & $verifyScriptPath -InstallerRoot $installerRoot -SkipWsl:$SkipWsl -RequireBash:$RequireBashChecksum
     if ($LASTEXITCODE -ne 0) {
         throw 'installer bundle checksum verification failed'
     }
 }
+
+$installerScriptPath = Join-Path $installerRoot 'install-copilot-setup.ps1'
+$versionOutput = @(& pwsh -NoProfile -File $installerScriptPath -Version *>&1)
+if ($LASTEXITCODE -ne 0) {
+    throw "staged installer version command failed: $($versionOutput -join [Environment]::NewLine)"
+}
+
+$versionPattern = '(?mi)^\s*Version\s*:\s*{0}\s*$' -f [regex]::Escape($Version)
+if (($versionOutput | Out-String) -notmatch $versionPattern) {
+    throw "staged installer did not report version $Version"
+}
+
+Write-Host ("PASS: Staged installer reports version {0}" -f $Version) -ForegroundColor Green
 
 Push-Location $stageRoot
 try {
@@ -233,8 +313,9 @@ try {
     }
 
     Write-Host ''
-    Write-Host 'Next step:' -ForegroundColor Cyan
-    Write-Host ('  & "{0}" -RepoDirectory "<path-to-terraform-provider-azurerm>"' -f (Join-Path $installerRoot 'install-copilot-setup.ps1')) -ForegroundColor White
+    Write-Host 'Dry-run checks completed:' -ForegroundColor Cyan
+    Write-Host '  - staged bundle checksum validated' -ForegroundColor White
+    Write-Host ('  - staged installer reported version {0}' -f $Version) -ForegroundColor White
 }
 finally {
     Pop-Location

--- a/tools/validate-ai-toolkit.ps1
+++ b/tools/validate-ai-toolkit.ps1
@@ -31,6 +31,7 @@ $architectureLayoutScriptPath = Join-Path $PSScriptRoot 'validate-architecture-l
 $copiedMarkdownLinksScriptPath = Join-Path $PSScriptRoot 'validate-copied-markdown-links.ps1'
 $contractsScriptPath = Join-Path $PSScriptRoot 'validate-contracts.ps1'
 $driftScriptPath = Join-Path $PSScriptRoot 'check-upstream-contributor-drift.ps1'
+$releaseBundleScriptPath = Join-Path $PSScriptRoot 'build-release-bundle_dry_run.ps1'
 $regressionHarnessScriptPath = Join-Path $PSScriptRoot 'regression/run-regression-harness.ps1'
 
 $npxCommand = Get-Command 'npx.cmd' -ErrorAction SilentlyContinue
@@ -513,6 +514,34 @@ try {
 
     $steps += Invoke-ValidationStep -Name 'architecture-layout' -Detail 'Validate the System Architecture diagram row width, right edge, and border padding.' -Command {
         & pwsh -NoProfile -File $architectureLayoutScriptPath
+    }
+
+    $steps += Invoke-ValidationStep -Name 'release-boundaries' -Detail 'Validate that release dry-run output defaults outside the AI source repository and rejects source-tree or persistent-installer roots.' -Command {
+        $defaultOutput = @(& pwsh -NoProfile -File $releaseBundleScriptPath -Version '0.0.0-validation' -ValidateOutputRootOnly 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            throw "default release output boundary validation failed: $($defaultOutput -join [Environment]::NewLine)"
+        }
+
+        $sourceProbePath = Join-Path $repoRoot '.release-boundary-validation-probe'
+        if (Test-Path -LiteralPath $sourceProbePath) {
+            throw "release boundary probe path already exists: $sourceProbePath"
+        }
+
+        $sourceOutput = @(& pwsh -NoProfile -File $releaseBundleScriptPath -Version '0.0.0-validation' -OutputRoot $sourceProbePath -ValidateOutputRootOnly 2>&1)
+        if ($LASTEXITCODE -eq 0 -or ($sourceOutput | Out-String) -notmatch 'outside the AI source repository') {
+            throw 'release bundle builder did not reject an OutputRoot inside the AI source repository'
+        }
+        if (Test-Path -LiteralPath $sourceProbePath) {
+            throw "release boundary validation wrote inside the AI source repository: $sourceProbePath"
+        }
+
+        $persistentInstallerRoot = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)) '.terraform-azurerm-ai-installer'
+        $profileOutput = @(& pwsh -NoProfile -File $releaseBundleScriptPath -Version '0.0.0-validation' -OutputRoot $persistentInstallerRoot -ValidateOutputRootOnly 2>&1)
+        if ($LASTEXITCODE -eq 0 -or ($profileOutput | Out-String) -notmatch 'must not use the persistent user-profile installer') {
+            throw 'release bundle builder did not reject the persistent user-profile installer as OutputRoot'
+        }
+
+        $global:LASTEXITCODE = 0
     }
 
     $steps += Invoke-ValidationStep -Name 'copied-markdown-links' -Detail 'Validate that links copied from the pull request template remain valid outside their source file.' -Command {

--- a/tools/verify-bundle-checksum.ps1
+++ b/tools/verify-bundle-checksum.ps1
@@ -18,10 +18,17 @@ param(
 
     # Historical name; when set, skips all Bash/WSL cross-checking.
     [Parameter(Mandatory = $false)]
-    [switch]$SkipWsl
+    [switch]$SkipWsl,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$RequireBash
 )
 
 $ErrorActionPreference = 'Stop'
+
+if ($SkipWsl -and $RequireBash) {
+    throw 'SkipWsl and RequireBash cannot be used together'
+}
 
 function Copy-ItemSafe {
     param(
@@ -91,6 +98,7 @@ Write-Host "PASS: PowerShell checksum validation succeeded" -ForegroundColor Gre
 $psHash = $result.Hash
 
 if (-not $SkipWsl) {
+    $bashVerified = $false
     $bashScript = 'set -euo pipefail
 root="$1"
 
@@ -137,14 +145,13 @@ rm -f "${tmp}"'
 
                 if ($wslHash -and $psHash -and ($wslHash.ToLowerInvariant() -eq $psHash.ToLowerInvariant())) {
                     Write-Host "PASS: WSL/Bash checksum matches PowerShell" -ForegroundColor Green
+                    $bashVerified = $true
                 } else {
-                    Write-Host "WARN: WSL/Bash checksum did not match PowerShell" -ForegroundColor Yellow
-                    Write-Host "  WSL : $wslHash" -ForegroundColor Yellow
-                    Write-Host "  PS  : $psHash" -ForegroundColor Yellow
+                    throw "WSL/Bash checksum did not match PowerShell`n  WSL : $wslHash`n  PS  : $psHash"
                 }
             }
             catch {
-                Write-Host "WARN: WSL checksum cross-check failed: $($_.Exception.Message)" -ForegroundColor Yellow
+                throw "WSL/Bash checksum cross-check failed: $($_.Exception.Message)"
             }
         }
     } else {
@@ -156,15 +163,18 @@ rm -f "${tmp}"'
 
                 if ($bashHash -and $psHash -and ($bashHash.ToLowerInvariant() -eq $psHash.ToLowerInvariant())) {
                     Write-Host "PASS: Bash checksum matches PowerShell" -ForegroundColor Green
+                    $bashVerified = $true
                 } else {
-                    Write-Host "WARN: Bash checksum did not match PowerShell" -ForegroundColor Yellow
-                    Write-Host "  Bash: $bashHash" -ForegroundColor Yellow
-                    Write-Host "  PS  : $psHash" -ForegroundColor Yellow
+                    throw "Bash checksum did not match PowerShell`n  Bash: $bashHash`n  PS  : $psHash"
                 }
             }
             catch {
-                Write-Host "WARN: Bash checksum cross-check failed: $($_.Exception.Message)" -ForegroundColor Yellow
+                throw "Bash checksum cross-check failed: $($_.Exception.Message)"
             }
         }
+    }
+
+    if ($RequireBash -and -not $bashVerified) {
+        throw 'Bash checksum verification was required but no Bash runtime was available'
     }
 }


### PR DESCRIPTION
<!--
When opening a PR, please follow these PR title prefix examples (use when applicable) to help maintainers and contributors triage changes quickly:

- [BREAKING CHANGE:] <short description>
- [ENHANCEMENT:] <short description>
- [BUG:] <short description>
- [DOCUMENTATION:] <short description>
- [CRASH:] <short description>
-->

## Community Note

<!-- Please leave this section as-is. -->
* Please vote on this PR by adding a 👍 reaction to help prioritize review.
* Please do not leave comments like "+1", "me too", or "any updates" as they add noise without helping prioritize.

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know.

If this is a breaking change, explain the user impact, why it is necessary, and provide explicit upgrade steps (include upgrade notes / changelog entry where appropriate). -->

This PR prevents pre-release validation from modifying the AI source repository, persistent user-profile installer, or provider working copies. It narrows the dry run to release-package checksum and version-stamping validation.

Dry-run bundles now use reserved version `0.0.1`, default to an external temporary directory, reject protected output paths, validate the PowerShell checksum, require matching Bash verification in non-Windows CI, and confirm the staged installer reports the expected version.

## Summary

<!-- What does this change do? Keep it short and concrete. -->

- Excludes bootstrap and repository installation from pre-release dry runs.
- Rejects output paths inside the source repository or persistent installer.
- Makes Bash checksum failures and mismatches fatal.
- Requires Bash checksum verification in non-Windows installer CI.
- Verifies staged installer version output automatically.
- Documents the protected-state and release-validation boundaries.

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [x] Enhancement
- [x] Documentation / examples
- [x] Maintenance / chore (dependencies, CI, refactors)
- [ ] Breaking change

## Scope

<!-- Check all that apply -->

- [x] Installer
- [x] Bash
- [x] PowerShell
- [ ] AI prompts (`.github/prompts/`)
- [ ] AI instructions (`.github/instructions/`)
- [ ] AI skills (`.github/skills/`)
- [x] GitHub Actions

## Related Issue(s)

<!-- Use GitHub closing keywords where applicable: -->
<!-- Example: Fixes #1234, Closes #1234, or Resolves #1234 -->

No related issue confirmed.

## Testing / Validation

<!-- Describe what you ran and/or how you validated this change. If you could not test, explain why. -->

- [x] Validated behavior locally (details below)

**Details:**

- Full `tools/validate-ai-toolkit.ps1` validation passed.
- All 76 regression cases passed.
- Reserved `0.0.1` bundle passed PowerShell checksum validation.
- Staged installer reported version `0.0.1`.
- Release-boundary validation passed.
- Upstream drift reported zero issues.
- Source `main`, provider checkout, and persistent installer remained unchanged.
- Bash checksum parity is enforced by the required non-Windows CI jobs.

## Changelog

- [x] Updated `CHANGELOG.md` (if user-visible)

## AI Assistance Disclosure
<!--
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the tooling, this must be disclosed in the pull request.
If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)
If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI assisted - this contribution was made by, or with the assistance of, AI/LLMs

## Checklist

- [x] Followed [CONTRIBUTING.md](https://github.com/WodansSon/terraform-azurerm-ai-assisted-development/blob/main/CONTRIBUTING.md)
- [x] Used a meaningful PR title
- [x] Updated docs/examples where needed
- [x] Applied appropriate labels (examples: `breaking-change`, `ai-assisted`, `ai-assisted-review`, `ai-prompts`, `ai-instructions`, `ai-skills`, `bash`, `powershell`, `waiting-response`, `blocked`, `dependencies`, `github-actions`)

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.